### PR TITLE
Introduce Server Stats

### DIFF
--- a/r2r/main/api/client.py
+++ b/r2r/main/api/client.py
@@ -147,6 +147,10 @@ class R2RClient:
     def health(self) -> dict:
         return self._make_request("GET", "health")
 
+    def server_stats(self) -> dict:
+        self._ensure_authenticated()
+        return self._make_request("GET", "server_stats")
+
     def update_prompt(
         self,
         name: str = "default_system",

--- a/r2r/pipes/ingestion/chunking_pipe.py
+++ b/r2r/pipes/ingestion/chunking_pipe.py
@@ -55,7 +55,6 @@ class ChunkingPipe(AsyncPipe):
 
             try:
                 iteration = 0
-                print("item.data = ", item.data)
                 async for chunk in self.chunking_provider.chunk(item.data):
                     yield Fragment(
                         id=generate_id_from_label(f"{item.id}-{iteration}"),


### PR DESCRIPTION
Protected route that gives statistics around the server where R2R is deployed.

{"results":{"start_time":"2024-08-01T23:32:01.591093+00:00","uptime_seconds":36.691362,"cpu_usage":17.0,"memory_usage":76.0}}
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bf436880c24e3e284a67c876d48290956d894750  | 
|--------|--------|

### Summary:
Introduced server statistics route, replaced JSON with TOML configuration, refactored providers, and updated ingestion pipeline with chunking.

**Key points**:
- Added `/server_stats` route in `r2r/main/api/routes/management/base.py` to provide server statistics.
- Replaced JSON configuration files with TOML in `Dockerfile`, `compose.yaml`, and various other files.
- Updated `R2RConfig` class in `r2r/main/assembly/config.py` to handle TOML files.
- Refactored `LLMProvider` to `CompletionProvider` across multiple files.
- Added `ChunkingProvider` and `ParsingProvider` in `r2r/base/providers`.
- Updated ingestion pipeline in `r2r/pipelines/ingestion_pipeline.py` to include chunking.
- Added new tests in `tests/test_cli.py`, `tests/test_config.py`, `tests/test_end_to_end.py`, and `tests/test_llms.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->