### PR TITLE
fix: Fix argument order on ingest_files

### DIFF
--- a/r2r/cli/commands/document_operations.py
+++ b/r2r/cli/commands/document_operations.py
@@ -70,7 +70,7 @@ def ingest_files(obj, file_paths, document_ids, metadatas, versions):
         versions = list(versions) if versions else None
 
         response = obj.ingest_files(
-            file_paths, document_ids, metadatas, versions
+            file_paths, metadatas, document_ids, versions
         )
     click.echo(response)
 


### PR DESCRIPTION
The arguments were being passed in the wrong order
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2766bea8edc087716bbdd310da2cc3bf3bb2dd28  | 
|--------|--------|

### Summary:
Fixes argument order in `ingest_files` function call in `r2r/cli/commands/document_operations.py` to ensure correct parameter alignment.

**Key points**:
- Corrects argument order in `ingest_files` function call in `r2r/cli/commands/document_operations.py`.
- Changes order from `file_paths, document_ids, metadatas, versions` to `file_paths, metadatas, document_ids, versions`.
- Ensures proper functionality by aligning with expected parameter order in `obj.ingest_files`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->