### PR TITLE
Query prefix support

### DIFF
--- a/r2r/base/__init__.py
+++ b/r2r/base/__init__.py
@@ -53,7 +53,7 @@ from .logging.run_manager import RunManager, manage_run
 from .parsers import AsyncParser
 from .pipeline.base_pipeline import AsyncPipeline
 from .pipes.base_pipe import AsyncPipe, AsyncState, PipeType
-from .providers.embedding_provider import EmbeddingConfig, EmbeddingProvider
+from .providers.embedding_provider import EmbeddingConfig, EmbeddingProvider, EmbeddingPurpose
 from .providers.eval_provider import EvalConfig, EvalProvider
 from .providers.kg_provider import KGConfig, KGProvider
 from .providers.llm_provider import LLMConfig, LLMProvider

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from enum import Enum
+from enum import StrEnum
 from typing import Optional, Dict
 
 from ..abstractions.search import VectorSearchResult
@@ -8,10 +8,10 @@ from .base_provider import Provider, ProviderConfig
 
 logger = logging.getLogger(__name__)
 
-class EmbeddingPurpose(Enum):
-    INDEX = 1
-    QUERY = 2
-    DOCUMENT = 3
+class EmbeddingPurpose(StrEnum):
+    INDEX = auto()
+    QUERY = auto()
+    DOCUMENT = auto()
 
 class EmbeddingConfig(ProviderConfig):
     """A base embedding configuration class"""
@@ -92,3 +92,17 @@ class EmbeddingProvider(Provider):
     ) -> list[int]:
         """Tokenizes the input string."""
         pass
+
+    def set_prefixes(self, config_prefixes: dict[str, str], base_model: str):
+        self.prefixes = {}
+
+        # use the configured prefixes if given
+        for t, p in config_prefixes.items():
+            purpose = EmbeddingPurpose(t.lower())
+            self.prefixes[purpose] = p
+
+        # but apply known defaults otherwise
+        if base_model in default_embedding_prefixes:
+            for t, p in default_embedding_prefixes[base_model].items():
+                if t not in self.prefixes:
+                    self.prefixes[t] = p

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -1,13 +1,17 @@
 import logging
 from abc import abstractmethod
 from enum import Enum
-from typing import Optional
+from typing import Optional, Dict
 
 from ..abstractions.search import VectorSearchResult
 from .base_provider import Provider, ProviderConfig
 
 logger = logging.getLogger(__name__)
 
+class EmbeddingPurpose(Enum):
+    INDEX = 1
+    QUERY = 2
+    DOCUMENT = 3
 
 class EmbeddingConfig(ProviderConfig):
     """A base embedding configuration class"""
@@ -19,6 +23,7 @@ class EmbeddingConfig(ProviderConfig):
     rerank_dimension: Optional[int] = None
     rerank_transformer_type: Optional[str] = None
     batch_size: int = 1
+    prefixes: Optional[dict[EmbeddingPurpose, str]] = None
 
     def validate(self) -> None:
         if self.provider not in self.supported_providers:
@@ -46,24 +51,30 @@ class EmbeddingProvider(Provider):
         super().__init__(config)
 
     @abstractmethod
-    def get_embedding(self, text: str, stage: PipeStage = PipeStage.BASE):
+    def get_embedding(
+        self, text: str, stage: PipeStage = PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX
+    ):
         pass
 
     async def async_get_embedding(
-        self, text: str, stage: PipeStage = PipeStage.BASE
+        self, text: str, stage: PipeStage = PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX
     ):
-        return self.get_embedding(text, stage)
+        return self.get_embedding(text, stage, purpose)
 
     @abstractmethod
     def get_embeddings(
-        self, texts: list[str], stage: PipeStage = PipeStage.BASE
+        self, texts: list[str], stage: PipeStage = PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX
     ):
         pass
 
     async def async_get_embeddings(
-        self, texts: list[str], stage: PipeStage = PipeStage.BASE
+        self, texts: list[str], stage: PipeStage = PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX
     ):
