### PR TITLE
Make metadatas for ingest_files optional

### DIFF
--- a/r2r/main/r2r_client.py
+++ b/r2r/main/r2r_client.py
@@ -60,8 +60,8 @@ class R2RClient:
 
     def ingest_files(
         self,
-        metadatas: Optional[list[dict]],
         files: list[str],
+        metadatas: Optional[list[dict]] = None,
         ids: Optional[list[str]] = None,
         user_ids: Optional[list[str]] = None,
     ) -> dict:


### PR DESCRIPTION
The metadatas parameter for ingest_files is not truly optional, and returns the following:

```
response = client.ingest_files(
    files=file_paths,
    user_ids=[user_id]
)
```

`TypeError: R2RClient.ingest_files() missing 1 required positional argument: 'metadatas'`

We should instead set a default metadatas parameter of None, i.e. `metadatas: Optional[list[dict]] = None,` in the ingest_files method.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 471aa699324b24b9a749008961c9aa2a2a43021c  | 
|--------|--------|

### Summary:
This PR updates the `ingest_files` method in the `R2RClient` class to make the `metadatas` parameter optional, enhancing method flexibility and usability.

**Key points**:
- Modified `ingest_files` method in `R2RClient` class to make `metadatas` parameter optional by setting default to `None`.
- Located in `r2r/main/r2r_client.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
