### PR TITLE
Add debug mode to Posthog

### DIFF
--- a/r2r/telemetry/posthog.py
+++ b/r2r/telemetry/posthog.py
@@ -14,8 +14,12 @@ class PosthogClient:
     read events or any of your other data stored with PostHog, so it's safe to use in public apps.
     """
 
-    def __init__(self, api_key: str, enabled: bool = True):
+    def __init__(
+        self, api_key: str, enabled: bool = True, debug: bool = False
+    ):
         self.enabled = enabled
+        self.debug = debug
+
         if self.enabled:
             logger.info(
                 "Initializing anonymized telemetry. To disable, set TELEMETRY_ENABLED=false in your environment."
@@ -23,8 +27,12 @@ class PosthogClient:
             posthog.project_api_key = api_key
         else:
             posthog.disabled = True
+
+        if self.debug:
+            posthog.debug = True
+
         logger.info(
-            f"Posthog telemetry {'enabled' if self.enabled else 'disabled'}"
+            f"Posthog telemetry {'enabled' if self.enabled else 'disabled'}, debug mode {'on' if self.debug else 'off'}"
         )
 
     def capture(self, event: BaseTelemetryEvent):
@@ -34,6 +42,11 @@ class PosthogClient:
 
 # Initialize the telemetry client with a flag to enable or disable telemetry
 telemetry_enabled = os.getenv("TELEMETRY_ENABLED", "true").lower() in (
+    "true",
+    "1",
+    "t",
+)
+debug_mode = os.getenv("DEBUG_MODE", "false").lower() in (
     "true",
     "1",
     "t",


### PR DESCRIPTION
Adding this in to allow debug mode when telemetry is disabled. Helps to avoid sending to Posthog while developing

`export TELEMETRY_ENABLED=false`
`export DEBUG_MODE=true`
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 73534ef95bb339670546a8e7685bbdc8b4b3bd39  | 
|--------|--------|

### Summary:
Added debug mode to `PosthogClient` in `r2r/telemetry/posthog.py`, controlled by `DEBUG_MODE` environment variable, to enable debug logging without sending telemetry data.

**Key points**:
- Added `debug` parameter to `PosthogClient.__init__` in `r2r/telemetry/posthog.py`
- Controlled by `DEBUG_MODE` environment variable
- Enables debug logging without sending telemetry data
- Updated telemetry client initialization to include `debug` parameter


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->