### PR TITLE
Fix type annotations to run with Python 3.9

### DIFF
--- a/r2r/parsers/structured/csv_parser.py
+++ b/r2r/parsers/structured/csv_parser.py
@@ -1,4 +1,4 @@
-from typing import IO, AsyncGenerator, Union
+from typing import IO, AsyncGenerator, Optional, Union
 
 from r2r.base.abstractions.document import DataType
 from r2r.base.parsers.base_parser import AsyncParser
@@ -36,7 +36,7 @@ class CSVParserAdvanced(AsyncParser[DataType]):
         self.StringIO = StringIO
 
     def get_delimiter(
-        self, file_path: str | None = None, file: IO[bytes] | None = None
+        self, file_path: Optional[str] = None, file: Optional[IO[bytes]] = None
     ):
 
         sniffer = self.csv.Sniffer()


### PR DESCRIPTION
According to the `tool.poetry.dependencies.python` key of `pyproject.toml`, the package supports `">=3.9,<3.13"`. However, when running `r2r --help` with Python 3.9, I received the following error:

> `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`

The problem was that one set of type annotations uses the `|` operator instead of `typing.Union`, which was not supported until Python 3.10. I switched to using the `typing` module to restore support for Python 3.9.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit de4bdf4f7d5d33deb19cfdcd2c76506b014562c1  | 
|--------|--------|

### Summary:
Replaced `|` operator with `Optional` in `CSVParserAdvanced.get_delimiter` to ensure Python 3.9 compatibility.

**Key points**:
- Replaced `|` operator with `Optional` in `get_delimiter` function.
- Affects `CSVParserAdvanced` class in `r2r/parsers/structured/csv_parser.py`.
- Ensures compatibility with Python 3.9 as per `pyproject.toml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->