### PR TITLE
Fix: resolve unreachable host.docker.internal when Ollama is on host …

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -43,6 +43,8 @@ services:
       - postgres
     networks:
       - r2r-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
       interval: 10s


### PR DESCRIPTION
```bash
$ r2r --config-name=local_neo4j_kg serve --docker --docker-ext-neo4j
```

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 22da2469a01877c26913227770665fcb6f8abc63  | 
|--------|--------|

### Summary:
Added `extra_hosts` entry in `compose.yaml` to resolve `host.docker.internal` for `r2r` service.

**Key points**:
- Updated `compose.yaml` to add `extra_hosts` entry for `r2r` service.
- Resolves `host.docker.internal` to `host-gateway`.
- Ensures `OLLAMA_API_BASE` can reference host services correctly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->