### PR TITLE
Revert Warning for Unset OpenAI API Key

### DIFF
--- a/r2r/embeddings/openai/openai_base.py
+++ b/r2r/embeddings/openai/openai_base.py
@@ -36,12 +36,11 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
                 "OpenAIEmbeddingProvider must be initialized with provider `openai`."
             )
         if not os.getenv("OPENAI_API_KEY"):
-            logger.warning("OPENAI_API_KEY not set. OpenAIEmbeddingProvider will not be used.")
-            self.client = None
-            self.async_client = None
-        else:
-            self.client = OpenAI()
-            self.async_client = AsyncOpenAI()
+            raise ValueError(
+                "Must set OPENAI_API_KEY in order to initialize OpenAIEmbeddingProvider."
+                )
+        self.client = OpenAI()
+        self.async_client = AsyncOpenAI()
 
         if config.rerank_model:
             raise ValueError(
@@ -80,8 +79,6 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         text: str,
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.SEARCH,
     ) -> list[float]:
-        if not self.client:
-            raise ValueError("OpenAIEmbeddingProvider not initialized due to missing OPENAI_API_KEY.")
         if stage != EmbeddingProvider.PipeStage.SEARCH:
             raise ValueError(
                 "OpenAIEmbeddingProvider only supports search stage."
@@ -108,8 +105,6 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         text: str,
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.SEARCH,
     ) -> list[float]:
-        if not self.client:
-            raise ValueError("OpenAIEmbeddingProvider not initialized due to missing OPENAI_API_KEY.")
         if stage != EmbeddingProvider.PipeStage.SEARCH:
             raise ValueError(
                 "OpenAIEmbeddingProvider only supports search stage."
@@ -133,8 +128,6 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         texts: list[str],
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.SEARCH,
     ) -> list[list[float]]:
-        if not self.client:
-            raise ValueError("OpenAIEmbeddingProvider not initialized due to missing OPENAI_API_KEY.")
         if stage != EmbeddingProvider.PipeStage.SEARCH:
             raise ValueError(
                 "OpenAIEmbeddingProvider only supports search stage."

--- a/r2r/main/r2r_app.py
+++ b/r2r/main/r2r_app.py
@@ -155,7 +155,6 @@ class R2RApp(metaclass=AsyncSyncMeta):
         self._setup_routes()
         if do_apply_cors:
             self._apply_cors()
-        self._check_embedding_provider()
 
     def _setup_routes(self):
         self.app.add_api_route(
@@ -935,8 +934,3 @@ class R2RApp(metaclass=AsyncSyncMeta):
             allow_methods=["*"],  # Allows all methods
             allow_headers=["*"],  # Allows all headers
         )
-
-    def _check_embedding_provider(self):
-        if self.config.embedding.provider == "openai" and not os.getenv("OPENAI_API_KEY"):
-            logger.warning("OpenAI API key not found. Embedding provider will not be used.")
-            raise ValueError("OpenAI API key not found. Please set the OPENAI_API_KEY environment variable.")


### PR DESCRIPTION
Reverts changes in #382 such that no OAI key will fail loudly rather than being a logger warning.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 366dc64f39ff9dfd3c692b08cfd5d75775e24bb6  | 
|--------|--------|

### Summary:
Reverts to raising an error for unset OpenAI API key during provider initialization and removes redundant checks in the application setup.

**Key points**:
- Revert to raising `ValueError` if `OPENAI_API_KEY` is unset during `OpenAIEmbeddingProvider` initialization.
- Remove redundant API key check and warning in `r2r_app.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
