### PR TITLE
Add exclusion for Postgres to Docker

### DIFF
--- a/compose.postgres.yaml
+++ b/compose.postgres.yaml
@@ -1,0 +1,29 @@
+networks:
+  r2r-network:
+    name: r2r-network
+
+services:
+  r2r:
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_DB=${POSTGRES_DBNAME:-postgres}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - r2r-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: on-failure
+
+volumes:
+  postgres_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -114,3 +114,102 @@ services:
 
 volumes:
   postgres_data:
+
+
+
+# x-depends-on:
+#   neo4j: &neo4j-dependency
+#     condition: service_healthy
+#   ollama: &ollama-dependency
+#     condition: service_healthy
+#   postgres: &postgres-dependency
+#     condition: service_healthy
+
+# networks:
+#   r2r-network:
+#     name: r2r-network
+#     driver: bridge
+#     attachable: true
+#     ipam:
+#       driver: default
+#       config:
+#         - subnet: 172.28.0.0/16
+#     labels:
+#       - "com.docker.compose.recreate=always"
+
+
+# services:
+#   r2r:
+#     image: ${R2R_IMAGE:-emrgntcmplxty/r2r:main}
+#     ports:
+#       - "8000:8000"
+#     environment:
+#       - PYTHONUNBUFFERED=1
+#       - POSTGRES_USER=${POSTGRES_USER:-postgres}
+#       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+#       - POSTGRES_HOST=postgres
+#       - POSTGRES_PORT=5432
+#       - POSTGRES_DBNAME=${POSTGRES_DBNAME:-postgres}
+#       - POSTGRES_VECS_COLLECTION=${POSTGRES_VECS_COLLECTION:-${CONFIG_NAME:-vecs}}
+#       - NEO4J_USER=${NEO4J_USER:-neo4j}
+#       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-ineedastrongerpassword}
+#       - NEO4J_URL=${NEO4J_URL:-bolt://neo4j:7687}
+#       - NEO4J_DATABASE=${NEO4J_DATABASE:-neo4j}
+#       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+#       - OLLAMA_API_BASE=${OLLAMA_API_BASE:-http://host.docker.internal:11434}
+#       - CONFIG_NAME=${CONFIG_NAME:-}
+#       - CONFIG_PATH=${CONFIG_PATH:-}
+#       - CLIENT_MODE=${CLIENT_MODE:-false}
+#     networks:
+#       - r2r-network
+#     healthcheck:
+#       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
+#       interval: 10s
+#       timeout: 5s
+#       retries: 5
+#     restart: on-failure
+#     volumes:
+#       - ${CONFIG_PATH:-/}:${CONFIG_PATH:-/app/config}
+#     labels:
+#       - "traefik.enable=true"
+#       - "traefik.http.routers.r2r.rule=PathPrefix(`/api`)"
+#       - "traefik.http.services.r2r.loadbalancer.server.port=8000"
+#       - "traefik.http.middlewares.r2r-strip-prefix.stripprefix.prefixes=/api"
+#       - "traefik.http.middlewares.r2r-add-v1.addprefix.prefix=/v1"
+#       - "traefik.http.routers.r2r.middlewares=r2r-strip-prefix,r2r-add-v1,r2r-headers"
+#       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Origin=*"
+#       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Methods=GET,POST,OPTIONS"
+#       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Headers=DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
+#       - "traefik.http.middlewares.r2r-headers.headers.customresponseheaders.Access-Control-Expose-Headers=Content-Length,Content-Range"
+#     extra_hosts:
+#       - host.docker.internal:host-gateway
+
+#   r2r-dashboard:
+#     image: emrgntcmplxty/r2r-dashboard:latest
+#     environment:
+#       - NEXT_PUBLIC_API_URL=http://traefik:80/api
+#     depends_on:
+#       - r2r
+#     networks:
+#       - r2r-network
+#     labels:
+#       - "traefik.enable=true"
+#       - "traefik.http.routers.dashboard.rule=PathPrefix(`/`)"
+#       - "traefik.http.services.dashboard.loadbalancer.server.port=3000"
+
+#   traefik:
+#     image: traefik:v2.9
+#     command:
+#       - "--api.insecure=true"
+#       - "--providers.docker=true"
+#       - "--providers.docker.exposedbydefault=false"
+#       - "--entrypoints.web.address=:80"
+#       - "--accesslog=true"
+#       - "--accesslog.filepath=/var/log/traefik/access.log"
+#     ports:
+#       - "80:80"
+#       - "8080:8080"  # Traefik dashboard
+#     volumes:
+#       - /var/run/docker.sock:/var/run/docker.sock:ro
+#     networks:
+#       - r2r-network

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,8 @@ x-depends-on:
     condition: service_healthy
   ollama: &ollama-dependency
     condition: service_healthy
+  postgres: &postgres-dependency
+    condition: service_healthy
 
 networks:
   r2r-network:
@@ -39,8 +41,6 @@ services:
       - CONFIG_NAME=${CONFIG_NAME:-}
       - CONFIG_PATH=${CONFIG_PATH:-}
       - CLIENT_MODE=${CLIENT_MODE:-false}
