### PR TITLE
Replace the placeholder bs4 package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ asyncpg = "^0.29.0"
 redis = "^5.0.4"
 
 # ingestion
-bs4 = "^0.0.2"
+beautifulsoup4 = "^4.12.3"
 openpyxl = "^3.1.2"
 markdown = "^3.6"
 pypdf = "^4.2.0"


### PR DESCRIPTION
`bs4` is just a placeholder which installs `beautifulsoup4`. Use the proper name in the dep list. Update the version to match reality.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 33f5446baf7c6289834268d8fc67be990bf9fab8  | 
|--------|--------|

### Summary:
Replace `bs4` with `beautifulsoup4` and update its version in `pyproject.toml`.

**Key points**:
- Replace `bs4` with `beautifulsoup4` in `pyproject.toml`.
- Update version to `^4.12.3` to match the actual package version.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->