### PR TITLE
Trivial correction on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ export POSTGRES_DBNAME=YOUR_POSTGRES_DBNAME
 # Optional on first pull. Advised when fetching the latest updates.
 docker pull emrgntcmplxty/r2r:latest
 
-# Runs the image. If you set up the environment you don't need to modify anything. Otherwise, add your values on the right side of the -e commands.
+# Runs the image. If you set up the environment you don't need to modify anything.
+# Otherwise, add your values on the right side of the -e commands.
 # For Windows, remove the "\" from your command.
 docker run -d \
    --name r2r \


### PR DESCRIPTION
I just corrected one of my yesterday's comments on Readme,md. I just separated one of the comments into 2 lines because it was looking ugly and bothered me.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d984861fb40d6a18ff9d267514c9f74fea6af917  | 
|--------|--------|

### Summary:
Updated `README.md` to improve readability by splitting a long comment into two lines.

**Key points**:
- Updated `README.md` for better readability.
- Split a long comment into two lines in the Docker run instructions section.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->