### PR TITLE
Change the call to create upload directory

### DIFF
--- a/r2r/main/app.py
+++ b/r2r/main/app.py
@@ -1,6 +1,7 @@
 import re
 import json
 import logging
+import os
 from pathlib import Path
 from typing import AsyncGenerator, Generator, Optional, Union, cast
 from pydantic import HttpUrl
@@ -71,7 +72,7 @@ def create_app(
     upload_path = upload_path or find_project_root(CURRENT_DIR) / "uploads"
 
     if not upload_path.exists():
-        upload_path.mkdir()
+        os.makedirs(upload_path, exist_ok=True)
 
     @app.post("/process_url")
     async def process_url(


### PR DESCRIPTION
A simple change to how upload directory is created.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://app.ellipsis.dev/images/ellipsis_github_logo_white_bg_60x60_sharp.png" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit e765575943008de4c417586b10c03aa37937f858.  | 
|--------|--------|

### Summary:
This PR modifies the `create_app` function in `/r2r/main/app.py` to use `os.makedirs` with `exist_ok=True` for creating the upload directory, ensuring all parent directories are created and no error is raised if the directory already exists.

**Key points**:
- Modified the `create_app` function in `/r2r/main/app.py`.
- Replaced `upload_path.mkdir()` with `os.makedirs(upload_path, exist_ok=True)` for creating the upload directory.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
