### PR TITLE
Add `in` filter over metadata fields / values 

### DIFF
--- a/r2r/providers/vector_dbs/pgvector/pgvector_db.py
+++ b/r2r/providers/vector_dbs/pgvector/pgvector_db.py
@@ -313,18 +313,25 @@ class PGVectorDB(VectorDBProvider):
         pass
 
     def delete_by_metadata(
-        self, metadata_fields: str, metadata_values: Union[bool, int, str]
+        self,
+        metadata_fields: list[str],
+        metadata_values: list[Union[bool, int, str]],
     ) -> list[str]:
         super().delete_by_metadata(metadata_fields, metadata_values)
         if self.collection is None:
             raise ValueError(
                 "Please call `initialize_collection` before attempting to run `delete_by_metadata`."
             )
-        return self.collection.delete(
-            filters={
-                k: {"$eq": v} for k, v in zip(metadata_fields, metadata_values)
-            }
-        )
+
+        # Construct a filter that matches documents where ANY of the field-value pairs match
+        filters = {}
+        for field, value in zip(metadata_fields, metadata_values):
+            if field not in filters:
+                filters[field] = {"$in": [value]}
+            else:
+                filters[field]["$in"].append(value)
+
+        return self.collection.delete(filters=filters)
 
     def get_metadatas(
         self,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5d42a087cee36a0bb21742c7ebdc4f462753fde0  | 
|--------|--------|

### Summary:
Enhanced `delete_by_metadata` in `r2r/providers/vector_dbs/pgvector/pgvector_db.py` to support filtering by multiple metadata fields and values using the `$in` operator.

**Key points**:
- **File Modified**: `r2r/providers/vector_dbs/pgvector/pgvector_db.py`
- **Method Modified**: `PGVectorDB.delete_by_metadata`
- **Change**: Updated `delete_by_metadata` to accept lists for `metadata_fields` and `metadata_values`.
- **Behavior**: Constructs a filter using the `$in` operator to match documents where any of the field-value pairs match.
- **Error Handling**: Raises `ValueError` if `collection` is not initialized.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->