### PR TITLE
Add --no_images flag for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ COPY . /app
 EXPOSE 8000
 
 # Set the command to run the application with Gunicorn
-CMD ["gunicorn", "r2r.examples.servers.configurable_pipeline:r2r_app", "--bind", "0.0.0.0:8000", "--workers", "2", "--threads", "8", "--timeout", "0", "--worker-class", "uvicorn.workers.UvicornWorker"]
+CMD ["gunicorn", "r2r.examples.servers.configurable_pipeline:r2r_app", "--bind", "0.0.0.0:8000", "--workers", "2", "--threads", "8", "--timeout", "0", "--worker-class", "uvicorn.workers.UvicornWorker", "--no_images"]

--- a/docs/pages/cookbooks/local-rag.mdx
+++ b/docs/pages/cookbooks/local-rag.mdx
@@ -50,7 +50,7 @@ A local vector database will be used to store the embeddings. The current defaul
 
 ```bash filename="bash"
 # cd $WORKDIR
-python -m r2r.examples.servers.configurable_pipeline --host 0.0.0.0 --port 8000 --config local_ollama --pipeline_type qna
+python -m r2r.examples.servers.configurable_pipeline --host 0.0.0.0 --port 8000 --config local_ollama --pipeline_type qna --no_images
 ```
 
 The server exposes a REST API for interacting with the R2R RAG pipeline and application. See the [API docs](/getting-started/app-api) for more details on the available endpoints.

--- a/docs/pages/cookbooks/local-rag.mdx
+++ b/docs/pages/cookbooks/local-rag.mdx
@@ -23,12 +23,19 @@ To streamline this process, we've provided pre-configured local settings in the 
 
 ```json
 {
-    "embedding": {
-      "provider": "sentence-transformers",
-      "base_model": "all-MiniLM-L6-v2",
-      "dimension": 384,
-      "batch_size": 32
+  "embedding": {
+    "provider": "sentence-transformers",
+    "base_model": "all-MiniLM-L6-v2",
+    "base_dimension": 384,
+    "batch_size": 32
+  },
+  "eval": {
+    "provider": "local",
+    "frequency": 0.0,
+    "llm":{
+      "provider": "litellm"
     }
+  }
 }
 ```
 

--- a/r2r/examples/configs/local_ollama.json
+++ b/r2r/examples/configs/local_ollama.json
@@ -4,5 +4,12 @@
     "base_model": "all-MiniLM-L6-v2",
     "base_dimension": 384,
     "batch_size": 32
+  },
+  "eval": {
+    "provider": "local",
+    "frequency": 0.0,
+    "llm":{
+      "provider": "litellm"
+    }
   }
 }

--- a/r2r/examples/servers/configurable_pipeline.py
+++ b/r2r/examples/servers/configurable_pipeline.py
@@ -45,6 +45,7 @@ class PipelineType(Enum):
 def r2r_app(
     config_name: str = "default",
     pipeline_type: PipelineType = PipelineType.QNA,
+    no_images: bool = False,
 ) -> FastAPI:
     config_name = os.getenv("CONFIG_OPTION") or config_name
 
@@ -65,7 +66,7 @@ def r2r_app(
         )
 
     if pipeline_type == PipelineType.QNA:
-        return R2RAppBuilder(config).build().app
+        return R2RAppBuilder(config).build(no_images=no_images).app
     elif pipeline_type == PipelineType.WEB:
         web_search_pipe = R2RWebSearchPipe(
             serper_client=SerperClient()  # TODO - Develop a `WebSearchProvider` for configurability
@@ -114,6 +115,11 @@ if __name__ == "__main__":
         choices=[ele.lower() for ele in PipelineType.__members__.keys()],
         help="Specific pipeline to deploy",
     )
+    parser.add_argument(
+        "--no_images",
+        action="store_true",
+        help="Flag to exclude image files from ingestion",
+    )
 
     args, _ = parser.parse_known_args()
 
@@ -121,10 +127,13 @@ if __name__ == "__main__":
     port = os.getenv("PORT") or args.port
     config_name = os.getenv("CONFIG_OPTION") or args.config
     pipeline_type = os.getenv("PIPELINE_TYPE") or args.pipeline_type
+    no_images = os.getenv("NO_IMAGES") or args.no_images
 
     logger.info(f"Environment CONFIG_OPTION: {config_name}")
 
-    app = r2r_app(config_name, PipelineType(pipeline_type))
+    app = r2r_app(
+        config_name, PipelineType(pipeline_type), no_images=no_images
+    )
 
     import uvicorn
 

--- a/r2r/pipes/parsing_pipe.py
+++ b/r2r/pipes/parsing_pipe.py
@@ -119,6 +119,7 @@ class R2RDocumentParsingPipe(DocumentParsingPipe):
         pipe_logger: Optional[KVLoggingSingleton] = None,
         type: PipeType = PipeType.INGESTOR,
         config: Optional[LoggableAsyncPipe.PipeConfig] = None,
+        no_images: bool = False,
         *args,
         **kwargs,
     ):
@@ -136,10 +137,17 @@ class R2RDocumentParsingPipe(DocumentParsingPipe):
             **kwargs,
         )
 
+        self.no_images = no_images
         self.parsers = {}
 
         if not override_parsers:
             override_parsers = {}
+
+        available_parsers = self.AVAILABLE_PARSERS.copy()
+        if self.no_images:
+            for doc_type in self.IMAGE_TYPES:
+                if doc_type in available_parsers:
+                    del available_parsers[doc_type]
 
         for doc_type, parser_key in selected_parsers.items():
             if doc_type in override_parsers:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c8d0066da410fc64d38d989546ae28786662b86d  | 
|--------|--------|

### Summary:
Introduces a `--no_images` flag to exclude image files during ingestion, with necessary adjustments in related modules to support this feature.

**Key points**:
- Added `--no_images` flag to `configurable_pipeline.py` to exclude image files during ingestion.
- Modified `r2r_factory.py` and `parsing_pipe.py` to support conditional image file exclusion based on the new flag.
- Updated `R2RDocumentParsingPipe` to dynamically adjust available parsers based on the `no_images` flag.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->