### PR TITLE
Patch/fix streaming response bug

### DIFF
--- a/r2r/examples/quickstart.py
+++ b/r2r/examples/quickstart.py
@@ -371,7 +371,6 @@ class R2RQuickstart:
                 response = response["results"]
                 t1 = time.time()
                 print(f"Time taken to get RAG response: {t1-t0:.2f} seconds")
-                print("response = ", response)
                 print(f"Search Results:\n{response['search_results']}")
                 print(f"Completion:\n{response['completion']}")
 

--- a/r2r/examples/quickstart.py
+++ b/r2r/examples/quickstart.py
@@ -368,10 +368,12 @@ class R2RQuickstart:
                 rag_generation_config=rag_generation_config,
             )
             if not stream:
+                response = response["results"]
                 t1 = time.time()
                 print(f"Time taken to get RAG response: {t1-t0:.2f} seconds")
-                print("Search Results:\n{response.search_results}")
-                print("Completion:\n{response.completion}")
+                print("response = ", response)
+                print(f"Search Results:\n{response['search_results']}")
+                print(f"Completion:\n{response['completion']}")
 
             else:
                 for chunk in response:

--- a/r2r/main/api/client.py
+++ b/r2r/main/api/client.py
@@ -275,6 +275,7 @@ class R2RClient:
             ),
             rag_generation_config=rag_generation_config,
         )
+        print("request = ", request)
 
         if rag_generation_config.stream:
             return self._stream_rag_sync(request)

--- a/r2r/main/api/client.py
+++ b/r2r/main/api/client.py
@@ -275,7 +275,6 @@ class R2RClient:
             ),
             rag_generation_config=rag_generation_config,
         )
-        print("request = ", request)
 
         if rag_generation_config.stream:
             return self._stream_rag_sync(request)

--- a/r2r/main/api/routes/base_router.py
+++ b/r2r/main/api/routes/base_router.py
@@ -2,6 +2,7 @@ import functools
 import logging
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
 
 from r2r.base import manage_run
 from r2r.main.abstractions import R2RException
@@ -22,6 +23,9 @@ class BaseRouter:
             ) as run_id:
                 try:
                     results = await func(*args, **kwargs)
+                    if isinstance(results, StreamingResponse):
+                        return results
+
                     return {"results": results}
                 except R2RException as re:
                     raise HTTPException(

--- a/r2r/main/api/routes/retrieval.py
+++ b/r2r/main/api/routes/retrieval.py
@@ -42,8 +42,13 @@ class RetrievalRouter(BaseRouter):
                 request.rag_generation_config
                 and request.rag_generation_config.stream
             ):
+
+                async def stream_generator():
+                    async for chunk in response:
+                        yield chunk
+
                 return StreamingResponse(
-                    response, media_type="application/json"
+                    stream_generator(), media_type="application/json"
                 )
             else:
                 return response[0]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 73399a35b04e6646268f86c990472c9c4d5650a8  | 
|--------|--------|

### Summary:
Fixed streaming response handling in RAG functionality, added debug logs, and fixed string formatting.

**Key points**:
- **Fixed**: Streaming response handling in `r2r/main/api/routes/retrieval.py` by adding `stream_generator` for `rag_app`.
- **Updated**: `r2r/main/api/routes/base_router.py` to return `StreamingResponse` if applicable.
- **Added**: Debug print statement in `r2r/main/api/client.py` to log the RAG request.
- **Fixed**: String formatting in `r2r/examples/quickstart.py` for non-streaming RAG responses.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->