-    depends_on:
-      - postgres
     networks:
       - r2r-network
     healthcheck:
@@ -78,23 +78,6 @@ services:
       - "traefik.http.routers.dashboard.rule=PathPrefix(`/`)"
       - "traefik.http.services.dashboard.loadbalancer.server.port=3000"
 
-  postgres:
-    image: pgvector/pgvector:pg16
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - POSTGRES_DB=${POSTGRES_DBNAME:-postgres}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    networks:
-      - r2r-network
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    restart: on-failure
-
   traefik:
     image: traefik:v2.9
     command:
@@ -111,105 +94,3 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - r2r-network
-
-volumes:
-  postgres_data:
-
-
-
-# x-depends-on:
-#   neo4j: &neo4j-dependency
-#     condition: service_healthy
-#   ollama: &ollama-dependency
-#     condition: service_healthy
-#   postgres: &postgres-dependency
-#     condition: service_healthy
-
-# networks:
-#   r2r-network:
-#     name: r2r-network
-#     driver: bridge
-#     attachable: true
-#     ipam:
-#       driver: default
-#       config:
-#         - subnet: 172.28.0.0/16
-#     labels:
-#       - "com.docker.compose.recreate=always"
-
-
-# services:
-#   r2r:
-#     image: ${R2R_IMAGE:-emrgntcmplxty/r2r:main}
-#     ports:
-#       - "8000:8000"
-#     environment:
-#       - PYTHONUNBUFFERED=1
-#       - POSTGRES_USER=${POSTGRES_USER:-postgres}
-#       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-#       - POSTGRES_HOST=postgres
-#       - POSTGRES_PORT=5432
-#       - POSTGRES_DBNAME=${POSTGRES_DBNAME:-postgres}
-#       - POSTGRES_VECS_COLLECTION=${POSTGRES_VECS_COLLECTION:-${CONFIG_NAME:-vecs}}
-#       - NEO4J_USER=${NEO4J_USER:-neo4j}
-#       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-ineedastrongerpassword}
-#       - NEO4J_URL=${NEO4J_URL:-bolt://neo4j:7687}
-#       - NEO4J_DATABASE=${NEO4J_DATABASE:-neo4j}
-#       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-#       - OLLAMA_API_BASE=${OLLAMA_API_BASE:-http://host.docker.internal:11434}
-#       - CONFIG_NAME=${CONFIG_NAME:-}
-#       - CONFIG_PATH=${CONFIG_PATH:-}
-#       - CLIENT_MODE=${CLIENT_MODE:-false}
-#     networks:
-#       - r2r-network
-#     healthcheck:
-#       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
-#       interval: 10s
-#       timeout: 5s
-#       retries: 5
-#     restart: on-failure
-#     volumes:
-#       - ${CONFIG_PATH:-/}:${CONFIG_PATH:-/app/config}
-#     labels:
-#       - "traefik.enable=true"
-#       - "traefik.http.routers.r2r.rule=PathPrefix(`/api`)"
-#       - "traefik.http.services.r2r.loadbalancer.server.port=8000"
-#       - "traefik.http.middlewares.r2r-strip-prefix.stripprefix.prefixes=/api"
-#       - "traefik.http.middlewares.r2r-add-v1.addprefix.prefix=/v1"
-#       - "traefik.http.routers.r2r.middlewares=r2r-strip-prefix,r2r-add-v1,r2r-headers"
-#       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Origin=*"
-#       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Methods=GET,POST,OPTIONS"
-#       - "traefik.http.middlewares.r2r-headers.headers.customrequestheaders.Access-Control-Allow-Headers=DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization"
-#       - "traefik.http.middlewares.r2r-headers.headers.customresponseheaders.Access-Control-Expose-Headers=Content-Length,Content-Range"
-#     extra_hosts:
-#       - host.docker.internal:host-gateway
-
-#   r2r-dashboard:
-#     image: emrgntcmplxty/r2r-dashboard:latest
-#     environment:
-#       - NEXT_PUBLIC_API_URL=http://traefik:80/api
-#     depends_on:
-#       - r2r
-#     networks:
-#       - r2r-network
-#     labels:
-#       - "traefik.enable=true"
-#       - "traefik.http.routers.dashboard.rule=PathPrefix(`/`)"
-#       - "traefik.http.services.dashboard.loadbalancer.server.port=3000"
-
-#   traefik:
-#     image: traefik:v2.9
-#     command:
-#       - "--api.insecure=true"
-#       - "--providers.docker=true"
-#       - "--providers.docker.exposedbydefault=false"
-#       - "--entrypoints.web.address=:80"
-#       - "--accesslog=true"
-#       - "--accesslog.filepath=/var/log/traefik/access.log"
-#     ports:
-#       - "80:80"
-#       - "8080:8080"  # Traefik dashboard
-#     volumes:
-#       - /var/run/docker.sock:/var/run/docker.sock:ro
-#     networks:
-#       - r2r-network

