### PR TITLE
Modify posthog client

### DIFF
--- a/r2r/telemetry/posthog.py
+++ b/r2r/telemetry/posthog.py
@@ -25,6 +25,7 @@ class PosthogClient:
                 "Initializing anonymized telemetry. To disable, set TELEMETRY_ENABLED=false in your environment."
             )
             posthog.project_api_key = api_key
+            posthog.disable_geoip = False
         else:
             posthog.disabled = True
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ff0a03975ab909189b0efc99cc57da43788ede7b  | 
|--------|--------|

### Summary:
Added `posthog.disable_geoip = False` to the `PosthogClient` initialization to ensure GeoIP tracking is not disabled when telemetry is enabled.

**Key points**:
- **File**: `r2r/telemetry/posthog.py`
- **Class**: `PosthogClient`
- **Change**: Added `posthog.disable_geoip = False` in the `__init__` method when telemetry is enabled.
- **Behavior**: Ensures GeoIP tracking is not disabled when telemetry is enabled.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->