### PR TITLE
Add optional metadata to KG cookbook

### DIFF
--- a/docs/pages/cookbooks/knowledge-graph.mdx
+++ b/docs/pages/cookbooks/knowledge-graph.mdx
@@ -68,20 +68,28 @@ from r2r import R2RAppBuilder, Document
 if __name__ == "__main__":
     r2r_app = R2RAppBuilder(from_config="neo4j_kg").build()
 
-    r2r_app.ingest_documents([
-        Document(
-            type="txt",
-            data="John is a person that works at Google.",
-            # Metadata is optional
-            metadata={"title":"KG Document 1", "user_id":"063edaf8-3e63-4cb9-a4d6-a855f36376c3"},
-        ),
-        Document(
-            type="txt",
-            data="Paul is a person that works at Microsoft that knows John.",
-            # Metadata is optional
-            metadata={"title":"KG Document 2", "user_id":"063edaf8-3e63-4cb9-a4d6-a855f36376c3"},
-        )
-    ])
+    r2r_app.ingest_documents(
+        [
+            Document(
+                type="txt",
+                data="John is a person that works at Google.",
+                # Metadata is optional
+                metadata={
+                    "title": "KG Document 1",
+                    "user_id": "063edaf8-3e63-4cb9-a4d6-a855f36376c3",
+                },
+            ),
+            Document(
+                type="txt",
+                data="Paul is a person that works at Microsoft that knows John.",
+                # Metadata is optional
+                metadata={
+                    "title": "KG Document 2",
+                    "user_id": "063edaf8-3e63-4cb9-a4d6-a855f36376c3",
+                },
+            ),
+        ]
+    )
 ```
 
 #### Navigation

--- a/docs/pages/cookbooks/knowledge-graph.mdx
+++ b/docs/pages/cookbooks/knowledge-graph.mdx
@@ -72,12 +72,14 @@ if __name__ == "__main__":
         Document(
             type="txt",
             data="John is a person that works at Google.",
-            metadata={},
+            # Metadata is optional
+            metadata={"title":"KG Document 1", "user_id":"063edaf8-3e63-4cb9-a4d6-a855f36376c3"},
         ),
         Document(
             type="txt",
             data="Paul is a person that works at Microsoft that knows John.",
-            metadata={},
+            # Metadata is optional
+            metadata={"title":"KG Document 2", "user_id":"063edaf8-3e63-4cb9-a4d6-a855f36376c3"},
         )
     ])
 ```

--- a/r2r/examples/scripts/basic_kg_cookbook.py
+++ b/r2r/examples/scripts/basic_kg_cookbook.py
@@ -8,12 +8,20 @@ if __name__ == "__main__":
             Document(
                 type="txt",
                 data="John is a person that works at Google.",
-                metadata={},
+                # Metadata is optional
+                metadata={
+                    "title": "KG Document 1",
+                    "user_id": "063edaf8-3e63-4cb9-a4d6-a855f36376c3",
+                },
             ),
             Document(
                 type="txt",
                 data="Paul is a person that works at Microsoft that knows John.",
-                metadata={},
+                # Metadata is optional
+                metadata={
+                    "title": "KG Document 2",
+                    "user_id": "063edaf8-3e63-4cb9-a4d6-a855f36376c3",
+                },
             ),
         ]
     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e6e84ee5ce6b8b85797c436d90bbc04a23afd357  | 
|--------|--------|

### Summary:
Added optional metadata fields `title` and `user_id` to documents in the knowledge graph cookbook and example script.

**Key points**:
- Updated `docs/pages/cookbooks/knowledge-graph.mdx` to include optional metadata in document examples.
- Modified `r2r/examples/scripts/basic_kg_cookbook.py` to add optional metadata (`title` and `user_id`) to `Document` instances.
- Metadata fields added: `title` and `user_id`.
- Metadata is optional and does not affect existing functionality.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->