### PR TITLE
Fix entity_types type

### DIFF
--- a/r2r/main/api/routes/retrieval/base.py
+++ b/r2r/main/api/routes/retrieval/base.py
@@ -29,12 +29,19 @@ class RetrievalRouter(BaseRouter):
                 else None
             ),
         ):
-            if "kg_search_generation_config" in request.kg_search_settings:
-                request.kg_search_settings["kg_search_generation_config"] = (
+            kg_search_settings = request.kg_search_settings or {}
+
+            if "entity_types" not in kg_search_settings:
+                kg_search_settings["entity_types"] = []
+            elif not isinstance(kg_search_settings["entity_types"], list):
+                kg_search_settings["entity_types"] = [
+                    kg_search_settings["entity_types"]
+                ]
+
+            if "kg_search_generation_config" in kg_search_settings:
+                kg_search_settings["kg_search_generation_config"] = (
                     GenerationConfig(
-                        **request.kg_search_settings[
-                            "kg_search_generation_config"
-                        ]
+                        **kg_search_settings["kg_search_generation_config"]
                         or {}
                     )
                 )
@@ -44,9 +51,7 @@ class RetrievalRouter(BaseRouter):
                 vector_search_settings=VectorSearchSettings(
                     **(request.vector_search_settings or {})
                 ),
-                kg_search_settings=KGSearchSettings(
-                    **(request.kg_search_settings or {})
-                ),
+                kg_search_settings=KGSearchSettings(**kg_search_settings),
                 user=auth_user,
             )
             return results


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 202178f9583f6cb646a96f508147b6cfadeaa2b2  | 
|--------|--------|

### Summary:
Fixes type issue with `entity_types` in `kg_search_settings` in `r2r/main/api/routes/retrieval/base.py` by ensuring it is always a list.

**Key points**:
- Fixes type issue with `entity_types` in `kg_search_settings` in `r2r/main/api/routes/retrieval/base.py`.
- Ensures `entity_types` is always a list.
- Handles cases where `entity_types` is not provided or is a single value.
- Updates `search_app` function to check and convert `entity_types` to a list if necessary.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->