### PR TITLE
docs/ Fix typos and update names in config_setup.mdx

### DIFF
--- a/docs/pages/tutorials/config_setup.mdx
+++ b/docs/pages/tutorials/config_setup.mdx
@@ -2,7 +2,7 @@
 
 ### Introduction
 
-In [Easy Local RAG with R2R: A Step-by-Step Guide](https://r2r-docs.sciphi.ai/tutorials/local_rag), you take a look of how our framework `R2R` work and how to use the RAG pipeline. But now, let's talk more in details about  the `config.json` file.
+In [Easy Local RAG with R2R: A Step-by-Step Guide](https://r2r-docs.sciphi.ai/tutorials/local_rag), you take a look of how our framework `R2R` work and how to use the RAG pipeline. But now, let's talk more in details about the `config.json` file.
 
 ### config.json
 
@@ -51,7 +51,7 @@ The `config.json` file is configured by default for cloud-based services, as you
 }
 ```
 
-To use the configuration you want, it is as easy as just changing the values of the json file. For example, if you want to use an embedding model of Hugging Face `sentence-transformers`, just have to change the embedding provider:
+To use the configuration you want, it is as easy as just changing the values of the Json file. For example, if you want to use an embedding model of Hugging Face `sentence-transformers`, just have to change the embedding provider:
 
 ```json
   "embedding": {
@@ -65,7 +65,7 @@ To know what values each section can take, consult `Config setup` documentation 
 
 ### Try a different set up of the [Easy Local RAG](https://r2r-docs.sciphi.ai/tutorials/local_rag)
 
-You can se the `config.json` set up of our preview tutorial [here](https://github.com/SciPhi-AI/R2R/blob/main/r2r/examples/configs/local_ollama.json).
+You can see the `config.json` set up of our preview tutorial [here](https://github.com/SciPhi-AI/R2R/blob/main/r2r/examples/configs/local_ollama.json).
 
 In that example, a local vector database configuration was used. Now let's see how to use `Qdrant` as vector database and also try a different language model with `ollama`.
 
@@ -77,7 +77,7 @@ For using `Qdrant` as vector database, you need to have the following values con
 * `QDRANT_PORT`: Qdrant server port
 * `QDRANT_API_KEY`: Qdrant API key
 
-To do so, if you used linux just need to type the next command on your terminal:
+To do so, if you use Linux just need to type the next commands on your terminal:
 ```bash
 export QDRANT_HOST=http://localhost
 export QDRANT_PORT=6333
@@ -118,10 +118,10 @@ docker run -p 6333:6333 -p 6334:6334 \
 
 ##### Server Standup
 
-Similar to our previous tutorial, only that now we will use a new `congig.sjon` through `--config`
+Similar to our previous tutorial, only that now we will use a new `config.json` through `--config` called `local_embedding_qdrant.json` (take a look of the full file [here](https://github.com/SciPhi-AI/R2R/blob/main/r2r/examples/configs/local_embedding_qdrant.json))
 
 ```python
-python -m r2r.examples.servers.basic_pipeline --config testConfi
+python -m r2r.examples.servers.basic_pipeline --config local_embedding_qdrant
 ```
 
 ##### Ingesting and Embedding Documents
@@ -129,7 +129,7 @@ python -m r2r.examples.servers.basic_pipeline --config testConfi
 This step is exactly the same:
 
 ```python
-python -m r2r.examples.clients.run_basic_client ingest
+python -m r2r.examples.clients.run_qna_client ingest
 ```
 
 The output should look something like this:
@@ -140,7 +140,7 @@ The output should look something like this:
 
 ##### Running Queries on the Local LLM
 
-As we mentioned previously, To query our knowledge base using ollama, first ensure that you have started the ollama server with this command in the terminal:
+As we mentioned previously, to query our knowledge base using `ollama`, first ensure that you have started the ollama server with this command in the terminal:
 
 ```bash
 ollama serve
@@ -149,7 +149,7 @@ ollama serve
 Then, to ask a question, run:
 
 ```python
-python -m r2r.examples.clients.run_basic_client rag_completion \
+python -m r2r.examples.clients.run_qna_client rag_completion \
   --query="What does Marcus Aurelius say about the rules of life?" \
   --model="ollama/phi" # or any other LLM that you have
 ```

--- a/docs/pages/tutorials/local_rag.mdx
+++ b/docs/pages/tutorials/local_rag.mdx
@@ -105,7 +105,7 @@ With our environment set up and our server running in a separate process, we're 
 Run this command to ingest the document:
 
 ```bash
-python -m r2r.examples.clients.run_basic_client ingest
+python -m r2r.examples.clients.run_qna_client ingest
 ```
 
 The output should look something like this:
@@ -137,7 +137,7 @@ ollama serve llama2
 Then, to ask a question, run:
 
 ```bash
-python -m r2r.examples.clients.run_basic_client rag_completion \
+python -m r2r.examples.clients.run_qna_client rag_completion \
   --query="What does Marcus Aurelius say about the rules of life?" \
   --model="ollama/llama2"
 ```
@@ -145,7 +145,7 @@ python -m r2r.examples.clients.run_basic_client rag_completion \
 For Llama.cpp, run:
 
 ```bash
-python -m r2r.examples.clients.run_basic_client rag_completion \
+python -m r2r.examples.clients.run_qna_client rag_completion \
   --query="What does Marcus Aurelius say about the rules of life?" \
   --model=tinyllama-1.1b-chat-v1.0.Q2_K.gguf
 ```


### PR DESCRIPTION
* Fix some typos in `config_setup.mdx`

* Updated name for `testConfi` in `config_setup.mdx`: 
`testConfi` => `local_embedding_qdran`

* Updated call for `run_qna_client.py` in both documentation `config_setup.mdx` and `local_rag.mdx`:
`r2r.examples.clients.run_basic_client` => `r2r.examples.clients.run_qna_client`

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit b569b40bc9b84c43192837654ceaf52c47085c8f.  | 
|--------|--------|

### Summary:
This PR corrects typos and updates function calls and a variable name in the documentation files `config_setup.mdx` and `local_rag.mdx`.

**Key points**:
- Fixed typos in `config_setup.mdx` and `local_rag.mdx`.
- Updated function call from `r2r.examples.clients.run_basic_client` to `r2r.examples.clients.run_qna_client` in both files.
- Renamed `testConfi` to `local_embedding_qdrant` in `config_setup.mdx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
