### PR TITLE
Prevent duplicate files from being uploaded in the same request

### DIFF
--- a/r2r/main/services/ingestion_service.py
+++ b/r2r/main/services/ingestion_service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+from collections import defaultdict
 from datetime import datetime
 from typing import Any, Optional, Union
 
@@ -80,6 +81,7 @@ class IngestionService(Service):
         document_infos = []
         skipped_documents = []
         processed_documents = {}
+        duplicate_documents = defaultdict(list)
 
         existing_document_info = {
             doc_info.document_id: doc_info
@@ -88,6 +90,14 @@ class IngestionService(Service):
 
         for iteration, document in enumerate(documents):
             version = versions[iteration] if versions else "v0"
+
+            # Check for duplicates within the current batch
+            if document.id in processed_documents:
+                duplicate_documents[document.id].append(
+                    document.metadata.get("title", str(document.id))
+                )
+                continue
+
             if (
                 document.id in existing_document_info
                 and existing_document_info[document.id].version == version
@@ -96,11 +106,6 @@ class IngestionService(Service):
                 logger.error(
                     f"Document with ID {document.id} was already successfully processed."
                 )
-                if len(documents) == 1:
-                    raise R2RException(
-                        status_code=409,
-                        message=f"Document with ID {document.id} was already successfully processed.",
-                    )
                 skipped_documents.append(
                     (
                         document.id,
@@ -129,6 +134,14 @@ class IngestionService(Service):
                 "title", str(document.id)
             )
 
+        if duplicate_documents:
+            duplicate_details = [
+                f"{doc_id}: {', '.join(titles)}"
+                for doc_id, titles in duplicate_documents.items()
+            ]
+            warning_message = f"Duplicate documents detected: {'; '.join(duplicate_details)}. These duplicates were skipped."
+            raise R2RException(status_code=418, message=warning_message)
+
         if skipped_documents and len(skipped_documents) == len(documents):
             logger.error("All provided documents already exist.")
             raise R2RException(
@@ -145,6 +158,7 @@ class IngestionService(Service):
                     for doc in documents
                     if doc.id
                     not in [skipped[0] for skipped in skipped_documents]
+                    and doc.id not in duplicate_documents
                 ]
             ),
             versions=[info.version for info in document_infos],

--- a/r2r/main/services/management_service.py
+++ b/r2r/main/services/management_service.py
@@ -3,8 +3,6 @@ import uuid
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import networkx as nx
-
 from r2r.base import (
     AnalysisTypes,
     FilterCriteria,


### PR DESCRIPTION
Now throws `HTTP 418: I'm a teapot` when a user tries to upload the same file more than once in the same request.

https://www.rfc-editor.org/rfc/rfc2324#section-2.3.2
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 060e20a23a6f632fc0fc44165c409d37200f87fd  | 
|--------|--------|

### Summary:
Introduced logic to prevent duplicate file uploads within the same request, throwing `HTTP 418: I'm a teapot` error, along with various refactorings and configuration updates.

**Key points**:
- **Prevent Duplicate Uploads**: Added logic to detect and skip duplicate files within the same request in `r2r/main/services/ingestion_service.py`.
- **Error Handling**: Throws `HTTP 418: I'm a teapot` for duplicate file uploads.
- **Configuration Updates**: Modified `compose.yaml` and `pyproject.toml` for environment and dependency management.
- **CLI Enhancements**: Updated `r2r/cli/cli.py` to handle new configurations and options.
- **API Changes**: Renamed `print_relationships` to `inspect_knowledge_graph` in `r2r/main/api/client.py`, `r2r/main/api/routes/management.py`, and related files.
- **Vector Handling**: Added custom `Vector` type in `r2r/vecs/collection.py` for better vector operations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->