### PR TITLE
Fix Docker, make it more explicit to set OpenAI key where needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ R2R was conceived to help developers bridge the gap between local LLM experiment
 
 # Quick Install:
 
-```bash copy
+```bash
 # use the `'r2r[all]'` to download all required deps
 pip install r2r
 
@@ -49,12 +49,12 @@ export OPENAI_API_KEY=sk-...
 
 ### With local installation
 
-```bash copy
+```bash
 python -m r2r.examples.servers.configurable_pipeline --host 0.0.0.0 --port 8000
 ```
 ### With Docker
 
-```bash copy
+```bash
 docker pull emrgntcmplxty/r2r:latest
 docker run -d --name r2r -p 8000:8000 emrgntcmplxty/r2r:latest -e OPENAI_API_KEY=...
 ```
@@ -83,7 +83,7 @@ The R2R demo offers a step-by-step guide on running the default R2R Retrieval-Au
 
 To comprehensively demonstrate the RAG functionalities of the R2R framework, we must start by ingesting a realistic set of documents. Running the command below will parse, chunk, embed, and store a preset list of files. The included file types cover HTML, PDF, PNG, and TXT examples:
 
-```bash copy
+```bash
 python -m r2r.examples.demo ingest_as_files
 ```
 
@@ -106,7 +106,7 @@ r2r.pipes.embedding_pipe - INFO - Fragmented the input document ids into counts 
 
 To verify the successful ingestion of the demo documents, you can fetch the metadata for the uploaded documents associated with the default demo user ID:
 
-```bash copy
+```bash
 python -m r2r.examples.demo documents_info
 ```
 
@@ -126,7 +126,7 @@ python -m r2r.examples.demo documents_info
 ```
 
 
-```bash copy
+```bash
 python -m r2r.examples.demo users_stats
 ```
 
@@ -146,7 +146,7 @@ python -m r2r.examples.demo users_stats
 
 Documents are stored by default in a local vector database. The vector database provider and settings can be specified via an input `config.json`. To perform a search query on the ingested user documents, use the following command:
 
-```bash copy
+```bash
 python -m r2r.examples.demo search --query="Who was Aristotle?"
 ```
 
@@ -177,7 +177,7 @@ the wider Aristotelian tradition that followed, which set the groundwork for the
 
 To generate a response for a query using RAG, execute the following command:
 
-```bash copy
+```bash
 python -m r2r.examples.demo rag --query="What was Uber's profit in 2020?"
 ```
 
@@ -221,7 +221,7 @@ Time taken to run RAG: 2.29 seconds
 
 For streaming results from a RAG query, use the following command:
 
-```bash copy
+```bash
 python -m r2r.examples.demo rag --query="What was Lyft's profit in 2020?" --streaming=true
 ```
 
@@ -241,7 +241,7 @@ Time taken to stream RAG response: 2.79 seconds
 
 To update document(s) we may use the `update_as_files` or `update_as_documents` endpoints. Running the demo with `update_as_files` overwrites the data associated with 'aristotle.txt' with new data corresponding to 'aristotle_v2.txt' and increments the file version.
 
-```bash copy
+```bash
 python -m r2r.examples.demo update_as_files
 ```
 
@@ -249,7 +249,7 @@ python -m r2r.examples.demo update_as_files
 
 To delete a document by its ID, or any other metadata field, use the delete command. For example, to delete all chunks corresponding to the uploaded file `aristotle.txt`, we can call delete on the metadata field `document_id` with the value `15255e98-e245-5b58-a57f-6c51babf72dd`:
 
-```bash copy
+```bash
 python -m r2r.examples.demo delete --keys="['document_id']" --values="['c9bdbac7-0ea3-5c9e-b590-018bd09b127b']"
 ```
 
@@ -257,7 +257,7 @@ python -m r2r.examples.demo delete --keys="['document_id']" --values="['c9bdbac7
 
 To delete all documents associated with a given user, run the delete command on the `user_id`:
 
-```bash copy
+```bash
 # run the following command with care, as it will erase all ingested user data for `063edaf8-3e63-4cb9-a4d6-a855f36376c3`
 python -m r2r.examples.demo delete --keys="['user_id']" --values="['063edaf8-3e63-4cb9-a4d6-a855f36376c3']"
 ```
@@ -270,7 +270,7 @@ This section extends the previous demo by showing how to set up and use the R2R 
 
 Use the following command to start the server:
 
-```bash copy
+```bash
 python -m r2r.examples.demo serve
 ```
 
@@ -279,25 +279,25 @@ This command starts the R2R server on the default host `0.0.0.0` and port `8000`
 ### Example Commands
 
 1. **Ingest Documents as Files**:
-   ```bash copy
+   ```bash
    python -m r2r.examples.demo ingest_as_files --client_server_mode
    ```
    This command will send the ingestion request to the server running at `http://localhost:8000`.
 
 2. **Perform a Search**:
