### PR TITLE
Patch/remove get r2r args kwargs

### DIFF
--- a/r2r/examples/quickstart.py
+++ b/r2r/examples/quickstart.py
@@ -69,7 +69,7 @@ class R2RQuickstart:
                 f"Running in client-server mode with base_url: {self.base_url}"
             )
         else:
-            self.r2r_app = get_r2r_app(R2RAppBuilder(config))
+            self.r2r_app = get_r2r_app(app_builder=R2RAppBuilder(config))
             logger.info("Running locally")
 
         root_path = os.path.dirname(os.path.abspath(__file__))

--- a/r2r/main/dependencies.py
+++ b/r2r/main/dependencies.py
@@ -6,9 +6,9 @@ from .assembly.builder import R2RAppBuilder
 r2r_app_instance = None
 
 
-def get_r2r_app(app_builder: Optional[str] = None, *args, **kwargs):
+def get_r2r_app(app_builder: Optional[str] = None):
     global r2r_app_instance
     if r2r_app_instance is None:
         builder = app_builder or R2RAppBuilder()
-        r2r_app_instance = builder.build(*args, **kwargs)
+        r2r_app_instance = builder.build()
     return r2r_app_instance


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1d8e888f5508f153c4adde011f180b4c8bf4a223  | 
|--------|--------|

### Summary:
Removed `*args` and `**kwargs` from `get_r2r_app` function and updated its usage in `r2r/examples/quickstart.py`.

**Key points**:
- **Modified** `r2r/main/dependencies.py`: Updated `get_r2r_app` function to remove `*args` and `**kwargs` parameters.
- **Updated** `r2r/examples/quickstart.py`: Changed the call to `get_r2r_app` to match the new function signature by explicitly passing `app_builder=R2RAppBuilder(config)`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->