### PR TITLE
Fix compose env list

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -79,9 +79,9 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      POSTGRES_DB: ${POSTGRES_DBNAME:-postgres}
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_DB=${POSTGRES_DBNAME:-postgres}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
Hey guys!
Quick fix for an issue I encountered: The listing of env variables in the postgres container had a weird issue for me. The env variables were all properly set in the container when e.g. using a shell in it, however, neither the R2R service nor psql from within the postgres container could connect to the server.
This should fix it. I'm not sure if raising the PR to dev is the way to go as CONTRIBUTING.md is pretty sparse on that. But the changes are so simple, you can just do what you want with them.
Cheers :)
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d0963a8138c1fa768ef5bee4762601c2919655c6  | 
|--------|--------|

### Summary:
Fixes environment variable syntax in `compose.yaml` for `postgres` service to ensure proper connection handling.

**Key points**:
- **File Modified**: `compose.yaml`
- **Change**: Updated environment variable syntax for `postgres` service.
- **Old Syntax**: `POSTGRES_USER: ${POSTGRES_USER:-postgres}`
- **New Syntax**: `- POSTGRES_USER=${POSTGRES_USER:-postgres}`
- **Issue Fixed**: Ensures `R2R` service and `psql` can connect to the `postgres` server.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->