### PR TITLE
fix Missing required keys in embedding config in local_ollama config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "r2r"
-version = "0.2.59"
+version = "0.2.60"
 description = "SciPhi R2R"
 authors = ["Owen Colegrove <owen@sciphi.ai>"]
 license = "MIT"

--- a/r2r/examples/configs/local_ollama.json
+++ b/r2r/examples/configs/local_ollama.json
@@ -22,7 +22,12 @@
     "provider": "ollama",
     "base_model": "mxbai-embed-large",
     "base_dimension": 1024,
-    "batch_size": 32
+    "batch_size": 32,
+    "text_splitter": {
+      "type": "recursive_character",
+      "chunk_size": 512,
+      "chunk_overlap": 20
+    }
   },
   "ingestion":{
     "excluded_parsers": [

--- a/r2r/providers/llms/openai/base_openai.py
+++ b/r2r/providers/llms/openai/base_openai.py
@@ -29,7 +29,7 @@ class OpenAILLM(LLMProvider):
                 "The provided config must be an instance of OpenAIConfig."
             )
         try:
-            from openai import OpenAI  # noqa
+            from openai import AsyncOpenAI, OpenAI  # noqa
         except ImportError:
             raise ImportError(
                 "Error, `openai` is required to run an OpenAILLM. Please install it using `pip install openai`."
@@ -44,6 +44,7 @@ class OpenAILLM(LLMProvider):
             )
         super().__init__(config)
         self.config: LLMConfig = config
+        self.async_client = AsyncOpenAI()
         self.client = OpenAI()
 
     def get_completion(
@@ -141,4 +142,4 @@ class OpenAILLM(LLMProvider):
 
         args = {**args, **kwargs}
         # Create the chat completion
-        return await self.client.chat.completions.create(**args)
+        return await self.async_client.chat.completions.create(**args)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c75435707fc4659a65bd94290075196dd43cc0aa  | 
|--------|--------|

### Summary:
Added missing `text_splitter` configuration to the embedding section in `r2r/examples/configs/local_ollama.json`.

**Key points**:
- Updated `r2r/examples/configs/local_ollama.json` to include missing required keys in the embedding configuration.
- Added `text_splitter` object with `type`, `chunk_size`, and `chunk_overlap` properties to the `embedding` section.
- Ensures proper configuration for text splitting in embeddings.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->