### PR TITLE
adding an e2e example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,7 @@ The project includes several basic examples that demonstrate application deploym
    python -m r2r.examples.basic.run_client
    ```
 
-3. [`pdf chat`](r2r/examples/pdf_chat/run_client.py): An example demonstrating upload and chat with a more realistic pdf.
-
-   ```bash
-   # Ingest pdf
-   python -m r2r.examples.pdf_chat.run_client ingest
-
-   # Return search results
-   python -m r2r.examples.pdf_chat.run_client search "What are the key themes of Meditations?"
-
-   # Stream a rag response
-   poetry run python -m r2r.examples.pdf_chat.run_client rag_completion_streaming "According to Meditaitons, what are some principles to live by?"
-   ```
-
-
-4. [`academy`](r2r/examples/academy): A more sophisticated demo demonstrating how to build a more novel pipeline which involves synthetic queries
+3. [`academy`](r2r/examples/academy): A more sophisticated demo demonstrating how to build a more novel pipeline which involves synthetic queries
 
    ```bash
    # Launch the `academy` example application
@@ -93,9 +79,10 @@ The project includes several basic examples that demonstrate application deploym
    # Ask a question
    python -m r2r.examples.academy.run_client search "What are the key themes of Meditations?"
    ```
+4. [`end-to-end`](r2r/examples/end-to-end): An example showing how to combine a complete web application with the basic RAG pipeline above.
 
 
-4. [`intelligence`](app.sciphi.ai): A cloud platform which can be used to deploy R2R pipelines powered by SciPhi
+5. [`intelligence`](app.sciphi.ai): A cloud platform which can be used to deploy R2R pipelines powered by SciPhi
 
 
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ The project includes several basic examples that demonstrate application deploym
    # Ask a question
    python -m r2r.examples.academy.run_client search "What are the key themes of Meditations?"
    ```
-4. [`end-to-end`](r2r/examples/end-to-end): An example showing how to combine a complete web application with the basic RAG pipeline above.
-
+4. [`end-to-end`](docs/pages/examples/end-to-end.mdx): An example showing how to combine a complete web application with the basic RAG pipeline above.
 
 5. [`intelligence`](app.sciphi.ai): A cloud platform which can be used to deploy R2R pipelines powered by SciPhi
 

--- a/docs/pages/examples/end-to-end.mdx
+++ b/docs/pages/examples/end-to-end.mdx
@@ -1,0 +1,53 @@
+# Running a RAG Pipeline Locally with R2R
+
+## Step 1: Fork and Clone the R2R Basic RAG Template Repository
+
+1. Navigate to the [R2R Basic RAG Template repository](https://github.com/SciPhi-AI/R2R-basic-rag-template) on GitHub.
+2. Click on the "Fork" button in the upper right corner of the page to create a copy of the repository in your own GitHub account.
+3. Clone your forked repository to your local machine:
+   ```
+   git clone https://github.com/your-username/R2R-basic-rag-template.git
+   ```
+4. Navigate to the cloned repository:
+   ```
+   cd R2R-basic-rag-template
+   ```
+
+## Step 2: Configure the RAG Pipeline
+
+1. Open the `config.json` file in a text editor.
+2. Modify the configuration options according to your requirements. The `config.json` file allows you to specify settings such as the vector database provider, LLM settings, embedding settings, parsing logic, evaluation provider, and more.
+3. Save the changes to the `config.json` file.
+
+## Step 3: Install Dependencies and Run the Application
+
+1. Install the required dependencies:
+   ```
+   pip install -r requirements.txt
+   ```
+2. Set the OpenAI API key as an environment variable:
+   ```
+   export OPENAI_API_KEY=your-api-key
+   ```
+3. Run the application:
+   ```
+   python src/app.py
+   ```
+4. The RAG pipeline endpoint will be accessible at `http://localhost:8000`.
+
+## Step 4: Interact with the RAG Pipeline
+
+You can now interact with the locally deployed RAG pipeline using the R2R client or by sending HTTP requests to the endpoint.
+
+## Step 5: Building Your Own Application
+
+If you want to build your own application that interacts with the RAG pipeline, you can use the [APP Basic RAG Template repository](https://github.com/SciPhi-AI/APP-basic-rag-template) as a starting point. This repository provides a template for building a web application that communicates with the RAG pipeline.
+
+To use the template:
+
+1. Fork the [APP Basic RAG Template repository](https://github.com/SciPhi-AI/APP-basic-rag-template) on GitHub.
+2. Clone your forked repository to your local machine.
+3. Follow the instructions in the repository's README to set up and run the web application locally.
+4. Customize the web application according to your needs, integrating it with your locally deployed RAG pipeline.
+
+For more advanced usage and customization options, refer to the [R2R documentation](https://r2r.sciphi.ai).


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit f9df215c2916ddce0277863b88d8978aabc59b98.  | 
|--------|--------|

### Summary:
This PR removes the `pdf chat` example, adds an `end-to-end` example in `/README.md`, and provides a detailed guide on running a RAG pipeline locally with R2R in a new file `/docs/pages/examples/end-to-end.mdx`.

**Key points**:
- Removed `pdf chat` example from `/README.md`
- Added `end-to-end` example to `/README.md`
- Created new file `/docs/pages/examples/end-to-end.mdx` providing a guide on running a RAG pipeline locally with R2R


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
