### PR TITLE
Disable SSL when installing nltk wordnet

### DIFF
--- a/py/core/main/api/routes/auth/base.py
+++ b/py/core/main/api/routes/auth/base.py
@@ -20,7 +20,9 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 
 class AuthRouter(BaseRouter):
-    def __init__(self, engine: "R2REngine", run_type: RunType = RunType.INGESTION):
+    def __init__(
+        self, engine: "R2REngine", run_type: RunType = RunType.INGESTION
+    ):
         super().__init__(engine, run_type)
         self.setup_routes()
 

--- a/py/core/main/api/routes/ingestion/base.py
+++ b/py/core/main/api/routes/ingestion/base.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 
 
 class IngestionRouter(BaseRouter):
-    def __init__(self, engine: R2REngine, run_type: RunType = RunType.INGESTION):
+    def __init__(
+        self, engine: R2REngine, run_type: RunType = RunType.INGESTION
+    ):
         super().__init__(engine, run_type)
         self.openapi_extras = self.load_openapi_extras()
         self.setup_routes()

--- a/py/core/main/api/routes/management/base.py
+++ b/py/core/main/api/routes/management/base.py
@@ -31,7 +31,9 @@ from ..base_router import BaseRouter, RunType
 
 
 class ManagementRouter(BaseRouter):
-    def __init__(self, engine: R2REngine, run_type: RunType = RunType.MANAGEMENT):
+    def __init__(
+        self, engine: R2REngine, run_type: RunType = RunType.MANAGEMENT
+    ):
         super().__init__(engine, run_type)
         self.start_time = datetime.now(timezone.utc)
         self.setup_routes()

--- a/py/core/main/api/routes/restructure/base.py
+++ b/py/core/main/api/routes/restructure/base.py
@@ -7,7 +7,9 @@ from fastapi import Body, Depends
 
 
 class RestructureRouter(BaseRouter):
-    def __init__(self, engine: R2REngine, run_type: RunType = RunType.RESTRUCTURE):
+    def __init__(
+        self, engine: R2REngine, run_type: RunType = RunType.RESTRUCTURE
+    ):
         super().__init__(engine, run_type)
         self.setup_routes()
 

--- a/py/core/main/api/routes/retrieval/base.py
+++ b/py/core/main/api/routes/retrieval/base.py
@@ -23,7 +23,9 @@ from ..base_router import BaseRouter
 
 
 class RetrievalRouter(BaseRouter):
-    def __init__(self, engine: R2REngine, run_type: RunType = RunType.RETRIEVAL):
+    def __init__(
+        self, engine: R2REngine, run_type: RunType = RunType.RETRIEVAL
+    ):
         super().__init__(engine, run_type)
         self.openapi_extras = self.load_openapi_extras()
         self.setup_routes()

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -63,9 +63,7 @@ class ManagementService(Service):
         aggregated_logs = []
 
         for run in run_info:
