### PR TITLE
Add ollama to docker compose

### DIFF
--- a/compose.neo4j.yaml
+++ b/compose.neo4j.yaml
@@ -1,8 +1,7 @@
-
 networks:
   r2r-network:
     name: r2r-network
-    
+
 services:
   r2r:
     depends_on:

--- a/compose.ollama.yaml
+++ b/compose.ollama.yaml
@@ -1,0 +1,28 @@
+networks:
+  r2r-network:
+    name: r2r-network
+
+services:
+  r2r:
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+    volumes:
+      - ollama_data:/root/.ollama
+    networks:
+      - r2r-network
+    healthcheck:
+      test: ["CMD", "ollama", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  ollama_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,8 @@
 x-depends-on:
   neo4j: &neo4j-dependency
     condition: service_healthy
+  ollama: &ollama-dependency
+    condition: service_healthy
 
 networks:
   r2r-network:
@@ -13,7 +15,7 @@ networks:
         - subnet: 172.28.0.0/16
     labels:
       - "com.docker.compose.recreate=always"
-      
+
 
 services:
   r2r:

--- a/r2r/cli/cli.py
+++ b/r2r/cli/cli.py
@@ -72,9 +72,16 @@ def cli(ctx, config_path, config_name, client_mode, base_url):
     is_flag=True,
     help="Run using Docker with external Neo4j",
 )
+@click.option(
+    "--docker-ext-ollama",
+    is_flag=True,
+    help="Run using Docker with external Ollama",
+)
 @click.option("--project-name", default="r2r", help="Project name for Docker")
 @click.pass_obj
-def serve(obj, host, port, docker, docker_ext_neo4j, project_name):
+def serve(
+    obj, host, port, docker, docker_ext_neo4j, docker_ext_ollama, project_name
+):
     """Start the R2R server."""
     # Load environment variables from .env file if it exists
     load_dotenv()
@@ -94,9 +101,12 @@ def serve(obj, host, port, docker, docker_ext_neo4j, project_name):
         )
         compose_yaml = os.path.join(package_dir, "compose.yaml")
         compose_neo4j_yaml = os.path.join(package_dir, "compose.neo4j.yaml")
+        compose_ollama_yaml = os.path.join(package_dir, "compose.ollama.yaml")
 
-        if not os.path.exists(compose_yaml) or not os.path.exists(
-            compose_neo4j_yaml
+        if (
+            not os.path.exists(compose_yaml)
+            or not os.path.exists(compose_neo4j_yaml)
+            or not os.path.exists(compose_ollama_yaml)
         ):
             click.echo(
                 "Error: Docker Compose files not found in the package directory."
@@ -107,6 +117,8 @@ def serve(obj, host, port, docker, docker_ext_neo4j, project_name):
         docker_command = f"docker-compose -f {compose_yaml}"
         if docker_ext_neo4j:
             docker_command += f" -f {compose_neo4j_yaml}"
+        if docker_ext_ollama:
+            docker_command += f" -f {compose_ollama_yaml}"
         if host != "0.0.0.0" or port != 8000:
             docker_command += (
                 f" --build-arg HOST={host} --build-arg PORT={port}"


### PR DESCRIPTION
To install a new model, a user would run:
`docker exec -it r2r-ollama-1 ollama pull llama3`



<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8ad0f26e00537f53211d663d9a7a60eb1d3f3dd0  | 
|--------|--------|

### Summary:
Added support for running the Ollama service in Docker Compose and updated the CLI to handle the new service.

**Key points**:
- Added `compose.ollama.yaml` to define the Ollama service in Docker Compose.
- Updated `compose.yaml` to include Ollama service dependency.
- Modified `r2r/cli/cli.py` to add `--docker-ext-ollama` option for running with external Ollama service.
- Updated `serve` function in `r2r/cli/cli.py` to include `compose.ollama.yaml` in Docker Compose command if `--docker-ext-ollama` is specified.
- Ensured Docker Compose files are checked for existence before running Docker commands.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->