### PR TITLE
Remove email in refresh

### DIFF
--- a/py/core/base/abstractions/search.py
+++ b/py/core/base/abstractions/search.py
@@ -54,8 +54,10 @@ class VectorSearchResult(BaseModel):
             },
         }
 
+
 class KGLocalSearchResult(BaseModel):
     """Result of a local knowledge graph search operation."""
+
     query: str
     entities: list[dict[str, Any]]
     relationships: list[dict[str, Any]]
@@ -70,6 +72,7 @@ class KGLocalSearchResult(BaseModel):
 
 class KGGlobalSearchResult(BaseModel):
     """Result of a global knowledge graph search operation."""
+
     query: str
     search_result: list[Dict[str, Any]]
 
@@ -82,6 +85,7 @@ class KGGlobalSearchResult(BaseModel):
 
 class KGSearchResult(BaseModel):
     """Result of a knowledge graph search operation."""
+
     local_result: Optional[KGLocalSearchResult] = None
     global_result: Optional[KGGlobalSearchResult] = None
 

--- a/py/core/base/providers/auth.py
+++ b/py/core/base/providers/auth.py
@@ -90,9 +90,7 @@ class AuthProvider(Provider, ABC):
         pass
 
     @abstractmethod
-    def refresh_access_token(
-        self, user_email: str, refresh_token: str
-    ) -> Dict[str, str]:
+    def refresh_access_token(self, refresh_token: str) -> Dict[str, str]:
         pass
 
     async def auth_wrapper(

--- a/py/core/main/api/routes/auth/base.py
+++ b/py/core/main/api/routes/auth/base.py
@@ -141,7 +141,6 @@ class AuthRouter(BaseRouter):
             This endpoint allows users to obtain a new access token using their refresh token.
             """
             refresh_result = await self.engine.arefresh_access_token(
-                user_email=auth_user.email,
                 refresh_token=refresh_token,
             )
             return refresh_result

--- a/py/core/main/services/auth_service.py
+++ b/py/core/main/services/auth_service.py
@@ -74,11 +74,9 @@ class AuthService(Service):
 
     @telemetry_event("RefreshToken")
     async def refresh_access_token(
-        self, user_email: str, refresh_token: str
+        self, refresh_token: str
     ) -> dict[str, Token]:
-        return self.providers.auth.refresh_access_token(
-            user_email, refresh_token
-        )
+        return self.providers.auth.refresh_access_token(refresh_token)
 
     @telemetry_event("ChangePassword")
     async def change_password(

--- a/py/core/pipes/retrieval/kg_search_search_pipe.py
+++ b/py/core/pipes/retrieval/kg_search_search_pipe.py
@@ -14,11 +14,16 @@ from core.base import (
     PromptProvider,
     RunLoggingSingleton,
 )
+from core.base.abstractions.search import (
+    KGGlobalSearchResult,
+    KGLocalSearchResult,
+    KGSearchResult,
+)
 
-from core.base.abstractions.search import KGLocalSearchResult, KGGlobalSearchResult, KGSearchResult
 from ..abstractions.generator_pipe import GeneratorPipe
 
 logger = logging.getLogger(__name__)
+
 
 class KGSearchSearchPipe(GeneratorPipe):
     """
@@ -127,7 +132,12 @@ class KGSearchSearchPipe(GeneratorPipe):
                 )
                 all_search_results.append(search_result)
 
-            yield KGLocalSearchResult(query=message, entities=all_search_results[0], relationships=all_search_results[1], communities=all_search_results[2])
+            yield KGLocalSearchResult(
+                query=message,
+                entities=all_search_results[0],
+                relationships=all_search_results[1],
+                communities=all_search_results[2],
+            )
 
     async def global_search(
         self,
@@ -209,7 +219,9 @@ class KGSearchSearchPipe(GeneratorPipe):
 
             output = output.choices[0].message.content
 
-            yield KGGlobalSearchResult(query=message, search_result=output, citations=None)
+            yield KGGlobalSearchResult(
+                query=message, search_result=output, citations=None
+            )
 
     async def _run_logic(
         self,

--- a/py/core/providers/auth/r2r_auth.py
+++ b/py/core/providers/auth/r2r_auth.py
@@ -197,24 +197,17 @@ class R2RAuthProvider(AuthProvider):
             raise R2RException(status_code=401, message="Email not verified")
 
         access_token = self.create_access_token(data={"sub": user.email})
-        refresh_token = self.create_refresh_token(data={"sub": user.email})
+        refresh_token = self.create_refresh_token()
         return {
             "access_token": Token(token=access_token, token_type="access"),
             "refresh_token": Token(token=refresh_token, token_type="refresh"),
         }
 
-    def refresh_access_token(
-        self, user_email: str, refresh_token: str
-    ) -> Dict[str, Token]:
+    def refresh_access_token(self, refresh_token: str) -> Dict[str, Token]:
         token_data = self.decode_token(refresh_token)
         if token_data.token_type != "refresh":
             raise R2RException(
                 status_code=401, message="Invalid refresh token"
-            )
-        if token_data.email != user_email:
-            raise R2RException(
-                status_code=402,
-                message="Invalid email address attached to token",
             )
 
         # Invalidate the old refresh token and create a new one
@@ -223,9 +216,7 @@ class R2RAuthProvider(AuthProvider):
         new_access_token = self.create_access_token(
             data={"sub": token_data.email}
         )
-        new_refresh_token = self.create_refresh_token(
-            data={"sub": token_data.email}
-        )
+        new_refresh_token = self.create_refresh_token()
         return {
             "access_token": Token(token=new_access_token, token_type="access"),
             "refresh_token": Token(

--- a/py/sdk/models.py
+++ b/py/sdk/models.py
@@ -200,12 +200,13 @@ class KGSearchResult(BaseModel):
                     {
                         "Paris": {
                             "name": "Paris",
-                            "description": "Paris is the capital of France."
+                            "description": "Paris is the capital of France.",
                         }
                     }
-                ]
+                ],
             }
         }
+
 
 class R2RException(Exception):
     def __init__(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a7f7d8661fd3989fb67426498872b2ff7bcbd091  | 
|--------|--------|

### Summary:
Removed `user_email` from `refresh_access_token` function across multiple files, simplifying the token refresh process by relying solely on `refresh_token`.

**Key points**:
- Removed `user_email` parameter from `refresh_access_token` function in `py/core/base/providers/auth.py`.
- Updated `refresh_access_token_app` in `py/core/main/api/routes/auth/base.py` to exclude `user_email`.
- Modified `refresh_access_token` method in `py/core/main/services/auth_service.py` to remove `user_email`.
- Adjusted `refresh_access_token` in `py/core/providers/auth/r2r_auth.py` to eliminate email validation logic.
- Simplified token refresh process by relying solely on `refresh_token`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->