### PR TITLE
Allow setting of BASE_URL from environment. Add env var  TRAEFIK_DASHBOARD_PORT

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -32,8 +32,6 @@ services:
       - PYTHONUNBUFFERED=1
       - PORT=${PORT:-8000}
       - HOST=${HOST:-0.0.0.0}
-      - BASE_URL=${BASE_URL:-http://localhost}
-      
       # R2R
       - CONFIG_NAME=${CONFIG_NAME:-}
       - CONFIG_PATH=${CONFIG_PATH:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,8 @@ services:
       - PYTHONUNBUFFERED=1
       - PORT=${PORT:-8000}
       - HOST=${HOST:-0.0.0.0}
+      - BASE_URL=${BASE_URL:-http://localhost}
+      
       # R2R
       - CONFIG_NAME=${CONFIG_NAME:-}
       - CONFIG_PATH=${CONFIG_PATH:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -112,8 +112,7 @@ services:
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest
     environment:
-      #- NEXT_PUBLIC_API_URL=http://traefik:${TRAEFIK_PORT:-80}/api
-      - NEXT_PUBLIC_API_URL=http://traefik:${TRAEFIK_PORT:-9080}/api
+      - NEXT_PUBLIC_API_URL=http://traefik:${TRAEFIK_PORT:-80}/api
     depends_on:
       - r2r
     networks:
@@ -129,8 +128,7 @@ services:
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      #- "--entrypoints.web.address=:${TRAEFIK_PORT:-80}"
-      - "--entrypoints.web.address=:${TRAEFIK_PORT:-9080}"
+      - "--entrypoints.web.address=:${TRAEFIK_PORT:-80}"
       - "--accesslog=true"
       - "--accesslog.filepath=/var/log/traefik/access.log"
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,7 +33,7 @@ services:
       - PORT=${PORT:-8000}
       - HOST=${HOST:-0.0.0.0}
       # smig: Allow setting of BASE_URL from environment
-      - BASE_URL=${BASE_URL:-0.0.0.0}      
+      - BASE_URL=${BASE_URL:-http://localhost}      
       
       # R2R
       - CONFIG_NAME=${CONFIG_NAME:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,9 @@ services:
       - PYTHONUNBUFFERED=1
       - PORT=${PORT:-8000}
       - HOST=${HOST:-0.0.0.0}
+      # smig: Allow setting of BASE_URL from environment
+      - BASE_URL=${BASE_URL:-0.0.0.0}      
+      
       # R2R
       - CONFIG_NAME=${CONFIG_NAME:-}
       - CONFIG_PATH=${CONFIG_PATH:-}
@@ -131,10 +134,10 @@ services:
       - "--accesslog=true"
       - "--accesslog.filepath=/var/log/traefik/access.log"
     ports:
-      #- "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"
-      - "${TRAEFIK_PORT:-9080}:${TRAEFIK_PORT:-9080}"
+      - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"
+      # smig: allow setting from environment
       #- "8080:8080"  # Traefik dashboard
-      - "${TRAEFIK_DASHBOARD_PORT:-8081}:${TRAEFIK_DASHBOARD_PORT:-8081}"
+      - "${TRAEFIK_DASHBOARD_PORT:-8080}:${TRAEFIK_DASHBOARD_PORT:-8080}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:

--- a/compose.yamlORIG
+++ b/compose.yamlORIG
@@ -109,8 +109,7 @@ services:
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest
     environment:
-      #- NEXT_PUBLIC_API_URL=http://traefik:${TRAEFIK_PORT:-80}/api
-      - NEXT_PUBLIC_API_URL=http://traefik:${TRAEFIK_PORT:-9080}/api
+      - NEXT_PUBLIC_API_URL=http://traefik:${TRAEFIK_PORT:-80}/api
     depends_on:
       - r2r
     networks:
@@ -126,15 +125,12 @@ services:
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      #- "--entrypoints.web.address=:${TRAEFIK_PORT:-80}"
-      - "--entrypoints.web.address=:${TRAEFIK_PORT:-9080}"
+      - "--entrypoints.web.address=:${TRAEFIK_PORT:-80}"
       - "--accesslog=true"
       - "--accesslog.filepath=/var/log/traefik/access.log"
     ports:
-      #- "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"
-      - "${TRAEFIK_PORT:-9080}:${TRAEFIK_PORT:-9080}"
-      #- "8080:8080"  # Traefik dashboard
-      - "${TRAEFIK_DASHBOARD_PORT:-8081}:${TRAEFIK_DASHBOARD_PORT:-8081}"
+      - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"
+      - "8080:8080"  # Traefik dashboard
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:

--- a/r2r/examples/configs/local_llm_neo4j_kg.toml
+++ b/r2r/examples/configs/local_llm_neo4j_kg.toml
@@ -36,4 +36,12 @@ kg_extraction_prompt = "zero_shot_ner_kg_extraction"
   add_generation_kwargs = { }
 
 [database]
-provider = "pgvector"
+provider = "postgres"
+
+[agent]
+system_instruction_name = "rag_agent"
+tool_names = ["search"]
+  
+  [agent.generation_config]
+  model = "ollama/llama3.1"
+

--- a/r2r/examples/configs/local_llm_neo4j_kg.tomlORIG
+++ b/r2r/examples/configs/local_llm_neo4j_kg.tomlORIG
@@ -1,0 +1,39 @@
+[completion]
+provider = "litellm"
+concurrent_request_limit = 1
+
+  [completion.generation_config]
+  model = "ollama/llama3.1"
+  temperature = 0.1
+  top_p = 1
+  max_tokens_to_sample = 1_024
+  stream = false
+  add_generation_kwargs = { }
+
+[embedding]
+provider = "ollama"
+base_model = "mxbai-embed-large"
+base_dimension = 1_024
+batch_size = 32
+add_title_as_prefix = true
+
+[ingestion]
+excluded_parsers = [ "gif", "jpeg", "jpg", "png", "svg", "mp3", "mp4" ]
+
+[kg]
+provider = "neo4j"
+batch_size = 1
+max_entities = 10
+max_relations = 20
+kg_extraction_prompt = "zero_shot_ner_kg_extraction"
+
+  [kg.kg_extraction_config]
+  model = "ollama/sciphi/triplex"
+  temperature = 1
+  top_p = 1
+  max_tokens_to_sample = 1_024
+  stream = false
+  add_generation_kwargs = { }
+
+[database]
+provider = "pgvector"


### PR DESCRIPTION
1. Allow setting of BASE_URL from environment
>  Addresses remote machine dashboard authentication failure: https://discord.com/channels/1120774652915105934/1270176220390228140

3. Allow setting Traefik dashboard from environment via TRAEFIK_DASHBOARD_PORT. Keep existing default ports.
> Addresses handling port conflict with 8080


