### PR TITLE
Fix Undefined Volume Error by Using Absolute Path for Config File

### DIFF
--- a/r2r/cli/utils/docker_utils.py
+++ b/r2r/cli/utils/docker_utils.py
@@ -350,7 +350,7 @@ def build_docker_command(
     os.environ["TRAEFIK_PORT"] = str(available_port + 1)
 
     os.environ["CONFIG_PATH"] = (
-        os.path.basename(config_path) if config_path else ""
+        os.path.abspath(config_path) if config_path else ""
     )
 
     os.environ["R2R_IMAGE"] = image or ""


### PR DESCRIPTION
#### Issue

**Original Issue:** Can not use `--config-path` when starting `r2r` with Docker #890 

**Description:** When starting the `r2r` server with Docker using the `--config-path` option, the following error occurs:

```
Starting Docker Compose setup...
service "r2r" refers to undefined volume local_llm_neo4j_kg.toml: invalid compose project
```

This error indicates that Docker Compose is unable to locate the volume due to the config path being incorrectly interpreted.

#### Solution

To address this issue, I have updated the code to convert the `config_path` to its absolute path instead of just obtaining the basename. This change ensures that Docker Compose uses the correct absolute path for the volume, preventing the "Undefined Volume" error.

#### Code Changes

- **Updated Code:** Changed the environment variable assignment to use `os.path.abspath` for `config_path`.

**Before:**
```python
os.environ["CONFIG_PATH"] = (
    os.path.basename(config_path) if config_path else ""
)
```

**After:**
```python
os.environ["CONFIG_PATH"] = (
    os.path.abspath(config_path) if config_path else ""
)
```

This modification ensures that the `CONFIG_PATH` environment variable contains the absolute path to the config file, allowing Docker Compose to correctly locate and mount the volume.

#### Testing

1. **Test Setup:** Ensure that a local config file is placed in the current directory.
2. **Run Command:** Start the `r2r` server with Docker using the command:
   ```sh
   r2r --config-path=local_llm_neo4j_kg.toml serve --docker
   ```
3. **Verification:** Confirm that Docker Compose starts successfully without the "Undefined Volume" error.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a3b88c18677f7f88b67cba45872bb7a5f0f93582  | 
|--------|--------|

### Summary:
Fixes Docker Compose volume error by using absolute path for `CONFIG_PATH` in `r2r/cli/utils/docker_utils.py`.

**Key points**:
- Fixes issue #890 related to Docker Compose volume error.
- Updates `r2r/cli/utils/docker_utils.py`.
- Modifies `build_docker_command` function.
- Changes `CONFIG_PATH` to use `os.path.abspath` for absolute path.
- Ensures Docker Compose locates config file correctly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->