### PR TITLE
fix: update the basic example client to use correct port for example app

### DIFF
--- a/r2r/examples/basic/run_client.py
+++ b/r2r/examples/basic/run_client.py
@@ -5,7 +5,7 @@ from r2r.client import R2RClient
 from r2r.core.utils import generate_id_from_label
 
 # Initialize the client with the base URL of your API
-base_url = "http://localhost:8010"
+base_url = "http://localhost:8000"
 client = R2RClient(base_url)
 
 print("Upserting entry to remote db...")


### PR DESCRIPTION
This PR updates the client code to talk with the example server on the correct port.

Test Plan:
Before (Interacting with example server using the client):
![image](https://github.com/SciPhi-AI/R2R/assets/26037101/4b9e7a2b-7156-4c75-84aa-1e2823f76dd5)

After bug fix (Interacting with example server using the client):
![image](https://github.com/SciPhi-AI/R2R/assets/26037101/7eb5e23b-ad40-4f0a-9675-ab2f8cef6632)


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit fdb847524ccd0469f0b652a4a65e08f32a6b938b.  | 
|--------|--------|

### Summary:
This PR fixes the client-server communication by updating the port in the `base_url` of the `run_client.py` file.

**Key points**:
- Updated `base_url` in `run_client.py` from `http://localhost:8010` to `http://localhost:8000`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