--- a/r2r/cli/commands/server_operations.py
+++ b/r2r/cli/commands/server_operations.py
@@ -133,6 +133,11 @@ def health(obj):
 @click.option(
     "--exclude-ollama", is_flag=True, help="Exclude Ollama from Docker setup"
 )
+@click.option(
+    "--exclude-postgres",
+    is_flag=True,
+    help="Exclude Postgres from Docker setup",
+)
 @click.option("--project-name", default="r2r", help="Project name for Docker")
 @click.option(
     "--config-path",
@@ -148,6 +153,7 @@ def serve(
     docker,
     exclude_neo4j,
     exclude_ollama,
+    exclude_postgres,
     project_name,
     config_path,
     image,
@@ -173,6 +179,7 @@ def serve(
             port,
             exclude_neo4j,
             exclude_ollama,
+            exclude_postgres,
             project_name,
             config_path,
             image,

--- a/r2r/cli/utils/docker_utils.py
+++ b/r2r/cli/utils/docker_utils.py
@@ -12,7 +12,7 @@ from requests.exceptions import RequestException
 
 def bring_down_docker_compose(project_name, volumes, remove_orphans):
     compose_files = get_compose_files()
-    docker_command = f"docker compose -f {compose_files['base']} -f {compose_files['neo4j']} -f {compose_files['ollama']}"
+    docker_command = f"docker compose -f {compose_files['base']} -f {compose_files['neo4j']} -f {compose_files['ollama']} -f {compose_files['postgres']}"
     docker_command += f" --project-name {project_name}"
 
     if volumes:
@@ -74,11 +74,12 @@ def run_docker_serve(
     port,
     exclude_neo4j,
     exclude_ollama,
+    exclude_postgres,
     project_name,
     config_path,
     image,
 ):
-    unset_env_vars()
+    unset_env_vars(exclude_postgres)
     set_config_env_vars(obj)
     set_ollama_api_base(exclude_ollama)
 
@@ -100,6 +101,7 @@ def run_docker_serve(
         port,
         exclude_neo4j,
         exclude_ollama,
+        exclude_postgres,
         project_name,
         config_path,
         image,
@@ -130,26 +132,32 @@ def check_external_ollama():
         )
 
 
-def unset_env_vars():
+def unset_env_vars(exclude_postgres=False):
     env_vars = [
         "NEO4J_USER",
         "NEO4J_PASSWORD",
         "NEO4J_URL",
         "NEO4J_DATABASE",
         "OLLAMA_API_BASE",
-        "POSTGRES_HOST",
-        "POSTGRES_USER",
-        "POSTGRES_PASSWORD",
-        "POSTGRES_PORT",
-        "POSTGRES_DBNAME",
-        "POSTGRES_VECS_COLLECTION",
     ]
+
+    if not exclude_postgres:
+        postgres_vars = [
+            "POSTGRES_HOST",
+            "POSTGRES_USER",
+            "POSTGRES_PASSWORD",
+            "POSTGRES_PORT",
+            "POSTGRES_DBNAME",
+            "POSTGRES_VECS_COLLECTION",
+        ]
+        env_vars.extend(postgres_vars)
 
     for var in env_vars:
         if value := os.environ.get(var):
             warning_text = click.style("Warning:", fg="red", bold=True)
             prompt = (
                 f"{warning_text} It's only necessary to set this environment variable when connecting to an instance not managed by R2R.\n"
+                f"Add the flag --exclude-postgres to avoid deploying a Postgres instance with R2R.\n"
                 f"Environment variable {var} is set to '{value}'. Unset it?"
             )
             if click.confirm(prompt, default=True):
@@ -182,6 +190,7 @@ def get_compose_files():
         "base": os.path.join(package_dir, "compose.yaml"),
         "neo4j": os.path.join(package_dir, "compose.neo4j.yaml"),
         "ollama": os.path.join(package_dir, "compose.ollama.yaml"),
+        "postgres": os.path.join(package_dir, "compose.postgres.yaml"),
     }
 
     for name, path in compose_files.items():
@@ -200,6 +209,7 @@ def build_docker_command(
     port,
     exclude_neo4j,
     exclude_ollama,
+    exclude_postgres,
     project_name,
     config_path,
     image,
@@ -209,6 +219,8 @@ def build_docker_command(
         command += f" -f {compose_files['neo4j']}"
     if not exclude_ollama:
         command += f" -f {compose_files['ollama']}"
+    if not exclude_postgres:
+        command += f" -f {compose_files['postgres']}"
 
     command += f" --project-name {project_name}"
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d482593d7fb257bb9c7865d87216e64febc6d102  | 
|--------|--------|

### Summary:
Add support for excluding Postgres from Docker setup with new CLI option and updated Docker Compose configurations.

**Key points**:
- Added `compose.postgres.yaml` for Postgres Docker service configuration.
- Updated `compose.yaml` to include Postgres service and its dependencies.
- Modified `r2r/cli/commands/server_operations.py` to add `--exclude-postgres` option in `serve` command.
- Updated `r2r/cli/utils/docker_utils.py` to handle `exclude_postgres` flag in Docker commands and environment variable management.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->