### PR TITLE
patch the quickstart bug

### DIFF
--- a/r2r/examples/quickstart.py
+++ b/r2r/examples/quickstart.py
@@ -253,7 +253,7 @@ class R2RQuickstart:
                 metadatas=metadatas,
                 files=[new for old, new in file_tuples],
                 document_ids=[
-                    generate_id_from_label(old_file)
+                    generate_id_from_label(old_file.split(os.path.sep)[-1])
                     for old_file, new_file in file_tuples
                 ],
                 monitor=True,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d9afd745c8bb731467faf07e7a9f8ced80b73c3b  | 
|--------|--------|

### Summary:
Updated `generate_id_from_label` call in `R2RQuickstart.update_as_files` to use only the filename part of the path for consistent document ID generation.

**Key points**:
- **File Modified**: `r2r/examples/quickstart.py`
- **Function Modified**: `R2RQuickstart.update_as_files`
- **Change**: Updated the `generate_id_from_label` function call to use only the filename part of the path (`old_file.split(os.path.sep)[-1]`) instead of the full path.
- **Reason**: Ensures consistent document ID generation when updating files.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->