-        return self.get_embeddings(texts, stage)
+        return self.get_embeddings(texts, stage, purpose)
 
     @abstractmethod
     def rerank(

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from enum import StrEnum
+from enum import StrEnum, auto
 from typing import Optional, Dict
 
 from ..abstractions.search import VectorSearchResult

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -1,7 +1,7 @@
 import logging
 from abc import abstractmethod
 from enum import Enum, StrEnum, auto
-from typing import Optional, Dict
+from typing import Optional
 
 from ..abstractions.search import VectorSearchResult
 from .base_provider import Provider, ProviderConfig
@@ -48,7 +48,7 @@ class EmbeddingConfig(ProviderConfig):
     rerank_dimension: Optional[int] = None
     rerank_transformer_type: Optional[str] = None
     batch_size: int = 1
-    prefixes: Optional[dict[EmbeddingPurpose, str]] = None
+    prefixes: Optional[dict[str, str]] = None
 
     def validate(self) -> None:
         if self.provider not in self.supported_providers:

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -25,6 +25,16 @@ default_embedding_prefixes = {
         EmbeddingPurpose.QUERY: 'search_query: ',
         EmbeddingPurpose.DOCUMENT: 'search_document: ',
     },
+    'mixedbread-ai/mxbai-embed-large-v1': {
+        EmbeddingPurpose.INDEX: '',
+        EmbeddingPurpose.QUERY: 'Represent this sentence for searching relevant passages: ',
+        EmbeddingPurpose.DOCUMENT: 'Represent this sentence for searching relevant passages: ',
+    },
+    'mixedbread-ai/mxbai-embed-large': {
+        EmbeddingPurpose.INDEX: '',
+        EmbeddingPurpose.QUERY: 'Represent this sentence for searching relevant passages: ',
+        EmbeddingPurpose.DOCUMENT: 'Represent this sentence for searching relevant passages: ',
+    },
 }
 
 

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -8,6 +8,12 @@ from .base_provider import Provider, ProviderConfig
 
 logger = logging.getLogger(__name__)
 
