### PR TITLE
Fix parsing config in example config files

### DIFF
--- a/r2r/examples/configs/local_llm.toml
+++ b/r2r/examples/configs/local_llm.toml
@@ -21,5 +21,5 @@ batch_size = 32
 add_title_as_prefix = true
 concurrent_request_limit = 32
 
-[ingestion]
+[parsing]
 excluded_parsers = [ "gif", "jpeg", "jpg", "png", "svg", "mp3", "mp4" ]

--- a/r2r/examples/configs/local_llm_neo4j_kg.toml
+++ b/r2r/examples/configs/local_llm_neo4j_kg.toml
@@ -17,7 +17,7 @@ base_dimension = 1_024
 batch_size = 32
 add_title_as_prefix = true
 
-[ingestion]
+[parsing]
 excluded_parsers = [ "gif", "jpeg", "jpg", "png", "svg", "mp3", "mp4" ]
 
 [kg]


### PR DESCRIPTION
The example files seem to be outdated, which leads to this issue: #842 

I have renamed the section "ingestion" to "parsing" which seems to take care of the issue
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9b0e00b5f2f06ab24c31837555b445e864ffdbaf  | 
|--------|--------|

### Summary:
Renamed `[ingestion]` to `[parsing]` in example config files to fix parsing issue #842.

**Key points**:
- Renamed `[ingestion]` section to `[parsing]` in `r2r/examples/configs/local_llm.toml`.
- Renamed `[ingestion]` section to `[parsing]` in `r2r/examples/configs/local_llm_neo4j_kg.toml`.
- Fixes parsing issue as per issue #842.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->