### PR TITLE
PDFParser filter out Multilingual unicode chars

### DIFF
--- a/r2r/pipes/ingestion/kg_storage_pipe.py
+++ b/r2r/pipes/ingestion/kg_storage_pipe.py
@@ -65,7 +65,7 @@ class KGStoragePipe(AsyncPipe):
                     embedding = None
                     if self.embedding_provider:
                         embedding = self.embedding_provider.get_embedding(
-                            "Entity:\n{entity.value}\nLabel:\n{entity.category}\nSubcategory:\n{entity.subcategory}"
+                            f"Entity:\n{entity.value}\nLabel:\n{entity.category}\nSubcategory:\n{entity.subcategory}"
                         )
                     nodes.append(
                         EntityNode(


### PR DESCRIPTION
PDFParser filter out Multilingual unicode chars together with non-printable characters.  Fix code to support multilingual like Chinese and Arabic etc.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 32d6ffc225460b6dc00396849680baea12e7b449  | 
|--------|--------|

### Summary:
Updated `r2r/parsers/media/pdf_parser.py` to filter out non-printable characters while retaining multilingual Unicode characters and improved error handling for missing imports in `PDFParserUnstructured`.

**Key points**:
- Updated `r2r/parsers/media/pdf_parser.py` to filter out non-printable characters while retaining multilingual Unicode characters.
- Modified `PDFParser.ingest` to include Unicode categories and specific ranges for Chinese, Arabic, Cyrillic, Greek, Thai, Japanese Hiragana, and Katakana characters.
- Improved error handling in `PDFParserUnstructured.__init__` to provide installation instructions for missing modules.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->