-   ```bash copy
+   ```bash
    python -m r2r.examples.demo search --query="Who was Aristotle?" --client_server_mode
    ```
    This command sends the search query to the server and retrieves the results.
 
 3. **Run a RAG Completion**:
-   ```bash copy
+   ```bash
    python -m r2r.examples.demo rag --query="What was Uber's profit in 2020?" --client_server_mode
    ```
    This command sends the RAG query to the server and retrieves the generated response.
 
 4. **Run a RAG Stream**:
-   ```bash copy
+   ```bash
    python -m r2r.examples.demo rag --query="What was Lyft's profit in 2020?" --streaming=true --client_server_mode
    ```
    This command streams the RAG query results from the server.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ R2R was conceived to help developers bridge the gap between local LLM experiment
 
 # Quick Install:
 
-```bash
+```bash copy
 # use the `'r2r[all]'` to download all required deps
 pip install r2r
 
@@ -49,12 +49,12 @@ export OPENAI_API_KEY=sk-...
 
 ### With local installation
 
-```bash
+```bash copy
 python -m r2r.examples.servers.configurable_pipeline --host 0.0.0.0 --port 8000
 ```
 ### With Docker
 
-```bash
+```bash copy
 docker pull emrgntcmplxty/r2r:latest
 docker run -d --name r2r -p 8000:8000 emrgntcmplxty/r2r:latest -e OPENAI_API_KEY=...
 ```
@@ -83,7 +83,7 @@ The R2R demo offers a step-by-step guide on running the default R2R Retrieval-Au
 
 To comprehensively demonstrate the RAG functionalities of the R2R framework, we must start by ingesting a realistic set of documents. Running the command below will parse, chunk, embed, and store a preset list of files. The included file types cover HTML, PDF, PNG, and TXT examples:
 
-```bash
+```bash copy
 python -m r2r.examples.demo ingest_as_files
 ```
 
@@ -106,7 +106,7 @@ r2r.pipes.embedding_pipe - INFO - Fragmented the input document ids into counts 
 
 To verify the successful ingestion of the demo documents, you can fetch the metadata for the uploaded documents associated with the default demo user ID:
 
-```bash
+```bash copy
 python -m r2r.examples.demo documents_info
 ```
 
@@ -126,7 +126,7 @@ python -m r2r.examples.demo documents_info
 ```
 
 
-```bash
+```bash copy
 python -m r2r.examples.demo users_stats
 ```
 
@@ -146,7 +146,7 @@ python -m r2r.examples.demo users_stats
 
 Documents are stored by default in a local vector database. The vector database provider and settings can be specified via an input `config.json`. To perform a search query on the ingested user documents, use the following command:
 
-```bash
+```bash copy
 python -m r2r.examples.demo search --query="Who was Aristotle?"
 ```
 
@@ -177,7 +177,7 @@ the wider Aristotelian tradition that followed, which set the groundwork for the
 
 To generate a response for a query using RAG, execute the following command:
 
-```bash
+```bash copy
 python -m r2r.examples.demo rag --query="What was Uber's profit in 2020?"
 ```
 
@@ -221,7 +221,7 @@ Time taken to run RAG: 2.29 seconds
 
 For streaming results from a RAG query, use the following command:
 
-```bash
+```bash copy
 python -m r2r.examples.demo rag --query="What was Lyft's profit in 2020?" --streaming=true
 ```
 
@@ -241,7 +241,7 @@ Time taken to stream RAG response: 2.79 seconds
 
 To update document(s) we may use the `update_as_files` or `update_as_documents` endpoints. Running the demo with `update_as_files` overwrites the data associated with 'aristotle.txt' with new data corresponding to 'aristotle_v2.txt' and increments the file version.
 
-```bash
+```bash copy
 python -m r2r.examples.demo update_as_files
 ```
 
@@ -249,7 +249,7 @@ python -m r2r.examples.demo update_as_files
 
 To delete a document by its ID, or any other metadata field, use the delete command. For example, to delete all chunks corresponding to the uploaded file `aristotle.txt`, we can call delete on the metadata field `document_id` with the value `15255e98-e245-5b58-a57f-6c51babf72dd`:
 
-```bash
+```bash copy
 python -m r2r.examples.demo delete --keys="['document_id']" --values="['c9bdbac7-0ea3-5c9e-b590-018bd09b127b']"
 ```
 
@@ -257,7 +257,7 @@ python -m r2r.examples.demo delete --keys="['document_id']" --values="['c9bdbac7
 
 To delete all documents associated with a given user, run the delete command on the `user_id`:
 