-            run_logs = [
-                log for log in logs if log["run_id"] == run.run_id
-            ]
+            run_logs = [log for log in logs if log["run_id"] == run.run_id]
             entries = [
                 {
                     "key": log["key"],
@@ -73,7 +71,9 @@ class ManagementService(Service):
                     "timestamp": log["timestamp"],
                 }
                 for log in run_logs
-            ][::-1]  # Reverse order so that earliest logged values appear first.
+            ][
+                ::-1
+            ]  # Reverse order so that earliest logged values appear first.
 
             log_entry = {
                 "run_id": str(run.run_id),

--- a/py/core/pipelines/ingestion_pipeline.py
+++ b/py/core/pipelines/ingestion_pipeline.py
@@ -123,9 +123,7 @@ class IngestionPipeline(AsyncPipeline):
             "embedding_pipeline_output": (
                 results[0] if self.embedding_pipeline else None
             ),
-            "kg_pipeline_output": (
-                results[-1] if self.kg_pipeline else None
-            ),
+            "kg_pipeline_output": (results[-1] if self.kg_pipeline else None),
         }
 
     def add_pipe(

--- a/py/poetry.lock
+++ b/py/poetry.lock
@@ -767,21 +767,6 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "dataclasses-json"
-version = "0.6.7"
-description = "Easily serialize dataclasses to and from JSON."
-optional = true
-python-versions = "<4.0,>=3.7"
-files = [
-    {file = "dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a"},
-    {file = "dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0"},
-]
-
-[package.dependencies]
-marshmallow = ">=3.18.0,<4.0.0"
-typing-inspect = ">=0.4.0,<1"
-
-[[package]]
 name = "decorator"
 version = "4.4.2"
 description = "Decorators for Humans"
@@ -1574,21 +1559,25 @@ test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "p
 
 [[package]]
 name = "importlib-resources"
-version = "6.4.3"
+version = "6.4.4"
 description = "Read resources from Python packages"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.4.3-py3-none-any.whl", hash = "sha256:2d6dfe3b9e055f72495c2085890837fc8c758984e209115c8792bddcb762cd93"},
-    {file = "importlib_resources-6.4.3.tar.gz", hash = "sha256:4a202b9b9d38563b46da59221d77bb73862ab5d79d461307bcb826d725448b98"},
+    {file = "importlib_resources-6.4.4-py3-none-any.whl", hash = "sha256:dda242603d1c9cd836c3368b1174ed74cb4049ecd209e7a1a0104620c18c5c11"},
+    {file = "importlib_resources-6.4.4.tar.gz", hash = "sha256:20600c8b7361938dc0bb2d5ec0297802e575df486f5a544fa414da65e13721f7"},
 ]
 
 [package.dependencies]
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
+type = ["pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -1714,17 +1703,6 @@ python-versions = ">=3.8"
 files = [
     {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
     {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
-]
-
-[[package]]
-name = "jsonpath-python"
-version = "1.0.6"
-description = "A more powerful JSONPath implementation in modern python"
-optional = true
-python-versions = ">=3.6"
-files = [
-    {file = "jsonpath-python-1.0.6.tar.gz", hash = "sha256:dd5be4a72d8a2995c3f583cf82bf3cd1a9544cfdabf2d22595b67aff07349666"},
-    {file = "jsonpath_python-1.0.6-py3-none-any.whl", hash = "sha256:1e3b78df579f5efc23565293612decee04214609208a2335884b3ee3f786b575"},
 ]
 
 [[package]]
@@ -2173,25 +2151,6 @@ files = [
     {file = "MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5"},
     {file = "MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"},
 ]
-
-[[package]]
-name = "marshmallow"
-version = "3.22.0"
-description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
-optional = true
-python-versions = ">=3.8"
-files = [
-    {file = "marshmallow-3.22.0-py3-none-any.whl", hash = "sha256:71a2dce49ef901c3f97ed296ae5051135fd3febd2bf43afe0ae9a82143a494d9"},
-    {file = "marshmallow-3.22.0.tar.gz", hash = "sha256:4972f529104a220bb8637d595aa4c9762afbe7f7a77d82dc58c1615d70c5823e"},
-]
-
-[package.dependencies]
-packaging = ">=17.0"
-
-[package.extras]
-dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
-docs = ["alabaster (==1.0.0)", "autodocsumm (==0.2.13)", "sphinx (==8.0.2)", "sphinx-issues (==4.1.0)", "sphinx-version-warning (==1.1.2)"]
-tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
 name = "matplotlib"
@@ -2680,11 +2639,11 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.21.0", markers = "python_version == \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.23.5", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\" and python_version < \"3.11\""},
     {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.19.3", markers = "platform_system == \"Linux\" and platform_machine == \"aarch64\" and python_version >= \"3.8\" and python_version < \"3.10\" or python_version > \"3.9\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_system != \"Darwin\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.23.5", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 
 [[package]]
@@ -2767,8 +2726,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3824,20 +3783,6 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-description = "A utility belt for advanced users of python-requests"
-optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
-    {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
-]
-
-[package.dependencies]
-requests = ">=2.0.1,<3.0.0"
-
-[[package]]
 name = "rpds-py"
 version = "0.20.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
@@ -4543,21 +4488,6 @@ files = [
 ]
 
 [[package]]
-name = "typing-inspect"
-version = "0.9.0"
-description = "Runtime inspection utilities for typing module."
-optional = true
-python-versions = "*"
-files = [
-    {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
-    {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
-]
-
-[package.dependencies]
-mypy-extensions = ">=0.3.0"
-typing-extensions = ">=3.7.4"
-
-[[package]]
 name = "tzdata"
 version = "2024.1"
 description = "Provider of IANA time zone data"
@@ -4591,41 +4521,6 @@ tqdm = "*"
 parametric-umap = ["tensorflow (>=2.1)"]
 plot = ["bokeh", "colorcet", "datashader", "holoviews", "matplotlib", "pandas", "scikit-image", "seaborn"]
 tbb = ["tbb (>=2019.0)"]
-
-[[package]]
-name = "unstructured-client"
-version = "0.25.5"
-description = "Python Client SDK for Unstructured API"
-optional = true
-python-versions = ">=3.8"
-files = [
-    {file = "unstructured-client-0.25.5.tar.gz", hash = "sha256:adb97ea56ce65f8b277d5b05f093e9d13a3320ac8dea7265ffa71f5e13ed5f84"},
-    {file = "unstructured_client-0.25.5-py3-none-any.whl", hash = "sha256:23537fee984e43d06a75f986a73e420a9659cc92010afb8324fbf67c85962eaf"},
-]
-
-[package.dependencies]
-certifi = ">=2023.7.22"
-charset-normalizer = ">=3.2.0"
-dataclasses-json = ">=0.6.4"
-deepdiff = ">=6.0"
-httpx = ">=0.27.0"
-idna = ">=3.4"
-jsonpath-python = ">=1.0.6"
-marshmallow = ">=3.19.0"
-mypy-extensions = ">=1.0.0"
-nest-asyncio = ">=1.6.0"
-packaging = ">=23.1"
-pypdf = ">=4.0"
-python-dateutil = ">=2.8.2"
-requests = ">=2.31.0"
-requests-toolbelt = ">=1.0.0"
-six = ">=1.16.0"
-typing-extensions = ">=4.7.1"
-typing-inspect = ">=0.9.0"
-urllib3 = ">=1.26.18"
-
-[package.extras]
-dev = ["pylint (==3.1.0)"]
 
 [[package]]
 name = "urllib3"
@@ -4914,10 +4809,10 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linke
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
-core = ["aiosqlite", "asyncpg", "bcrypt", "beautifulsoup4", "deepdiff", "fire", "fsspec", "graspologic", "gunicorn", "litellm", "markdown", "neo4j", "ollama", "openai", "openpyxl", "passlib", "poppler-utils", "posthog", "psutil", "pydantic", "pyjwt", "pypdf", "python-docx", "python-multipart", "python-pptx", "pyyaml", "redis", "requests", "sqlalchemy", "toml", "types-requests", "unstructured_client", "uvicorn", "vecs"]
+core = ["aiosqlite", "asyncpg", "bcrypt", "beautifulsoup4", "deepdiff", "fire", "fsspec", "graspologic", "gunicorn", "litellm", "markdown", "neo4j", "ollama", "openai", "openpyxl", "passlib", "poppler-utils", "posthog", "psutil", "pydantic", "pyjwt", "pypdf", "python-docx", "python-multipart", "python-pptx", "pyyaml", "redis", "requests", "sqlalchemy", "toml", "types-requests", "uvicorn", "vecs"]
 core-ingest-movies = ["moviepy", "opencv-python"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "32a72ff508ce34d83088f25d824aabf7134d70c56332bae6bc495b0bcafa84ec"
+content-hash = "e895ee32f5d5aa71a29548d0e48044276b364a43c54b62f7f6da0bb932b53499"

--- a/py/scripts/download_nltk_data.py
+++ b/py/scripts/download_nltk_data.py
@@ -1,7 +1,16 @@
+import ssl
+
 import nltk
 
 
 def download_nltk_data():
+    try:
+        _create_unverified_https_context = ssl._create_unverified_context
+    except AttributeError:
+        pass
+    else:
+        ssl._create_default_https_context = _create_unverified_https_context
+
     nltk.download("wordnet", quiet=True)
 
 


### PR DESCRIPTION
Need to disable SSL, read here for more:

https://stackoverflow.com/questions/38916452/nltk-download-ssl-certificate-verify-failed
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 57898e75d3614610970dc381a71a7e8be6515a32  | 
|--------|--------|

### Summary:
Disable SSL verification in `py/scripts/download_nltk_data.py` to fix SSL certificate verification issues when downloading NLTK WordNet data.

**Key points**:
- **File**: `py/scripts/download_nltk_data.py`
  - **Change**: Disable SSL verification by setting `_create_default_https_context` to `_create_unverified_https_context`.
  - **Purpose**: Workaround for SSL certificate verification failures when downloading NLTK WordNet data.
- **Other Changes**: Formatting adjustments in `__init__` methods across several router classes and list comprehensions in `py/core/main/services/management_service.py` and `py/core/pipelines/ingestion_pipeline.py`. These do not affect functionality.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->