### PR TITLE
broken link in tutorial fixed

### DIFF
--- a/docs/pages/tutorials/local_rag.mdx
+++ b/docs/pages/tutorials/local_rag.mdx
@@ -164,7 +164,7 @@ Configure the `embedding` section to set your desired embedding model, dimension
 #### Logging Provider
 R2R supports logging to Postgres, SQLite (local), and Redis. The logs capture pipeline execution information.
 
-Check out the [full R2R configuration docs](http://localhost:3000/deep-dive/config) for more details on all available options.
+Check out the [full R2R configuration docs](/deep-dive/config) for more details on all available options.
 
 ### Customizing Your RAG Pipeline
 


### PR DESCRIPTION
fixes #284 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 64bb1a893d119267c8cddc8f284b45056c16635e.  | 
|--------|--------|

### Summary:
This PR corrects a broken link in the tutorial documentation, ensuring users can access the full R2R configuration docs.

**Key points**:
- Fixed a broken link in `/docs/pages/tutorials/local_rag.mdx`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
