### PR TITLE
Patch/fix backoff for stream chat

### DIFF
--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -1,7 +1,56 @@
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from r2r import GenerationConfig, LLMConfig
-from r2r.providers import LiteLLMProvider
+from r2r.base.abstractions.llm import LLMChatCompletion, LLMChatCompletionChunk
+from r2r.providers import LiteLLMProvider, OpenAILLMProvider
+
+
+class MockCompletionResponse:
+    def __init__(self, content):
+        self.id = "mock_id"
+        self.created = int(time.time())
+        self.model = "gpt-3.5-turbo"
+        self.object = "chat.completion"
+        self.choices = [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ]
+
+    def dict(self):
+        return {
+            "id": self.id,
+            "created": self.created,
+            "model": self.model,
+            "object": self.object,
+            "choices": self.choices,
+        }
+
+
+class MockStreamResponse:
+    def __init__(self, content):
+        self.id = "mock_id"
+        self.created = int(time.time())
+        self.model = "gpt-3.5-turbo"
+        self.object = "chat.completion.chunk"
+        self.choices = [
+            {"index": 0, "delta": {"content": content}, "finish_reason": None}
+        ]
+
+    def dict(self):
+        return {
+            "id": self.id,
+            "created": self.created,
+            "model": self.model,
+            "object": self.object,
+            "choices": self.choices,
+        }
 
 
 @pytest.fixture
@@ -10,41 +59,25 @@ def lite_llm():
     return LiteLLMProvider(config)
 
 
