### PR TITLE
Allow BASE_URL and TRAEFIK_DASHBOARD_PORT (added) to be passed in from environment vars.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -34,7 +34,7 @@ services:
       - HOST=${HOST:-0.0.0.0}
       # smig: Allow setting of BASE_URL from environment
       - BASE_URL=${BASE_URL:-http://localhost}
-      
+
       # R2R
       - CONFIG_NAME=${CONFIG_NAME:-}
       - CONFIG_PATH=${CONFIG_PATH:-}
@@ -132,7 +132,7 @@ services:
       - "--accesslog=true"
       - "--accesslog.filepath=/var/log/traefik/access.log"
     ports:
-      - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"      
+      - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"
       #- "8080:8080"  # Traefik dashboard
       # smig: allow setting from environment
       - "${TRAEFIK_DASHBOARD_PORT:-8080}:${TRAEFIK_DASHBOARD_PORT:-8080}"

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,9 @@ services:
       - PYTHONUNBUFFERED=1
       - PORT=${PORT:-8000}
       - HOST=${HOST:-0.0.0.0}
+      # smig: Allow setting of BASE_URL from environment
+      - BASE_URL=${BASE_URL:-http://localhost}
+      
       # R2R
       - CONFIG_NAME=${CONFIG_NAME:-}
       - CONFIG_PATH=${CONFIG_PATH:-}
@@ -129,8 +132,10 @@ services:
       - "--accesslog=true"
       - "--accesslog.filepath=/var/log/traefik/access.log"
     ports:
-      - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"
-      - "8080:8080"  # Traefik dashboard
+      - "${TRAEFIK_PORT:-80}:${TRAEFIK_PORT:-80}"      
+      #- "8080:8080"  # Traefik dashboard
+      # smig: allow setting from environment
+      - "${TRAEFIK_DASHBOARD_PORT:-8080}:${TRAEFIK_DASHBOARD_PORT:-8080}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:


### PR DESCRIPTION
The changes are to allow the BASE_URL and TRAEFIK_DASHBOARD_PORT to be set from passed in environment variables. The TRAEFIK_DASHBOARD_PORT was added to replace the 8080 hardcode mapping.

This helped to conveniently address port conflicts.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a1dad48d0b1ce9a68c23fd483f9198b6e5ac8ef0  | 
|--------|--------|

### Summary:
`compose.yaml` now supports setting `BASE_URL` and `TRAEFIK_DASHBOARD_PORT` via environment variables, replacing hardcoded values.

**Key points**:
- Added `BASE_URL` environment variable in `services.r2r.environment` to allow dynamic setting.
- Replaced hardcoded Traefik dashboard port `8080` with `TRAEFIK_DASHBOARD_PORT` environment variable in `services.traefik.ports`.
- Default values are provided for both `BASE_URL` and `TRAEFIK_DASHBOARD_PORT` if not set in the environment.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->