### PR TITLE
Fix runtime warning about version reading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # Copy the application and config
 COPY r2r /app/r2r
 COPY r2r.json /app/r2r.json
+COPY pyproject.toml /app/pyproject.toml
 
 # Expose the port
 EXPOSE 8000


### PR DESCRIPTION
log in docker deploy:

```
2024-07-27 16:22:22,548 - WARNING - r2r.main.r2r - Failed to read version from pyproject.toml: [Errno 2] No such file or directory: '/app/pyproject.toml'
```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2da73250514aabe4edc1ccf9112ac6ec2d52f5cb  | 
|--------|--------|

### Summary:
Added `COPY pyproject.toml /app/pyproject.toml` to `Dockerfile` to fix runtime warning about missing `pyproject.toml`.

**Key points**:
- Added `COPY pyproject.toml /app/pyproject.toml` to `Dockerfile`.
- Fixes runtime warning about missing `pyproject.toml` during Docker deployment.
- Ensures version reading from `pyproject.toml` works correctly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->