+
+class EmbeddingPurpose(StrEnum):
+    INDEX = auto()
+    QUERY = auto()
+    DOCUMENT = auto()
+
 default_embedding_prefixes = {
     'nomic-embed-text-v1.5': {
         EmbeddingPurpose.INDEX: '',
@@ -21,11 +27,6 @@ default_embedding_prefixes = {
     },
 }
 
-
-class EmbeddingPurpose(StrEnum):
-    INDEX = auto()
-    QUERY = auto()
-    DOCUMENT = auto()
 
 class EmbeddingConfig(ProviderConfig):
     """A base embedding configuration class"""

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -8,6 +8,20 @@ from .base_provider import Provider, ProviderConfig
 
 logger = logging.getLogger(__name__)
 
+default_embedding_prefixes = {
+    'nomic-embed-text-v1.5': {
+        EmbeddingPurpose.INDEX: '',
+        EmbeddingPurpose.QUERY: 'search_query: ',
+        EmbeddingPurpose.DOCUMENT: 'search_document: ',
+    },
+    'nomic-embed-text': {
+        EmbeddingPurpose.INDEX: '',
+        EmbeddingPurpose.QUERY: 'search_query: ',
+        EmbeddingPurpose.DOCUMENT: 'search_document: ',
+    },
+}
+
+
 class EmbeddingPurpose(StrEnum):
     INDEX = auto()
     QUERY = auto()

--- a/r2r/base/providers/embedding_provider.py
+++ b/r2r/base/providers/embedding_provider.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from enum import StrEnum, auto
+from enum import Enum, StrEnum, auto
 from typing import Optional, Dict
 
 from ..abstractions.search import VectorSearchResult

--- a/r2r/pipes/retrieval/vector_search_pipe.py
+++ b/r2r/pipes/retrieval/vector_search_pipe.py
@@ -57,6 +57,7 @@ class VectorSearchPipe(SearchPipe):
         results = []
         query_vector = self.embedding_provider.get_embedding(
             message,
+            purpose=EmbeddingPurpose.QUERY,
         )
         search_results = (
             self.vector_db_provider.hybrid_search(

--- a/r2r/pipes/retrieval/vector_search_pipe.py
+++ b/r2r/pipes/retrieval/vector_search_pipe.py
@@ -7,6 +7,7 @@ from r2r.base import (
     AsyncPipe,
     AsyncState,
     EmbeddingProvider,
+    EmbeddingPurpose,
     PipeType,
     VectorDBProvider,
     VectorSearchResult,

--- a/r2r/providers/embeddings/ollama/ollama_base.py
+++ b/r2r/providers/embeddings/ollama/ollama_base.py
@@ -13,11 +13,13 @@ logger = logging.getLogger(__name__)
 
 default_embedding_prefixes = {
     'nomic-embed-text-v1.5': {
-        EmbeddingPurpose.INDEX: 'search_query: ',
+        EmbeddingPurpose.INDEX: '',
+        EmbeddingPurpose.QUERY: 'search_query: ',
         EmbeddingPurpose.DOCUMENT: 'search_document: ',
     },
     'nomic-embed-text': {
-        EmbeddingPurpose.INDEX: 'search_query: ',
+        EmbeddingPurpose.INDEX: '',
+        EmbeddingPurpose.QUERY: 'search_query: ',
         EmbeddingPurpose.DOCUMENT: 'search_document: ',
     },
 }
@@ -55,13 +57,7 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
         self.max_backoff = 60
         self.concurrency_limit = 10
         self.semaphore = asyncio.Semaphore(self.concurrency_limit)
-        set_prefixes(config.prefixes or {}, self.base_model)
-
-    def set_prefixes(self, prefixes: dict[EmbeddingPurpose, str], base_model: str):
-        self.prefixes = {}
-        if base_model and (base_model in default_embedding_prefixes):
-            for t, p in default_embedding_prefixes[base_model].items():
-                self.prefixes[t] = p
+        self.set_prefixes(config.prefixes or {}, self.base_model)
 
     async def process_queue(self):
         while True:

--- a/r2r/providers/embeddings/ollama/ollama_base.py
+++ b/r2r/providers/embeddings/ollama/ollama_base.py
@@ -11,20 +11,6 @@ from r2r.base import EmbeddingConfig, EmbeddingProvider, VectorSearchResult, Emb
 logger = logging.getLogger(__name__)
 
 
-default_embedding_prefixes = {
-    'nomic-embed-text-v1.5': {
-        EmbeddingPurpose.INDEX: '',
-        EmbeddingPurpose.QUERY: 'search_query: ',
-        EmbeddingPurpose.DOCUMENT: 'search_document: ',
-    },
-    'nomic-embed-text': {
-        EmbeddingPurpose.INDEX: '',
-        EmbeddingPurpose.QUERY: 'search_query: ',
-        EmbeddingPurpose.DOCUMENT: 'search_document: ',
-    },
-}
-
-
 class OllamaEmbeddingProvider(EmbeddingProvider):
     def __init__(self, config: EmbeddingConfig):
         super().__init__(config)

--- a/r2r/providers/embeddings/openai/openai_base.py
+++ b/r2r/providers/embeddings/openai/openai_base.py
@@ -73,6 +73,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         self,
         text: str,
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX,
     ) -> list[float]:
         if stage != EmbeddingProvider.PipeStage.BASE:
             raise ValueError(
@@ -101,6 +102,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         self,
         text: str,
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX,
     ) -> list[float]:
         if stage != EmbeddingProvider.PipeStage.BASE:
             raise ValueError(
@@ -126,6 +128,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         self,
         texts: list[str],
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX,
     ) -> list[list[float]]:
         if stage != EmbeddingProvider.PipeStage.BASE:
             raise ValueError(
@@ -153,6 +156,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         self,
         texts: list[str],
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX,
     ) -> list[list[float]]:
         if stage != EmbeddingProvider.PipeStage.BASE:
             raise ValueError(

--- a/r2r/providers/embeddings/openai/openai_base.py
+++ b/r2r/providers/embeddings/openai/openai_base.py
@@ -3,7 +3,7 @@ import os
 
 from openai import AsyncOpenAI, AuthenticationError, OpenAI
 
-from r2r.base import EmbeddingConfig, EmbeddingProvider, VectorSearchResult
+from r2r.base import EmbeddingConfig, EmbeddingProvider, EmbeddingPurpose, VectorSearchResult
 
 logger = logging.getLogger(__name__)
 

--- a/r2r/providers/embeddings/sentence_transformer/sentence_transformer_base.py
+++ b/r2r/providers/embeddings/sentence_transformer/sentence_transformer_base.py
@@ -92,6 +92,7 @@ class SentenceTransformerEmbeddingProvider(EmbeddingProvider):
         self,
         text: str,
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX,
     ) -> list[float]:
         if stage != EmbeddingProvider.PipeStage.BASE:
             raise ValueError("`get_embedding` only supports `SEARCH` stage.")
@@ -106,6 +107,7 @@ class SentenceTransformerEmbeddingProvider(EmbeddingProvider):
         self,
         texts: list[str],
         stage: EmbeddingProvider.PipeStage = EmbeddingProvider.PipeStage.BASE,
+        purpose: EmbeddingPurpose = EmbeddingPurpose.INDEX,
     ) -> list[list[float]]:
         if stage != EmbeddingProvider.PipeStage.BASE:
             raise ValueError("`get_embeddings` only supports `SEARCH` stage.")

--- a/r2r/providers/embeddings/sentence_transformer/sentence_transformer_base.py
+++ b/r2r/providers/embeddings/sentence_transformer/sentence_transformer_base.py
@@ -1,6 +1,6 @@
 import logging
 
-from r2r.base import EmbeddingConfig, EmbeddingProvider, VectorSearchResult
+from r2r.base import EmbeddingConfig, EmbeddingProvider, EmbeddingPurpose, VectorSearchResult
 
 logger = logging.getLogger(__name__)
 

--- a/r2r/providers/embeddings/sentence_transformer/sentence_transformer_base.py
+++ b/r2r/providers/embeddings/sentence_transformer/sentence_transformer_base.py
@@ -44,6 +44,7 @@ class SentenceTransformerEmbeddingProvider(EmbeddingProvider):
         self.rerank_encoder = self._init_model(
             config, EmbeddingProvider.PipeStage.RERANK
         )
+        self.set_prefixes(config.prefixes or {}, self.base_model)
 
     def _init_model(self, config: EmbeddingConfig, stage: str):
         stage_name = stage.name.lower()
@@ -100,6 +101,7 @@ class SentenceTransformerEmbeddingProvider(EmbeddingProvider):
             raise ValueError(
                 "`get_embedding` can only be called for the search stage if a search model is set."
             )
+        text = self.prefixes.get(purpose, '') + text
         encoder = self.search_encoder
         return encoder.encode([text]).tolist()[0]
 
@@ -120,7 +122,7 @@ class SentenceTransformerEmbeddingProvider(EmbeddingProvider):
             if stage == EmbeddingProvider.PipeStage.BASE
             else self.rerank_encoder
         )
-        return encoder.encode(texts).tolist()
+        return encoder.encode([(self.prefixes.get(purpose, '') + text) for text in texts]).tolist()
 
     def rerank(
         self,


### PR DESCRIPTION
Add support for embedding prefixes. There are various models which differentiate embeddings of content and embedding of queries for the content. For example nomic models expect prefix "search_query: " when looking up information.

Here, I'm adding both the dict for the model defaults and the ability to update those details from the config.