-# @pytest.mark.parametrize("llm_fixture", ["lite_llm"])
-# def test_get_completion_ollama(request, llm_fixture):
-#     llm = request.getfixturevalue(llm_fixture)
-
-#     messages = [
-#         {
-#             "role": "user",
-#             "content": "This is a test, return only the word `True`",
-#         }
-#     ]
-#     generation_config = GenerationConfig(
-#         model="ollama/llama2",
-#         temperature=0.0,
-#         top_p=0.9,
-#         max_tokens_to_sample=50,
-#         stream=False,
-#     )
-
-#     completion = llm.get_completion(messages, generation_config)
-#     # assert isinstance(completion, LLMChatCompletion)
-#     assert completion.choices[0].message.role == "assistant"
-#     assert completion.choices[0].message.content.strip() == "True"
+@pytest.fixture
+def openai_llm():
+    config = LLMConfig(provider="openai")
+    return OpenAILLMProvider(config)
 
 
-@pytest.mark.parametrize("llm_fixture", ["lite_llm"])
-def test_get_completion_openai(request, llm_fixture):
-    llm = request.getfixturevalue(llm_fixture)
-
-    messages = [
+@pytest.fixture
+def messages():
+    return [
         {
             "role": "user",
             "content": "This is a test, return only the word `True`",
         }
     ]
-    generation_config = GenerationConfig(
+
+
+@pytest.fixture
+def generation_config():
+    return GenerationConfig(
         model="gpt-3.5-turbo",
         temperature=0.0,
         top_p=0.9,
@@ -52,7 +85,94 @@ def test_get_completion_openai(request, llm_fixture):
         stream=False,
     )
 
-    completion = llm.get_completion(messages, generation_config)
-    # assert isinstance(completion, LLMChatCompletion)
-    assert completion.choices[0].message.role == "assistant"
-    assert completion.choices[0].message.content.strip() == "True"
+
+@pytest.mark.parametrize("llm_fixture", ["lite_llm", "openai_llm"])
+def test_get_completion(request, llm_fixture, messages, generation_config):
+    llm = request.getfixturevalue(llm_fixture)
+
+    with patch.object(
+        llm, "_execute_task_sync", return_value=MockCompletionResponse("True")
+    ):
+        completion = llm.get_completion(messages, generation_config)
+        assert isinstance(completion, LLMChatCompletion)
+        assert completion.choices[0].message.role == "assistant"
+        assert completion.choices[0].message.content.strip() == "True"
+        assert completion.id == "mock_id"
+        assert completion.model == "gpt-3.5-turbo"
+        assert completion.object == "chat.completion"
+
+
+@pytest.mark.parametrize("llm_fixture", ["lite_llm", "openai_llm"])
+def test_get_completion_stream(
+    request, llm_fixture, messages, generation_config
+):
+    llm = request.getfixturevalue(llm_fixture)
+    generation_config.stream = True
+
+    mock_responses = [
+        MockStreamResponse("T"),
+        MockStreamResponse("ru"),
+        MockStreamResponse("e"),
+    ]
+    with patch.object(llm, "_execute_task_sync", return_value=mock_responses):
+        stream = llm.get_completion_stream(messages, generation_config)
+        chunks = list(stream)
+        assert all(
+            isinstance(chunk, LLMChatCompletionChunk) for chunk in chunks
+        )
+        assert len(chunks) == 3
+        assert (
+            "".join(chunk.choices[0].delta.content for chunk in chunks)
+            == "True"
+        )
+        assert all(chunk.object == "chat.completion.chunk" for chunk in chunks)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("llm_fixture", ["lite_llm", "openai_llm"])
+async def test_aget_completion(
+    request, llm_fixture, messages, generation_config
+):
+    llm = request.getfixturevalue(llm_fixture)
+
+    with patch.object(
+        llm,
+        "_execute_task",
+        AsyncMock(return_value=MockCompletionResponse("True")),
+    ):
+        completion = await llm.aget_completion(messages, generation_config)
+        assert isinstance(completion, LLMChatCompletion)
+        assert completion.choices[0].message.role == "assistant"
+        assert completion.choices[0].message.content.strip() == "True"
+        assert completion.id == "mock_id"
+        assert completion.model == "gpt-3.5-turbo"
+        assert completion.object == "chat.completion"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("llm_fixture", ["lite_llm", "openai_llm"])
+async def test_aget_completion_stream(
+    request, llm_fixture, messages, generation_config
+):
+    llm = request.getfixturevalue(llm_fixture)
+    generation_config.stream = True
+
+    async def mock_stream():
+        yield MockStreamResponse("T")
+        yield MockStreamResponse("ru")
+        yield MockStreamResponse("e")
+
+    with patch.object(
+        llm, "_execute_task", AsyncMock(return_value=mock_stream())
+    ):
+        stream = llm.aget_completion_stream(messages, generation_config)
+        chunks = [chunk async for chunk in stream]
+        assert all(
+            isinstance(chunk, LLMChatCompletionChunk) for chunk in chunks
+        )
+        assert len(chunks) == 3
+        assert (
+            "".join(chunk.choices[0].delta.content for chunk in chunks)
+            == "True"
+        )
+        assert all(chunk.object == "chat.completion.chunk" for chunk in chunks)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 895e8b1a5b44f2121db0fa3564d756b0df0e6627  | 
|--------|--------|

### Summary:
Introduced backoff mechanisms for LLM providers, refactored CLI commands, and added comprehensive tests.

**Key points**:
- Added backoff mechanisms for sync and async tasks in `r2r/base/providers/llm.py`.
- Refactored CLI commands into separate modules under `r2r/cli/commands/`.
- Introduced `r2r/cli/command_group.py` for CLI group definition.
- Updated `r2r/cli/cli.py` to use new command modules.
- Added `r2r/cli/utils/timer.py` for timing CLI commands.
- Added `r2r/cli/utils/param_types.py` for custom Click parameter types.
- Added `r2r/cli/utils/docker_utils.py` for Docker-related utilities.
- Updated `r2r/main/app_entry.py` to use `CONFIG_PATH` from environment variables.
- Refactored `LiteLLMProvider` and `OpenAILLMProvider` to use new backoff mechanisms.
- Added comprehensive tests for LLM providers in `tests/test_llms.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->