### PR TITLE
Add basic telemetry

### DIFF
--- a/docs/pages/deep-dive/_meta.json
+++ b/docs/pages/deep-dive/_meta.json
@@ -5,5 +5,6 @@
   "config": "R2R Config",
   "ingestion": "Ingestion Pipeline",
   "search": "Search Pipeline",
-  "rag": "RAG Pipeline"
+  "rag": "RAG Pipeline",
+  "telemetry": "Telemetry"
 }

--- a/docs/pages/deep-dive/telemetry.mdx
+++ b/docs/pages/deep-dive/telemetry.mdx
@@ -1,0 +1,27 @@
+## Telemetry
+
+R2R utilizes telemetry that collects **anonymous** usage information.
+
+Why? We use this information to help us understand how R2R is used so that we can prioritize work on new features and bug fixes, allowing us to improve R2R's performance and stability.
+
+### Disabling Telemetry
+
+To disable telemetry, set the environment variable `TELEMETRY_ENABLED` to `false`, `0`, or `f`. You can do this in your terminal before running your application:
+
+```sh copy
+export TELEMETRY_ENABLED=false
+```
+
+With this setup, telemetry events will not be captured if telemetry is disabled, providing a way for users to control the logging of events.
+
+### What do you collect?
+
+We collect basic information such as:
+
+- **Feature Usage**: Which features are being used and how often.
+
+
+### Where is telemetry information stored?
+We use [Posthog](https://posthog.com/) for our telemetry data.
+
+Posthog is an open source platform for product analytics. Learn more about Posthog on [posthog.com](https://posthog.com/) or [github.com/posthog](https://github.com/posthog).

--- a/poetry.lock
+++ b/poetry.lock
@@ -249,6 +249,17 @@ tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
 tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 description = "Screen-scraping library"
@@ -1472,6 +1483,17 @@ intel-openmp = "==2021.*"
 tbb = "==2021.*"
 
 [[package]]
+name = "monotonic"
+version = "1.6"
+description = "An implementation of time.monotonic() for Python 2 & < 3.3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "monotonic-1.6-py2.py3-none-any.whl", hash = "sha256:68687e19a14f11f26d140dd5c86f3dba4bf5df58003000ed467e0e2a69bca96c"},
+    {file = "monotonic-1.6.tar.gz", hash = "sha256:3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7"},
+]
+
+[[package]]
 name = "moviepy"
 version = "1.0.3"
 description = "Video editing with Python"
@@ -2099,6 +2121,29 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "posthog"
+version = "3.5.0"
+description = "Integrate PostHog into any python application."
+optional = false
+python-versions = "*"
+files = [
+    {file = "posthog-3.5.0-py2.py3-none-any.whl", hash = "sha256:3c672be7ba6f95d555ea207d4486c171d06657eb34b3ce25eb043bfe7b6b5b76"},
+    {file = "posthog-3.5.0.tar.gz", hash = "sha256:8f7e3b2c6e8714d0c0c542a2109b83a7549f63b7113a133ab2763a89245ef2ef"},
+]
+
+[package.dependencies]
+backoff = ">=1.10.0"
+monotonic = ">=1.5"
+python-dateutil = ">2.1"
+requests = ">=2.7,<3.0"
+six = ">=1.5"
+
+[package.extras]
+dev = ["black", "flake8", "flake8-print", "isort", "pre-commit"]
+sentry = ["django", "sentry-sdk"]
+test = ["coverage", "flake8", "freezegun (==0.3.15)", "mock (>=2.0.0)", "pylint", "pytest", "pytest-timeout"]
 
 [[package]]
 name = "proglog"
@@ -3787,4 +3832,4 @@ local-embedding = ["sentence-transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "739bf3252eabe7f0d85d01e06e85a25220431bf526a549e7c1ef0a0f2f19381d"
+content-hash = "66ebc420f5a5d2a66e52c93e5c7b0cd275591ac76ee894f6de53ffae4a0f57f0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ ionic-api-sdk = {version = "0.9.3", optional = true}
 exa-py = {version = "^1.0.9", optional = true}
 dateutils = "^0.6.12"
 fsspec = "^2024.6.0"
+posthog = "^3.5.0"
 
 [tool.poetry.extras]
 all = ["tiktoken", "sentence-transformers"]

--- a/r2r/telemetry/events.py
+++ b/r2r/telemetry/events.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict
+import uuid
+
+
+class BaseTelemetryEvent:
+    def __init__(self, event_type: str, properties: Dict[str, Any]):
+        self.event_type = event_type
+        self.properties = properties
+        self.event_id = str(uuid.uuid4())
+
+
+class DailyActiveUserEvent(BaseTelemetryEvent):
+    def __init__(self, user_id: str):
+        super().__init__("DailyActiveUser", {"user_id": user_id})
+
+
+class FeatureUsageEvent(BaseTelemetryEvent):
+    def __init__(self, user_id: str, feature: str):
+        super().__init__(
+            "FeatureUsage", {"user_id": user_id, "feature": feature}
+        )
+
+
+class ErrorEvent(BaseTelemetryEvent):
+    def __init__(self, user_id: str, endpoint: str, error_message: str):
+        super().__init__(
+            "Error",
+            {
+                "user_id": user_id,
+                "endpoint": endpoint,
+                "error_message": error_message,
+            },
+        )
+
+
+class RequestLatencyEvent(BaseTelemetryEvent):
+    def __init__(self, endpoint: str, latency: float):
+        super().__init__(
+            "RequestLatency", {"endpoint": endpoint, "latency": latency}
+        )
+
+
+class GeographicDistributionEvent(BaseTelemetryEvent):
+    def __init__(self, user_id: str, country: str):
+        super().__init__(
+            "GeographicDistribution", {"user_id": user_id, "country": country}
+        )
+
+
+class SessionDurationEvent(BaseTelemetryEvent):
+    def __init__(self, user_id: str, duration: float):
+        super().__init__(
+            "SessionDuration", {"user_id": user_id, "duration": duration}
+        )
+
+
+class UserPathEvent(BaseTelemetryEvent):
+    def __init__(self, user_id: str, path: str):
+        super().__init__("UserPath", {"user_id": user_id, "path": path})

--- a/r2r/telemetry/posthog.py
+++ b/r2r/telemetry/posthog.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import posthog
+from r2r.telemetry.events import BaseTelemetryEvent
+
+logger = logging.getLogger(__name__)
+
+
+class PosthogClient:
+    """
+    This is a write-only project API key, so it can only create new events. It can't
+    read events or any of your other data stored with PostHog, so it's safe to use in public apps.
+    """
+
+    def __init__(self, api_key: str, enabled: bool = True):
+        self.enabled = enabled
+        if self.enabled:
+            logger.info(
+                "Initializing anonymized telemetry. To disable, set TELEMETRY_ENABLED=false in your environment."
+            )
+            posthog.project_api_key = api_key
+        else:
+            posthog.disabled = True
+        logger.info(
+            f"Posthog telemetry {'enabled' if self.enabled else 'disabled'}"
+        )
+
+    def capture(self, event: BaseTelemetryEvent):
+        if self.enabled:
+            posthog.capture(event.event_id, event.event_type, event.properties)
+
+
+# Initialize the telemetry client with a flag to enable or disable telemetry
+telemetry_enabled = os.getenv("TELEMETRY_ENABLED", "true").lower() in (
+    "true",
+    "1",
+    "t",
+)
+telemetry_client = PosthogClient(
+    api_key="phc_OPBbibOIErCGc4NDLQsOrMuYFTKDmRwXX6qxnTr6zpU",
+    enabled=telemetry_enabled,
+)

--- a/r2r/telemetry/telemetry_decorator.py
+++ b/r2r/telemetry/telemetry_decorator.py
@@ -1,0 +1,50 @@
+import asyncio
+import logging
+from functools import wraps
+from r2r.telemetry.events import FeatureUsageEvent, ErrorEvent
+from r2r.telemetry.posthog import telemetry_client
+
+logger = logging.getLogger(__name__)
+
+
+def telemetry_event(event_name):
+    def decorator(func):
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            user_id = kwargs.get("user_id", "unknown_user")
+            try:
+                result = await func(*args, **kwargs)
+                telemetry_client.capture(
+                    FeatureUsageEvent(user_id=user_id, feature=event_name)
+                )
+                return result
+            except Exception as e:
+                # Log the exception
+                logger.error(f"Error in {event_name}: {str(e)}")
+                telemetry_client.capture(
+                    ErrorEvent(
+                        user_id=user_id,
+                        endpoint=event_name,
+                        error_message=str(e),
+                    )
+                )
+                raise
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                future = asyncio.run_coroutine_threadsafe(
+                    async_wrapper(*args, **kwargs), loop
+                )
+                return future.result()
+            else:
+                return loop.run_until_complete(async_wrapper(*args, **kwargs))
+
+        return (
+            async_wrapper
+            if asyncio.iscoroutinefunction(func)
+            else sync_wrapper
+        )
+
+    return decorator


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9d50d4157c812e64dbd62ae27e6322137d784eb5  | 
|--------|--------|

### Summary:
Added telemetry support using Posthog to track feature usage and errors, with integration into various endpoints and documentation on how to disable it.

**Key points**:
- Added telemetry support using Posthog in `r2r/telemetry/posthog.py`.
- Introduced `BaseTelemetryEvent` and specific event classes in `r2r/telemetry/events.py`.
- Created `telemetry_event` decorator in `r2r/telemetry/telemetry_decorator.py` to log feature usage and errors.
- Updated `r2r/main/r2r_app.py` to include telemetry for various endpoints (e.g., `update_prompt_app`, `ingest_documents_app`, `search_app`).
- Added documentation for telemetry in `docs/pages/deep-dive/telemetry.mdx`.
- Updated `pyproject.toml` to include `posthog` dependency.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->