### PR TITLE
Feature/return failed files list

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,9 +25,9 @@
     "provider": "None"
   },
   "ingestion":{
-    "excluded_parsers": {
-      "mp4": "default"
-    }
+    "excluded_parsers": [
+      "mp4"
+    ]
   },
   "logging": {
     "provider": "local",

--- a/r2r/examples/configs/local_ollama.json
+++ b/r2r/examples/configs/local_ollama.json
@@ -6,15 +6,15 @@
     "batch_size": 32
   },
   "ingestion":{
-    "excluded_parsers": {
-      "gif": "default",
-      "jpeg": "default",
-      "jpg": "default",
-      "png": "default",
-      "svg": "default",
-      "mp3": "default",
-      "mp4": "default"
-    }
+    "excluded_parsers": [
+      "gif",
+      "jpeg",
+      "jpg",
+      "png",
+      "svg",
+      "mp3",
+      "mp4"
+    ]
   },
   "vector_database": {
     "provider": "pgvector"

--- a/r2r/examples/configs/local_ollama_rerank.json
+++ b/r2r/examples/configs/local_ollama_rerank.json
@@ -14,14 +14,14 @@
     }
   },
   "ingestion":{
-    "excluded_parsers": {
-      "gif": "default",
-      "jpeg": "default",
-      "jpg": "default",
-      "png": "default",
-      "svg": "default",
-      "mp3": "default",
-      "mp4": "default"
-    }
+    "excluded_parsers": [
+      "gif",
+      "jpeg",
+      "jpg",
+      "png",
+      "svg",
+      "mp3",
+      "mp4"
+    ]
   }
 }

--- a/r2r/examples/quickstart.py
+++ b/r2r/examples/quickstart.py
@@ -78,17 +78,17 @@ class R2RQuickstart:
         ]
         self.default_files = [
             os.path.join(root_path, "data", "aristotle.txt"),
-            os.path.join(root_path, "data", "got.txt"),
-            os.path.join(root_path, "data", "screen_shot.png"),
+            # os.path.join(root_path, "data", "got.txt"),
+            # os.path.join(root_path, "data", "screen_shot.png"),
             os.path.join(root_path, "data", "pg_essay_1.html"),
-            os.path.join(root_path, "data", "pg_essay_2.html"),
-            os.path.join(root_path, "data", "pg_essay_3.html"),
-            os.path.join(root_path, "data", "pg_essay_4.html"),
-            os.path.join(root_path, "data", "pg_essay_5.html"),
-            os.path.join(root_path, "data", "lyft_2021.pdf"),
-            os.path.join(root_path, "data", "uber_2021.pdf"),
-            os.path.join(root_path, "data", "sample.mp3"),
-            os.path.join(root_path, "data", "sample2.mp3"),
+            # os.path.join(root_path, "data", "pg_essay_2.html"),
+            # os.path.join(root_path, "data", "pg_essay_3.html"),
+            # os.path.join(root_path, "data", "pg_essay_4.html"),
+            # os.path.join(root_path, "data", "pg_essay_5.html"),
+            # os.path.join(root_path, "data", "lyft_2021.pdf"),
+            # os.path.join(root_path, "data", "uber_2021.pdf"),
+            # os.path.join(root_path, "data", "sample.mp3"),
+            # os.path.join(root_path, "data", "sample2.mp3"),
         ]
 
         self.file_tuples = file_tuples or [

--- a/r2r/examples/quickstart.py
+++ b/r2r/examples/quickstart.py
@@ -78,17 +78,17 @@ class R2RQuickstart:
         ]
         self.default_files = [
             os.path.join(root_path, "data", "aristotle.txt"),
-            # os.path.join(root_path, "data", "got.txt"),
-            # os.path.join(root_path, "data", "screen_shot.png"),
+            os.path.join(root_path, "data", "got.txt"),
+            os.path.join(root_path, "data", "screen_shot.png"),
             os.path.join(root_path, "data", "pg_essay_1.html"),
-            # os.path.join(root_path, "data", "pg_essay_2.html"),
-            # os.path.join(root_path, "data", "pg_essay_3.html"),
-            # os.path.join(root_path, "data", "pg_essay_4.html"),
-            # os.path.join(root_path, "data", "pg_essay_5.html"),
-            # os.path.join(root_path, "data", "lyft_2021.pdf"),
-            # os.path.join(root_path, "data", "uber_2021.pdf"),
-            # os.path.join(root_path, "data", "sample.mp3"),
-            # os.path.join(root_path, "data", "sample2.mp3"),
+            os.path.join(root_path, "data", "pg_essay_2.html"),
+            os.path.join(root_path, "data", "pg_essay_3.html"),
+            os.path.join(root_path, "data", "pg_essay_4.html"),
+            os.path.join(root_path, "data", "pg_essay_5.html"),
+            os.path.join(root_path, "data", "lyft_2021.pdf"),
+            os.path.join(root_path, "data", "uber_2021.pdf"),
+            os.path.join(root_path, "data", "sample.mp3"),
+            os.path.join(root_path, "data", "sample2.mp3"),
         ]
 
         self.file_tuples = file_tuples or [

--- a/r2r/main/assembly/config.py
+++ b/r2r/main/assembly/config.py
@@ -70,10 +70,9 @@ class R2RConfig:
 
         self.app = self.app  # for type hinting
         self.ingestion = self.ingestion  # for type hinting
-        self.ingestion["excluded_parsers"] = {
-            DocumentType(k): v
-            for k, v in self.ingestion["excluded_parsers"].items()
-        }
+        self.ingestion["excluded_parsers"] = [
+            DocumentType(k) for k in self.ingestion["excluded_parsers"]
+        ]
         self.embedding = EmbeddingConfig.create(**self.embedding)
         self.kg = KGConfig.create(**self.kg)
         eval_llm = self.eval.pop("llm", None)

--- a/r2r/main/assembly/factory.py
+++ b/r2r/main/assembly/factory.py
@@ -246,11 +246,11 @@ class R2RPipeFactory:
         )
 
     def create_parsing_pipe(
-        self, excluded_parsers: Optional[dict] = None, *args, **kwargs
+        self, excluded_parsers: Optional[list] = None, *args, **kwargs
     ) -> Any:
         from r2r.pipes import ParsingPipe
 
