### PR TITLE
Add support for CharacterTextSplitter

### DIFF
--- a/py/core/base/providers/chunking.py
+++ b/py/core/base/providers/chunking.py
@@ -10,6 +10,7 @@ class Method(str, Enum):
     BY_TITLE = "by_title"
     BASIC = "basic"
     RECURSIVE = "recursive"
+    CHARACTER = "character"
 
 
 class ChunkingConfig(ProviderConfig):

--- a/py/core/base/utils/splitter/text.py
+++ b/py/core/base/utils/splitter/text.py
@@ -628,9 +628,11 @@ class TextSplitter(BaseDocumentTransformer, ABC):
 class CharacterTextSplitter(TextSplitter):
     """Splitting text that looks at characters."""
 
+    DEFAULT_SEPARATOR: str = "\n\n"
+
     def __init__(
         self,
-        separator: str = "\n\n",
+        separator: str = DEFAULT_SEPARATOR,
         is_separator_regex: bool = False,
         **kwargs: Any,
     ) -> None:

--- a/py/core/providers/chunking/r2r_chunking.py
+++ b/py/core/providers/chunking/r2r_chunking.py
@@ -10,7 +10,6 @@ from core.base import (
 )
 from core.base.abstractions.document import DocumentExtraction
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -31,7 +30,7 @@ class R2RChunkingProvider(ChunkingProvider):
                 chunk_size=self.config.chunk_size,
                 chunk_overlap=self.config.chunk_overlap,
             )
-        elif self.config.method == "character":
+        elif self.config.method == Method.CHARACTER:
             from core.base.utils.splitter.text import CharacterTextSplitter
             separator = CharacterTextSplitter.DEFAULT_SEPARATOR
             if self.config.extra_fields:

--- a/py/core/providers/chunking/r2r_chunking.py
+++ b/py/core/providers/chunking/r2r_chunking.py
@@ -32,17 +32,19 @@ class R2RChunkingProvider(ChunkingProvider):
             )
         elif self.config.method == Method.CHARACTER:
             from core.base.utils.splitter.text import CharacterTextSplitter
+
             separator = CharacterTextSplitter.DEFAULT_SEPARATOR
             if self.config.extra_fields:
-                separator = self.config.extra_fields.get("separator",
-                                                        CharacterTextSplitter.DEFAULT_SEPARATOR)
+                separator = self.config.extra_fields.get(
+                    "separator", CharacterTextSplitter.DEFAULT_SEPARATOR
+                )
             return CharacterTextSplitter(
-                        chunk_size = self.config.chunk_size,
-                        chunk_overlap = self.config.chunk_overlap,
-                        separator = separator,
-                        keep_separator = False,
-                        strip_whitespace = True
-                        )
+                chunk_size=self.config.chunk_size,
+                chunk_overlap=self.config.chunk_overlap,
+                separator=separator,
+                keep_separator=False,
+                strip_whitespace=True,
+            )
         elif self.config.method == Method.BASIC:
             raise NotImplementedError(
                 "Basic chunking method not implemented. Please use Recursive."

--- a/py/core/providers/chunking/r2r_chunking.py
+++ b/py/core/providers/chunking/r2r_chunking.py
@@ -10,6 +10,7 @@ from core.base import (
 )
 from core.base.abstractions.document import DocumentExtraction
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,6 +31,19 @@ class R2RChunkingProvider(ChunkingProvider):
                 chunk_size=self.config.chunk_size,
                 chunk_overlap=self.config.chunk_overlap,
             )
+        elif self.config.method == "character":
+            from core.base.utils.splitter.text import CharacterTextSplitter
+            separator = CharacterTextSplitter.DEFAULT_SEPARATOR
+            if self.config.extra_fields:
+                separator = self.config.extra_fields.get("separator",
+                                                        CharacterTextSplitter.DEFAULT_SEPARATOR)
+            return CharacterTextSplitter(
+                        chunk_size = self.config.chunk_size,
+                        chunk_overlap = self.config.chunk_overlap,
+                        separator = separator,
+                        keep_separator = False,
+                        strip_whitespace = True
+                        )
         elif self.config.method == Method.BASIC:
             raise NotImplementedError(
                 "Basic chunking method not implemented. Please use Recursive."

--- a/py/sdk/models.py
+++ b/py/sdk/models.py
@@ -146,6 +146,7 @@ class Method(str, Enum):
     BY_TITLE = "by_title"
     BASIC = "basic"
     RECURSIVE = "recursive"
+    CHARACTER = "character"
 
 
 class ChunkingConfig(ProviderConfig):


### PR DESCRIPTION
Allows R2R client to override the text splitter. Example:

```python
ingestion_response = client.ingest_files(
        file_paths=[file_path],
        metadatas=metadata,
        # optionally override chunking settings at runtime
        chunking_settings={
            "provider": "r2r",
            "method": "character",
            "extra_fields": {
                "separator": "---"
            },
        }
    )
```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 237723c5e200fe08e80c72f9cd94f49821d083ce  | 
|--------|--------|

### Summary:
Added support for `CharacterTextSplitter` in R2R client, allowing text splitting by characters with customizable separators.

**Key points**:
- Added `CHARACTER` method to `Method` enum in `py/core/base/providers/chunking.py` and `py/sdk/models.py`.
- Introduced `CharacterTextSplitter` in `py/core/base/utils/splitter/text.py` with a default separator `\n\n`.
- Updated `R2RChunkingProvider._initialize_text_splitter` in `py/core/providers/chunking/r2r_chunking.py` to handle `CHARACTER` method.
- Allows overriding the text splitter settings via `chunking_settings` in the client ingestion method.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->