### PR TITLE
patch ollama embedding internals

### DIFF
--- a/r2r/pipes/retrieval/vector_search_pipe.py
+++ b/r2r/pipes/retrieval/vector_search_pipe.py
@@ -55,7 +55,7 @@ class VectorSearchPipe(SearchPipe):
             vector_search_settings.search_limit or self.config.search_limit
         )
         results = []
-        query_vector = self.embedding_provider.get_embedding(
+        query_vector = await self.embedding_provider.async_get_embedding(
             message,
         )
         search_results = (

--- a/r2r/providers/embeddings/ollama/ollama_base.py
+++ b/r2r/providers/embeddings/ollama/ollama_base.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import random
 from typing import Any
 
@@ -28,9 +29,16 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
                 "OllamaEmbeddingProvider does not support separate reranking."
             )
 
+        print("making an ollama client....")
         self.base_model = config.base_model
         self.base_dimension = config.base_dimension
-        self.client = AsyncClient()
+        # TODO - Clean this up!
+        self.base_url = os.getenv("OLLAMA_API_BASE")
+        logger.info(
+            f"Using Ollama API base URL: {self.base_url or 'http://127.0.0.1:11434'}"
+        )
+        self.client = AsyncClient(host=self.base_url)
+
         self.request_queue = asyncio.Queue()
         self.max_retries = 5
         self.initial_backoff = 1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cd218057745e75af2fd74ade7db5fe0d6e6824b6  | 
|--------|--------|

### Summary:
Updated `VectorSearchPipe` to use asynchronous embedding retrieval and modified `OllamaEmbeddingProvider` to initialize `AsyncClient` with a configurable base URL.

**Key points**:
- Updated `r2r/pipes/retrieval/vector_search_pipe.py` to use `async_get_embedding` instead of `get_embedding` in the `search` method.
- Modified `r2r/providers/embeddings/ollama/ollama_base.py` to initialize `AsyncClient` with a base URL from the `OLLAMA_API_BASE` environment variable.
- Added logging in `OllamaEmbeddingProvider.__init__` to log the base URL being used.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->