### PR TITLE
Support external LiteLLM proxy

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -37,6 +37,7 @@ services:
       - NEO4J_URL=${NEO4J_URL:-bolt://neo4j:7687}
       - NEO4J_DATABASE=${NEO4J_DATABASE:-neo4j}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
       - OLLAMA_API_BASE=${OLLAMA_API_BASE:-http://host.docker.internal:11434}
       - CONFIG_NAME=${CONFIG_NAME:-}
       - CONFIG_PATH=${CONFIG_PATH:-}


### PR DESCRIPTION
Enable the Docker (r2r service) to accept the OPENAI_BASE_URL variable from the environment.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bf90b4c1856ec1d75cb0577b5048e06935b922f4  | 
|--------|--------|

### Summary:
Added support for `OPENAI_BASE_URL` environment variable in `compose.yaml` to configure an external LiteLLM proxy.

**Key points**:
- Added `OPENAI_BASE_URL` environment variable to `services/r2r` in `compose.yaml`
- Allows setting a custom base URL for OpenAI API requests
- Supports external LiteLLM proxy configuration


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->