-```bash
+```bash copy
 # run the following command with care, as it will erase all ingested user data for `063edaf8-3e63-4cb9-a4d6-a855f36376c3`
 python -m r2r.examples.demo delete --keys="['user_id']" --values="['063edaf8-3e63-4cb9-a4d6-a855f36376c3']"
 ```
@@ -270,7 +270,7 @@ This section extends the previous demo by showing how to set up and use the R2R 
 
 Use the following command to start the server:
 
-```bash
+```bash copy
 python -m r2r.examples.demo serve
 ```
 
@@ -279,25 +279,25 @@ This command starts the R2R server on the default host `0.0.0.0` and port `8000`
 ### Example Commands
 
 1. **Ingest Documents as Files**:
-   ```bash
+   ```bash copy
    python -m r2r.examples.demo ingest_as_files --client_server_mode
    ```
    This command will send the ingestion request to the server running at `http://localhost:8000`.
 
 2. **Perform a Search**:
-   ```bash
+   ```bash copy
    python -m r2r.examples.demo search --query="Who was Aristotle?" --client_server_mode
    ```
    This command sends the search query to the server and retrieves the results.
 
 3. **Run a RAG Completion**:
-   ```bash
+   ```bash copy
    python -m r2r.examples.demo rag --query="What was Uber's profit in 2020?" --client_server_mode
    ```
    This command sends the RAG query to the server and retrieves the generated response.
 
 4. **Run a RAG Stream**:
-   ```bash
+   ```bash copy
    python -m r2r.examples.demo rag --query="What was Lyft's profit in 2020?" --streaming=true --client_server_mode
    ```
    This command streams the RAG query results from the server.

--- a/docs/pages/cookbooks/local-rag.mdx
+++ b/docs/pages/cookbooks/local-rag.mdx
@@ -35,6 +35,19 @@ To streamline this process, we've provided pre-configured local settings in the 
     "llm":{
       "provider": "litellm"
     }
+  },
+  "ingestion":{
+    "selected_parsers": {
+      "csv": "default",
+      "docx": "default",
+      "html": "default",
+      "json": "default",
+      "md": "default",
+      "pdf": "default",
+      "pptx": "default",
+      "txt": "default",
+      "xlsx": "default"
+    }
   }
 }
 ```
@@ -50,7 +63,7 @@ A local vector database will be used to store the embeddings. The current defaul
 
 ```bash filename="bash" copy
 # cd $WORKDIR
-python -m r2r.examples.servers.configurable_pipeline --host 0.0.0.0 --port 8000 --config local_ollama --pipeline_type qna --no_images
+python -m r2r.examples.servers.configurable_pipeline --host 0.0.0.0 --port 8000 --config local_ollama --pipeline_type qna
 ```
 
 The server exposes a REST API for interacting with the R2R RAG pipeline and application. See the [API docs](/getting-started/app-api) for more details on the available endpoints.
@@ -78,7 +91,6 @@ docker run -d \
   -p 8000:8000 \
   -e OLLAMA_API_BASE=http://host.docker.internal:11434 \
   -e CONFIG_OPTION=local_ollama \
