### PR TITLE
Make `None` provider more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ For a more complete view of R2R, check out our [documentation](https://r2r-docs.
 - **🖥️ Dashboard**: Use the [R2R Dashboard](https://github.com/SciPhi-AI/R2R-Dashboard), an open-source React+Next.js app for a user-friendly interaction with your pipelines.
 
 ## Table of Contents
-1. [Quick Install](#quick-install)
-2. [R2R Python SDK Demo](#r2r-python-sdk-demo)
+1. [Install](#install)
+2. [R2R Quickstart](#r2r-quickstart)
 3. [R2R Dashboard](#r2r-dashboard)
 4. [Community and Support](#community-and-support)
 5. [Contributing](#contributing)
@@ -82,9 +82,9 @@ This command starts the R2R container with the following options:
 </details>
 
 
-# R2R Python SDK Demo
+# R2R Quickstart
 
-The following demo offers a step-by-step guide on running the default R2R Retrieval-Augmented Generation (RAG) pipeline using the Python SDK. The demo ingests a list of provided provided documents and demonstrates search, RAG, and advanced functionality. The script at `r2r/examples/quickstart.py`, which powers the demo, can be configured and extended with sufficient developer familiarity.
+The following quickstart offers a step-by-step guide on running R2R locally as well as through the Python SDK. The guide ingests a list of provided provided documents and shows search, RAG, and advanced functionality. The script powering the quickstart can be found at `r2r/examples/quickstart.py`, and it can be configured and extended with sufficient developer familiarity.
 
 ![ingest_as_files](https://github.com/SciPhi-AI/R2R/assets/34580718/b0780f26-8e90-4459-9537-e5871453d003)
 

--- a/config.json
+++ b/config.json
@@ -19,20 +19,10 @@
     "rerank_model": "None"
   },
   "kg": {
-    "provider": "None",
-    "batch_size": 1,
-    "text_splitter": {
-      "type": "recursive_character",
-      "chunk_size": 1024,
-      "chunk_overlap": 0
-    }
+    "provider": "None"
   },
   "eval": {
-    "provider": "local",
-    "llm":{
-      "model": "gpt-4o",
-      "provider": "openai"
-    }
+    "provider": "None"
   },
   "ingestion":{
     "excluded_parsers": {

--- a/docs/pages/cookbooks/knowledge-graph.mdx
+++ b/docs/pages/cookbooks/knowledge-graph.mdx
@@ -40,7 +40,7 @@ After selecting a knowledge graph provider, the default R2R `IngestionPipeline` 
 R2R uses Neo4j as the primary knowledge graph provider. Follow [these instructions](https://neo4j.com/docs/operations-manual/current/installation/) to setup a Neo4j database. Ensure that your Neo4j database is running with version `>=5.13.0` with `APOC` installed. After setup, set the relevant environment variables as shown (or modify them accordingly):
 
 ```bash filename="User Terminal"
-pip install `r2r[kg]`
+pip install 'r2r[kg]'
 export NEO4J_USER=neo4j
 export NEO4J_PASSWORD=password
 export NEO4J_URL=bolt://localhost:7687

--- a/docs/pages/cookbooks/multimodal-rag.mdx
+++ b/docs/pages/cookbooks/multimodal-rag.mdx
@@ -2,11 +2,11 @@ import { Callout, FileTree } from 'nextra/components'
 
 ## Multimodal RAG with R2R
 
-R2R supports ingesting images, audio, and videos. These multimodal features are implemented in the `ImageParser`, `AudioParser`, and `MovieParser`, which can be found in [`parser_impls.py`](https://github.com/SciPhi-AI/R2R/blob/main/r2r/core/parsers/parser_impls.py). Currently, these features are powered by OpenAI multimodal models, but work is ongoing to expand support to other cloud providers and to include Local LLM support.
-
-<Callout>
-The features falling under 'multimodal' RAG are still preliminary, so we appreciate your feedback.
+<Callout type="info" emoji="⚠️">
+Multimodal RAG features in R2R are still under development.
 </Callout>
+
+R2R supports ingesting images, audio, and videos. These multimodal features are implemented in the `ImageParser`, `AudioParser`, and `MovieParser`, which can be found in [`parser_impls.py`](https://github.com/SciPhi-AI/R2R/blob/main/r2r/core/parsers/parser_impls.py). Currently, these features are powered by OpenAI multimodal models, but work is ongoing to expand support to other cloud providers and to include Local LLM support.
 
 ### Processing Different Modalities
 

--- a/docs/pages/cookbooks/rerank-search.mdx
+++ b/docs/pages/cookbooks/rerank-search.mdx
@@ -39,16 +39,21 @@ These settings build upon those shown in `/examples/configs/local_ollama.json` a
 
 ### Executing a Basic Search
 
+<Callout type="warning" emoji="🐳">
+If you are running with Docker, then you may skip the step below, but be sure you are running with the `local_ollama` config and have added the flag `--add-host=host.docker.internal:host-gateway`.
+</Callout>
+
 To execute a basic search, start by running the backend with the basic `local_ollama` config.
 
 ```bash filename="bash" copy
+pip install 'r2r[local-embedding]'
 python -m r2r.examples.servers.configurable_pipeline --host 0.0.0.0 --port 8000 --config local_ollama
 ```
 
 If the target database is empty, quickly populate it with demo files, which include `.txt`, `.pdf`, `.html`, and `.png` examples, using the command shown below. The `client_server_mode` flag specifies communication with an R2R server with the default URL of `http://localhost:8000`. To replicate the exact results shown below, these commands must be run in order on a clean database.
 
 ```bash filename="bash" copy
-python -m r2r.examples.quickstart ingest_as_files --client_server_mode
+python -m r2r.examples.quickstart ingest_as_files --client_server_mode --no-media
 ```
 
 Once the files are populated, run a search with the following command:
@@ -81,7 +86,7 @@ python -m r2r.examples.quickstart search --query="Who was Aristotle?" --client_s
 
 ### Executing a Reranked Search
 
-Executing a reranked search is as simple as specifying a config with a `rerank_model`, `rerank_dimension`, and optionally a `rerank_transformer_type`. We will now run with the reranking config specified at the start of this cookbook:
+Executing a reranked search is as simple as specifying a config with a `rerank_model`, `rerank_dimension`, and optionally a `rerank_transformer_type`. Let's stop the previous server and start it now with the reranking config specified at the start of this cookbook:
 
 ```bash filename="bash" copy
 # cd $WORKDIR

--- a/docs/pages/deep-dive/customizing-your-pipeline.mdx
+++ b/docs/pages/deep-dive/customizing-your-pipeline.mdx
@@ -111,7 +111,7 @@ if __name__ == "__main__":
         R2RAppBuilder()
         .with_pipe_factory(R2RPipeFactoryWithMultiSearch)
         .build(
-            # override inputs consumed by `R2RPipeFactoryWithMultiSearch.create_search_pipe`
+            # override inputs consumed by `R2RPipeFactoryWithMultiSearch.create_vector_search_pipe`
             multi_inner_search_pipe_override=web_search_pipe,
             query_generation_template_override=synthetic_query_generation_template,
         )
@@ -197,7 +197,7 @@ The `R2RPipeFactory` is responsible for creating the pipes used in the `R2RApp`.
 - **create_parsing_pipe**: Creates the parsing pipe.
 - **create_embedding_pipe**: Creates the embedding pipe.
 - **create_vector_storage_pipe**: Creates the vector storage pipe.
-- **create_search_pipe**: Creates the search pipe.
+- **create_vector_search_pipe**: Creates the search pipe.
 - **create_rag_pipe**: Creates the RAG pipe.
 - **create_eval_pipe**: Creates the evaluation pipe.
 
@@ -214,11 +214,11 @@ The `R2RPipelineFactory` is responsible for creating the various pipelines used 
 
 ### Example - Custom Pipe Factory
 
-The `R2RPipeFactoryWithMultiSearch` class shown below demonstrates how to override the `create_search_pipe` method of the `R2RPipeFactory` to use a `MultiSearchPipe`.
+The `R2RPipeFactoryWithMultiSearch` class shown below demonstrates how to override the `create_vector_search_pipe` method of the `R2RPipeFactory` to use a `MultiSearchPipe`.
 
 ```python copy
 class R2RPipeFactoryWithMultiSearch(R2RPipeFactory):
-    def create_search_pipe(self, *args, **kwargs):
+    def create_vector_search_pipe(self, *args, **kwargs):
         multi_search_config = MultiSearchPipe.PipeConfig()
         task_prompt_name = kwargs.get("task_prompt_name") or f"{multi_search_config.name}_task_prompt"
 
@@ -237,7 +237,7 @@ class R2RPipeFactoryWithMultiSearch(R2RPipeFactory):
                 **(kwargs.get("query_generation_template_override") or self.QUERY_GENERATION_TEMPLATE),
             )
 
-        inner_search_pipe = kwargs.get("multi_inner_search_pipe_override", None) or super().create_search_pipe(*args, **kwargs)
+        inner_search_pipe = kwargs.get("multi_inner_search_pipe_override", None) or super().create_vector_search_pipe(*args, **kwargs)
         inner_search_pipe.config.name = multi_search_config.name
 
         return MultiSearchPipe(

--- a/r2r/core/providers/eval_provider.py
+++ b/r2r/core/providers/eval_provider.py
@@ -7,15 +7,19 @@ from .llm_provider import GenerationConfig, LLMConfig
 class EvalConfig(ProviderConfig):
     """A base eval config class"""
 
-    llm: LLMConfig
+    llm: Optional[LLMConfig] = None
 
     def validate(self) -> None:
         if self.provider not in self.supported_providers:
             raise ValueError(f"Provider {self.provider} not supported.")
+        if self.provider and not self.llm:
+            raise ValueError(
+                "EvalConfig must have a `llm` attribute when specifying a provider."
+            )
 
     @property
     def supported_providers(self) -> list[str]:
-        return ["local"]
+        return [None, "local"]
 
 
 class EvalProvider(Provider):

--- a/r2r/core/providers/kg_provider.py
+++ b/r2r/core/providers/kg_provider.py
@@ -24,14 +24,12 @@ class KGConfig(ProviderConfig):
     kg_agent_prompt: Optional[str] = "kg_agent"
 
     def validate(self) -> None:
-        if not self.provider:
-            raise ValueError("Provider must be set.")
-        if self.provider and self.provider not in self.supported_providers:
+        if self.provider not in self.supported_providers:
             raise ValueError(f"Provider '{self.provider}' is not supported.")
 
     @property
     def supported_providers(self) -> list[str]:
-        return ["None", "neo4j"]
+        return [None, "neo4j"]
 
 
 class KGProvider(ABC):

--- a/r2r/examples/configs/local_ollama.json
+++ b/r2r/examples/configs/local_ollama.json
@@ -6,11 +6,7 @@
     "batch_size": 32
   },
   "eval": {
-    "provider": "local",
-    "frequency": 0.0,
-    "llm":{
-      "provider": "litellm"
-    }
+    "provider": "None"
   },
   "ingestion":{
     "excluded_parsers": {

--- a/r2r/examples/configs/local_ollama_rerank.json
+++ b/r2r/examples/configs/local_ollama_rerank.json
@@ -12,5 +12,16 @@
       "chunk_size": 512,
       "chunk_overlap": 20
     }
+  },
+  "ingestion":{
+    "excluded_parsers": {
+      "gif": "default",
+      "jpeg": "default",
+      "jpg": "default",
+      "png": "default",
+      "svg": "default",
+      "mp3": "default",
+      "mp4": "default"
+    }
   }
 }

--- a/r2r/examples/quickstart.py
+++ b/r2r/examples/quickstart.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-class R2RDemo:
+class R2RQuickstart:
     """A demo class for the R2R library."""
 
     DEMO_USER_ID = "063edaf8-3e63-4cb9-a4d6-a855f36376c3"
@@ -468,4 +468,4 @@ class R2RDemo:
 
 
 if __name__ == "__main__":
-    fire.Fire(R2RDemo)
+    fire.Fire(R2RQuickstart)

--- a/r2r/main/r2r_abstractions.py
+++ b/r2r/main/r2r_abstractions.py
@@ -30,15 +30,15 @@ class R2RProviders(BaseModel):
 
 
 class R2RPipes(BaseModel):
-    parsing_pipe: LoggableAsyncPipe
-    embedding_pipe: LoggableAsyncPipe
-    vector_storage_pipe: LoggableAsyncPipe
-    search_pipe: LoggableAsyncPipe
-    rag_pipe: LoggableAsyncPipe
-    streaming_rag_pipe: LoggableAsyncPipe
-    eval_pipe: LoggableAsyncPipe
-    kg_pipe: LoggableAsyncPipe
-    kg_storage_pipe: LoggableAsyncPipe
+    parsing_pipe: Optional[LoggableAsyncPipe]
+    embedding_pipe: Optional[LoggableAsyncPipe]
+    vector_storage_pipe: Optional[LoggableAsyncPipe]
+    vector_search_pipe: Optional[LoggableAsyncPipe]
+    rag_pipe: Optional[LoggableAsyncPipe]
+    streaming_rag_pipe: Optional[LoggableAsyncPipe]
+    eval_pipe: Optional[LoggableAsyncPipe]
+    kg_pipe: Optional[LoggableAsyncPipe]
+    kg_storage_pipe: Optional[LoggableAsyncPipe]
 
     class Config:
         arbitrary_types_allowed = True

--- a/r2r/main/r2r_config.py
+++ b/r2r/main/r2r_config.py
@@ -58,7 +58,12 @@ class R2RConfig:
 
         # Validate and set the configuration
         for section, keys in R2RConfig.REQUIRED_KEYS.items():
-            self._validate_config_section(default_config, section, keys)
+            # Check the keys when provider is set
+            if (
+                "provider" in default_config[section]
+                and default_config[section]["provider"] != "None"
+            ):
+                self._validate_config_section(default_config, section, keys)
             setattr(self, section, default_config[section])
 
         self.app = self.app  # for type hinting
@@ -69,9 +74,9 @@ class R2RConfig:
         }
         self.embedding = EmbeddingConfig.create(**self.embedding)
         self.kg = KGConfig.create(**self.kg)
-        eval_llm = self.eval.pop("llm")
+        eval_llm = self.eval.pop("llm", None)
         self.eval = EvalConfig.create(
-            **self.eval, llm=LLMConfig.create(**eval_llm)
+            **self.eval, llm=LLMConfig.create(**eval_llm) if eval_llm else None
         )
         self.completions = LLMConfig.create(**self.completions)
         self.logging = LoggingConfig.create(**self.logging)

--- a/r2r/main/r2r_factory.py
+++ b/r2r/main/r2r_factory.py
@@ -78,10 +78,6 @@ class R2RProviderFactory:
             embedding_provider = SentenceTransformerEmbeddingProvider(
                 embedding
             )
-        elif embedding.provider == "dummy":
-            from r2r.providers.embeddings import DummyEmbeddingProvider
-
-            embedding_provider = DummyEmbeddingProvider(embedding)
         elif embedding is None:
             embedding_provider = None
         else:
@@ -103,7 +99,7 @@ class R2RProviderFactory:
                 llm_provider=llm_provider,
                 prompt_provider=prompt_provider,
             )
-        elif eval_config.provider == "none":
+        elif eval_config.provider == None:
             eval_provider = None
         else:
             raise ValueError(
@@ -233,8 +229,8 @@ class R2RPipeFactory:
             or self.create_kg_storage_pipe(*args, **kwargs),
             vector_storage_pipe=vector_storage_pipe_override
             or self.create_vector_storage_pipe(*args, **kwargs),
-            search_pipe=search_pipe_override
-            or self.create_search_pipe(*args, **kwargs),
+            vector_search_pipe=search_pipe_override
+            or self.create_vector_search_pipe(*args, **kwargs),
             rag_pipe=rag_pipe_override
             or self.create_rag_pipe(*args, **kwargs),
             streaming_rag_pipe=streaming_rag_pipe_override
@@ -251,6 +247,9 @@ class R2RPipeFactory:
         return ParsingPipe(excluded_parsers=excluded_parsers or {})
 
     def create_embedding_pipe(self, *args, **kwargs) -> Any:
+        if self.config.embedding.provider is None:
+            return None
+
         from r2r.core import RecursiveCharacterTextSplitter
         from r2r.pipes import EmbeddingPipe
 
@@ -275,7 +274,29 @@ class R2RPipeFactory:
             embedding_batch_size=self.config.embedding.batch_size,
         )
 
+    def create_vector_storage_pipe(self, *args, **kwargs) -> Any:
+        if self.config.embedding.provider is None:
+            return None
+
+        from r2r.pipes import VectorStoragePipe
+
+        return VectorStoragePipe(vector_db_provider=self.providers.vector_db)
+
+    def create_vector_search_pipe(self, *args, **kwargs) -> Any:
+        if self.config.embedding.provider is None:
+            return None
+
+        from r2r.pipes import VectorSearchPipe
+
+        return VectorSearchPipe(
+            vector_db_provider=self.providers.vector_db,
+            embedding_provider=self.providers.embedding,
+        )
+
     def create_kg_pipe(self, *args, **kwargs) -> Any:
+        if self.config.kg.provider is None:
+            return None
+
         from r2r.core import RecursiveCharacterTextSplitter
         from r2r.pipes import KGExtractionPipe
 
@@ -299,23 +320,13 @@ class R2RPipeFactory:
         )
 
     def create_kg_storage_pipe(self, *args, **kwargs) -> Any:
+        if self.config.kg.provider is None:
+            return None
+
         from r2r.pipes import KGStoragePipe
 
         return KGStoragePipe(
             kg_provider=self.providers.kg,
-            embedding_provider=self.providers.embedding,
-        )
-
-    def create_vector_storage_pipe(self, *args, **kwargs) -> Any:
-        from r2r.pipes import VectorStoragePipe
-
-        return VectorStoragePipe(vector_db_provider=self.providers.vector_db)
-
-    def create_search_pipe(self, *args, **kwargs) -> Any:
-        from r2r.pipes import VectorSearchPipe
-
-        return VectorSearchPipe(
-            vector_db_provider=self.providers.vector_db,
             embedding_provider=self.providers.embedding,
         )
 
@@ -372,29 +383,29 @@ class R2RPipelineFactory:
 
     def create_search_pipeline(self, *args, **kwargs) -> SearchPipeline:
         search_pipeline = SearchPipeline()
-        search_pipeline.add_pipe(self.pipes.search_pipe)
+        search_pipeline.add_pipe(self.pipes.vector_search_pipe)
         return search_pipeline
 
     def create_rag_pipeline(
         self, streaming: bool = False, *args, **kwargs
     ) -> RAGPipeline:
-        search_pipe = self.pipes.search_pipe
+        vector_search_pipe = self.pipes.vector_search_pipe
         rag_pipe = (
             self.pipes.streaming_rag_pipe if streaming else self.pipes.rag_pipe
         )
 
         rag_pipeline = RAGPipeline()
-        rag_pipeline.add_pipe(search_pipe)
+        rag_pipeline.add_pipe(vector_search_pipe)
         rag_pipeline.add_pipe(
             rag_pipe,
             add_upstream_outputs=[
                 {
-                    "prev_pipe_name": search_pipe.config.name,
+                    "prev_pipe_name": vector_search_pipe.config.name,
                     "prev_output_field": "search_results",
                     "input_field": "raw_search_results",
                 },
                 {
-                    "prev_pipe_name": search_pipe.config.name,
+                    "prev_pipe_name": vector_search_pipe.config.name,
                     "prev_output_field": "search_queries",
                     "input_field": "query",
                 },

--- a/r2r/prebuilts/multi_search.py
+++ b/r2r/prebuilts/multi_search.py
@@ -25,7 +25,7 @@ class MultiSearchPipe(LoggableAsyncPipe):
         **kwargs,
     ):
         self.query_transform_pipe = query_transform_pipe
-        self.search_pipe = inner_search_pipe
+        self.vector_search_pipe = inner_search_pipe
         if (
             not query_transform_pipe.config.name
             == inner_search_pipe.config.name
@@ -72,8 +72,8 @@ class MultiSearchPipe(LoggableAsyncPipe):
             **kwargs,
         )
 
-        async for search_result in await self.search_pipe.run(
-            self.search_pipe.Input(message=query_generator),
+        async for search_result in await self.vector_search_pipe.run(
+            self.vector_search_pipe.Input(message=query_generator),
             state,
             *args,
             **kwargs,
@@ -89,7 +89,7 @@ class R2RPipeFactoryWithMultiSearch(R2RPipeFactory):
         }
     )
 
-    def create_search_pipe(self, *args, **kwargs):
+    def create_vector_search_pipe(self, *args, **kwargs):
         """
         A factory method to create a search pipe.
 
@@ -128,7 +128,7 @@ class R2RPipeFactoryWithMultiSearch(R2RPipeFactory):
         # Create search pipe override and pipes
         inner_search_pipe = kwargs.get(
             "multi_inner_search_pipe_override", None
-        ) or super().create_search_pipe(*args, **kwargs)
+        ) or super().create_vector_search_pipe(*args, **kwargs)
 
         # TODO - modify `create_..._pipe` to allow naming the pipe
         inner_search_pipe.config.name = multi_search_config.name


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0ad2258d7b3670eeab9fad5e51cc44df1e393097  | 
|--------|--------|

### Summary:
Enhanced robustness of the `None` provider by updating configuration validation, factory methods, and pipeline creation across multiple files.

**Key points**:
- **Updated `README.md`**: Renamed sections for clarity.
- **Updated `docs/pages/cookbooks/knowledge-graph.mdx`**: Fixed pip install command.
- **Updated `docs/pages/cookbooks/multimodal-rag.mdx`**: Moved callout for multimodal RAG features.
- **Updated `docs/pages/cookbooks/rerank-search.mdx`**: Added warning for Docker users and updated commands.
- **Updated `docs/pages/deep-dive/customizing-your-pipeline.mdx`**: Corrected method names for vector search pipe.
- **Updated `r2r/core/providers/eval_provider.py`**: Added support for `None` provider in `EvalConfig`.
- **Updated `r2r/core/providers/kg_provider.py`**: Added support for `None` provider in `KGConfig`.
- **Updated `r2r/examples/configs/local_ollama.json`**: Set eval provider to `None`.
- **Updated `r2r/examples/configs/local_ollama_rerank.json`**: Added ingestion settings.
- **Renamed `R2RDemo` to `R2RQuickstart` in `r2r/examples/quickstart.py`**.
- **Updated `r2r/main/r2r_abstractions.py`**: Made pipes optional.
- **Updated `r2r/main/r2r_config.py`**: Added validation for `None` provider.
- **Updated `r2r/main/r2r_factory.py`**: Added handling for `None` provider in various factory methods.
- **Updated `r2r/prebuilts/multi_search.py`**: Renamed `search_pipe` to `vector_search_pipe`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->