-        return ParsingPipe(excluded_parsers=excluded_parsers or {})
+        return ParsingPipe(excluded_parsers=excluded_parsers or [])
 
     def create_embedding_pipe(self, *args, **kwargs) -> Any:
         if self.config.embedding.provider is None:

--- a/r2r/pipelines/ingestion_pipeline.py
+++ b/r2r/pipelines/ingestion_pipeline.py
@@ -104,11 +104,13 @@ class IngestionPipeline(AsyncPipeline):
             # Wait for the enqueueing task to complete
             await enqueue_task
 
+            results = {}
             # Wait for the embedding and KG tasks to complete
             if self.embedding_pipeline:
-                await embedding_task
+                results["embedding_pipeline_output"] = await embedding_task
             if self.kg_pipeline:
-                await kg_task
+                results["kg_pipeline_output"] = await kg_task
+            return results
 
     def add_pipe(
         self,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ def test_r2r_config_deserialization(mock_file, mock_redis_client):
             },
         },
         "eval": {"llm": {"provider": "local"}},
-        "ingestion": {"excluded_parsers": {"pdf": "default"}},
+        "ingestion": {"excluded_parsers": ["pdf"]},
         "completions": {"provider": "lm_provider"},
         "logging": {
             "provider": "local",
@@ -111,7 +111,7 @@ def test_r2r_config_deserialization(mock_file, mock_redis_client):
     mock_redis_client.get.return_value = json.dumps(config_data)
     config = R2RConfig.load_from_redis(mock_redis_client, "test_key")
     assert config.app["max_file_size_in_mb"] == 128
-    assert config.ingestion["excluded_parsers"][DocumentType.PDF] == "default"
+    assert DocumentType.PDF in config.ingestion["excluded_parsers"]
 
 
 def test_r2r_config_missing_section():


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 024c0347b1823533a9b362bcbb675a1b41c64869  | 
|--------|--------|

### Summary:
Introduced a feature to return a list of failed files during the ingestion process, updated configurations, and enhanced error handling across multiple components.

**Key points**:
- Updated `r2r/examples/configs/local_ollama.json` and `r2r/examples/configs/local_ollama_rerank.json` to change `excluded_parsers` from a dictionary to a list.
- Modified `r2r/main/assembly/config.py` to handle `excluded_parsers` as a list.
- Updated `r2r/main/assembly/factory.py` to pass `excluded_parsers` as a list to `ParsingPipe`.
- Enhanced `r2r/main/services/ingestion_service.py` to track and return failed documents in `ingest_documents` and `ingest_files` methods.
- Modified `r2r/pipelines/ingestion_pipeline.py` to return results from embedding and KG pipelines.
- Updated `r2r/pipes/ingestion/embedding_pipe.py` to handle `DocumentProcessingError` and yield errors.
- Enhanced `r2r/pipes/ingestion/parsing_pipe.py` to yield `DocumentProcessingError` when parsing fails.
- Updated `r2r/pipes/ingestion/vector_storage_pipe.py` to handle and yield `DocumentProcessingError`.
- Modified tests in `tests/test_config.py` to reflect changes in `excluded_parsers` format.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->