### PR TITLE
Add check for version in aingest_files

### DIFF
--- a/r2r/main/r2r_app.py
+++ b/r2r/main/r2r_app.py
@@ -592,6 +592,8 @@ class R2RApp(metaclass=AsyncSyncMeta):
                     if document_ids is None
                     else document_ids[iteration]
                 )
+                
+                version = versions[iteration] if versions else "v0"
                 if (
                     version is not None
                     and str(document_id) in existing_document_ids


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6a018f2e55b1fde644add22f796c7cdc9db49648  | 
|--------|--------|

### Summary:
Added a check in `R2RApp.aingest_files` to set `version` to 'v0' if not provided.

**Key points**:
- **File Modified**: `r2r/main/r2r_app.py`
- **Function Modified**: `R2RApp.aingest_files`
- **Change**: Added a check to set `version` to 'v0' if not provided in the `versions` list.
- **Behavior**: Ensures that the `version` variable is always set, defaulting to 'v0' if `versions` is not provided.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->