-  -e NO_IMAGES=true \
   emrgntcmplxty/r2r:latest
 ```
 

--- a/docs/pages/cookbooks/server-client.mdx
+++ b/docs/pages/cookbooks/server-client.mdx
@@ -31,13 +31,14 @@ docker pull emrgntcmplxty/r2r:latest
 
 This will pull the latest R2R Docker image.
 
-Then, run the container with:
+Be sure to set an OpenAI API key in your environment and then run the container with:
 
 ```bash filename="bash" copy
 docker run -d \
   --name r2r \
   --add-host=host.docker.internal:host-gateway \
   -p 8000:8000 \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
   r2r:latest
 ```
 
@@ -46,6 +47,7 @@ This command starts the R2R container with the following options:
 - `--name r2r`: Assigns the name "r2r" to the container.
 - `--add-host=host.docker.internal:host-gateway`: Adds a host entry for the Docker host.
 - `-p 8000:8000`: Maps port 8000 of the container to port 8000 of the host.
+- `-e OPENAI_API_KEY=$OPENAI_API_KEY`: Pulls your OpenAI API key from your local enviornment for use in the container.
 - `r2r:latest`: Specifies the Docker image to use.
 
 </details>

--- a/r2r/examples/configs/local_ollama.json
+++ b/r2r/examples/configs/local_ollama.json
@@ -11,5 +11,18 @@
     "llm":{
       "provider": "litellm"
     }
+  },
+  "ingestion":{
+    "selected_parsers": {
+      "csv": "default",
+      "docx": "default",
+      "html": "default",
+      "json": "default",
+      "md": "default",
+      "pdf": "default",
+      "pptx": "default",
+      "txt": "default",
+      "xlsx": "default"
+    }
   }
 }

--- a/r2r/examples/servers/configurable_pipeline.py
+++ b/r2r/examples/servers/configurable_pipeline.py
@@ -66,7 +66,7 @@ def r2r_app(
         )
 
     if pipeline_type == PipelineType.QNA:
-        return R2RAppBuilder(config).build(no_images=no_images).app
+        return R2RAppBuilder(config).build().app
     elif pipeline_type == PipelineType.WEB:
         web_search_pipe = R2RWebSearchPipe(
             serper_client=SerperClient()  # TODO - Develop a `WebSearchProvider` for configurability
@@ -115,11 +115,6 @@ if __name__ == "__main__":
         choices=[ele.lower() for ele in PipelineType.__members__.keys()],
         help="Specific pipeline to deploy",
     )
-    parser.add_argument(
-        "--no_images",
-        action="store_true",
-        help="Flag to exclude image files from ingestion",
-    )
 
     args, _ = parser.parse_known_args()
 
@@ -127,13 +122,10 @@ if __name__ == "__main__":
     port = os.getenv("PORT") or args.port
     config_name = os.getenv("CONFIG_OPTION") or args.config
     pipeline_type = os.getenv("PIPELINE_TYPE") or args.pipeline_type
-    no_images = os.getenv("NO_IMAGES") or args.no_images
 
     logger.info(f"Environment CONFIG_OPTION: {config_name}")
 
-    app = r2r_app(
-        config_name, PipelineType(pipeline_type), no_images=no_images
-    )
+    app = r2r_app(config_name, PipelineType(pipeline_type))
 
     import uvicorn
 

--- a/r2r/main/r2r_factory.py
+++ b/r2r/main/r2r_factory.py
@@ -202,7 +202,6 @@ class R2RPipeFactory:
         *args,
         **kwargs,
     ) -> R2RPipes:
-        no_images = kwargs.get("no_images", False)
 
         return R2RPipes(
             parsing_pipe=parsing_pipe_override
@@ -228,21 +227,7 @@ class R2RPipeFactory:
     ) -> Any:
         from r2r.pipes import R2RDocumentParsingPipe
 
-        no_images = kwargs.get("no_images", False)
-
-        if no_images:
-            excluded_types = R2RDocumentParsingPipe.IMAGE_TYPES | {
-                DocumentType.MP3
-            }
-            selected_parsers = {
-                doc_type: parser_key
-                for doc_type, parser_key in (selected_parsers or {}).items()
-                if doc_type not in excluded_types
-            }
-
-        return R2RDocumentParsingPipe(
-            selected_parsers=selected_parsers or {}, no_images=no_images
-        )
+        return R2RDocumentParsingPipe(selected_parsers=selected_parsers or {})
 
     def create_embedding_pipe(self, *args, **kwargs) -> Any:
         from r2r.core import RecursiveCharacterTextSplitter

--- a/r2r/pipes/parsing_pipe.py
+++ b/r2r/pipes/parsing_pipe.py
@@ -119,7 +119,6 @@ class R2RDocumentParsingPipe(DocumentParsingPipe):
         pipe_logger: Optional[KVLoggingSingleton] = None,
         type: PipeType = PipeType.INGESTOR,
         config: Optional[LoggableAsyncPipe.PipeConfig] = None,
-        no_images: bool = False,
         *args,
         **kwargs,
     ):
@@ -137,17 +136,10 @@ class R2RDocumentParsingPipe(DocumentParsingPipe):
             **kwargs,
         )
 
-        self.no_images = no_images
         self.parsers = {}
 
         if not override_parsers:
             override_parsers = {}
-
-        available_parsers = self.AVAILABLE_PARSERS.copy()
-        if self.no_images:
-            for doc_type in self.IMAGE_TYPES:
-                if doc_type in available_parsers:
-                    del available_parsers[doc_type]
 
         for doc_type, parser_key in selected_parsers.items():
             if doc_type in override_parsers:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b84d64cda9699c3dcf25a99e36d7903ecb9c0335  | 
|--------|--------|

### Summary:
This PR updates Docker usage instructions to explicitly set the OpenAI API key and simplifies the codebase by removing the `no_images` flag across various functions.

**Key points**:
- Updated Docker commands in `/README.md` and `/docs/pages/cookbooks/server-client.mdx` to explicitly set the `OPENAI_API_KEY`.
- Removed `no_images` flag from functions in `/r2r/examples/servers/configurable_pipeline.py` and `/r2r/main/r2r_factory.py`, simplifying the codebase.
- Added parser configurations for various document types in `/r2r/examples/configs/local_ollama.json`.
- Adjusted Docker commands to pull the OpenAI API key from the environment, enhancing security and usability.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->