### PR TITLE
fix linux environment error "aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host host.docker.internal:11434 ssl:default [Name or service not known]"

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -65,6 +65,8 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
 
+
+
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -62,6 +62,8 @@ services:
       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Methods=GET,POST,OPTIONS"
       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Headers=DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
       - "traefik.http.middlewares.r2r-headers.headers.customresponseheaders.Access-Control-Expose-Headers=Content-Length,Content-Range"
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest


### PR DESCRIPTION
 linux environment: centos
Execute the following command and report an error：

`r2r --config-name=local_neo4j_kg serve --docker --docker-ext-neo4j 
ollama pull sciphi/triplex
ollama pull llama3.1
ollama pull mxbai-embed-large
ollama serve
echo "John is a person that works at Google.\n\nPaul is a person that works at Microsoft that collaborates with John." \
>> test.txt
r2r ingest-files test.txt
`
The error message is as follows：
`
Max retries reached. Last error: litellm.APIConnectionError: Cannot connect to host host.docker.internal:11434 ssl:default [Name or service not known]
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/aiohttp/connector.py", line 1203, in _create_direct_connection
    hosts = await self._resolve_host(host, port, traces=traces)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/connector.py", line 880, in _resolve_host
    return await asyncio.shield(resolved_host_task)
  File "/usr/local/lib/python3.10/asyncio/futures.py", line 285, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 304, in __wakeup
    future.result()
  File "/usr/local/lib/python3.10/asyncio/futures.py", line 201, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 234, in __step
    result = coro.throw(exc)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/connector.py", line 917, in _resolve_host_with_throttle
    addrs = await self._resolver.resolve(host, port, family=self._family)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/resolver.py", line 33, in resolve
    infos = await self._loop.getaddrinfo(
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 863, in getaddrinfo
    return await self.run_in_executor(
  File "/usr/local/lib/python3.10/asyncio/futures.py", line 285, in __await__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 304, in __wakeup
    future.result()
  File "/usr/local/lib/python3.10/asyncio/futures.py", line 201, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.10/socket.py", line 955, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/litellm/main.py", line 395, in acompletion
    response = await init_response
  File "/usr/local/lib/python3.10/site-packages/litellm/llms/ollama.py", line 507, in ollama_acompletion
    raise e
  File "/usr/local/lib/python3.10/site-packages/litellm/llms/ollama.py", line 442, in ollama_acompletion
    resp = await session.post(url, json=data)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/client.py", line 581, in _request
    conn = await self._connector.connect(
  File "/usr/local/lib/python3.10/site-packages/aiohttp/connector.py", line 544, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/connector.py", line 944, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
  File "/usr/local/lib/python3.10/site-packages/aiohttp/connector.py", line 1209, in _create_direct_connection
    raise ClientConnectorError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host host.docker.internal:11434 ssl:default [Name or service not known]
`

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit dd65c7115848fc4aa8e6bf013c66f2d07248db96  | 
|--------|--------|

### Summary:
Fixed connection error in Linux environment by adding `extra_hosts` entry in `compose.yaml` to map `host.docker.internal` to `host-gateway`.

**Key points**:
- **Issue**: Connection error in Linux environment (`centos`) when running specific commands.
- **Error**: `aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host host.docker.internal:11434 ssl:default [Name or service not known]`.
- **Fix**: Added `extra_hosts` entry in `compose.yaml` to map `host.docker.internal` to `host-gateway`.
- **File Modified**: `compose.yaml`.
- **Specific Change**: Added `extra_hosts` section under `r2r` service in `compose.yaml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->