### PR TITLE
Fix typo

### DIFF
--- a/r2r/embeddings/openai/base.py
+++ b/r2r/embeddings/openai/base.py
@@ -33,7 +33,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             )
         if not os.getenv("OPENAI_API_KEY"):
             raise ValueError(
-                "Must set OPEN_API_KEY in order to initialize OpenAIEmbeddingProvider."
+                "Must set OPENAI_API_KEY in order to initialize OpenAIEmbeddingProvider."
             )
         self.client = OpenAI()
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 62ade7ed42214eccb82a38877a0f2d38a57373be.  | 
|--------|--------|

### Summary:
This PR corrects a typo in the `OPENAI_API_KEY` environment variable within the error message of the `__init__` method in the `OpenAIEmbeddingProvider` class in the `/r2r/embeddings/openai/base.py` file.

**Key points**:
- Fixed a typo in the error message of the `__init__` method in the `OpenAIEmbeddingProvider` class.
- The typo was in the name of the environment variable `OPENAI_API_KEY`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
