### PR TITLE
let userid be None

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,6 +39,6 @@
   },
   "vector_database": {
     "provider": "pgvector",
-    "collection_name": "demo_vecs"
+    "collection_name": "demo_vecs_000_000_000"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "r2r"
-version = "0.2.3"
+version = "0.2.31"
 description = "SciPhi R2R"
 authors = ["Owen Colegrove <owen@sciphi.ai>"]
 license = "MIT"

--- a/r2r/main/services/ingestion_service.py
+++ b/r2r/main/services/ingestion_service.py
@@ -243,7 +243,7 @@ class IngestionService(Service):
                 "Number of user_ids entries does not match number of files."
             )
         elif user_ids and not all(
-            isinstance(user_id, uuid.UUID) for user_id in user_ids
+            (isinstance(user_id, uuid.UUID) for user_id in user_ids if user_id)
         ):
             raise ValueError("All user IDs must be of type UUID.")
         if len(files) == 0:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2d451f1d42ed8f702c9a4c9bdd79532bf94d7021  | 
|--------|--------|

### Summary:
Allow `user_ids` to be `None` in `ingest_files` function in `r2r/main/services/ingestion_service.py`.

**Key points**:
- Updated `pyproject.toml` version to `0.2.31`.
- Modified `r2r/main/services/ingestion_service.py`.
- In `ingest_files`, changed type check for `user_ids` to allow `None` values.
- Ensures `user_ids` can be `None` without causing a type error.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->