### PR TITLE
broken logo fix

### DIFF
--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { DocsThemeConfig } from "nextra-theme-docs";
 
 const config: DocsThemeConfig = {
-  logo: (
-    <img width={120} src="./public/r2r_mini.png" style={{ borderRadius: 5 }} />
-  ),
+  logo: <span>SciPhi</span>,
+  logoLink: "https://github.com/SciPhi-AI/R2R",
+  // logo: (
+  //   <img width={120} src="./public/r2r_mini.png" style={{ borderRadius: 5 }} />
+  // ),
   head: (
     <>
       <link rel="icon" type="image/png" href="./favicon.png" />


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit e70924c18c3b34c95bcf76093a966eede46e531e.  | 
|--------|--------|

### Summary:
This PR replaces the image logo with a text logo and adds a link to the project's GitHub repository in the `/docs/theme.config.tsx` file.

**Key points**:
- Replaced image logo with text logo 'SciPhi' in `config` object of `/docs/theme.config.tsx`.
- Added `logoLink` property to `config` object, linking to project's GitHub repository.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
