### PR TITLE
Add Pagination to Logs

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -9,13 +9,29 @@ on:
         type: string
 
 jobs:
-  build-and-publish:
-    runs-on: [ self-hosted, Linux ]
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.version.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Determine version to use
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "RELEASE_VERSION=main" >> $GITHUB_OUTPUT
+          fi
+
+  build-and-publish-amd64:
+    needs: prepare
+    runs-on: amd2
     permissions:
       packages: write
       contents: read
       id-token: write
       actions: write
+    timeout-minutes: 720
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -40,18 +56,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Determine version to use
-        id: version
-        run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "RELEASE_VERSION=main" >> $GITHUB_OUTPUT
-          fi
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -60,7 +64,7 @@ jobs:
             ragtoriches/prod
             us-east1-docker.pkg.dev/alert-rush-397022/sciphi-r2r/r2r
           tags: |
-            type=raw,value=${{ steps.version.outputs.RELEASE_VERSION }}
+            type=raw,value=${{ needs.prepare.outputs.release_version }}
             type=raw,value=latest
 
       - name: Build and Push Docker Image
@@ -71,9 +75,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
-      - name: Build and Push Docker Image
+      - name: Build and Push Docker Image (Unstructured)
         uses: docker/build-push-action@v5
         with:
           context: ./py
@@ -81,4 +85,68 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}-unstructured
           labels: ${{ steps.meta.outputs.labels }}-unstructured
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+
+  build-and-publish-arm64:
+    needs: prepare
+    runs-on: arm2
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+      actions: write
+    timeout-minutes: 720
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Google Auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      - name: Set up Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Configure SDK
+        run: 'gcloud auth configure-docker us-east1-docker.pkg.dev'
+
+      - name: Docker Auth
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RAGTORICHES_DOCKER_UNAME }}
+          password: ${{ secrets.RAGTORICHES_DOCKER_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ragtoriches/prod
+            us-east1-docker.pkg.dev/alert-rush-397022/sciphi-r2r/r2r
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.release_version }}
+            type=raw,value=latest
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./py
+          file: ./py/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+
+      - name: Build and Push Docker Image (Unstructured)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./py
+          file: ./py/Dockerfile.unstructured
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-unstructured
+          labels: ${{ steps.meta.outputs.labels }}-unstructured
+          platforms: linux/arm64

--- a/.github/workflows/py-ci-cd.yml
+++ b/.github/workflows/py-ci-cd.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   pre-commit:
     continue-on-error: true
-    runs-on: [ self-hosted, Linux ]
+    runs-on: amd1
 
     steps:
       - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
 
   pytest:
     continue-on-error: true
-    runs-on: [ self-hosted, Linux ]
+    runs-on: amd1
     timeout-minutes: 15
 
     env:

--- a/py/cli/commands/server.py
+++ b/py/cli/commands/server.py
@@ -38,15 +38,20 @@ def server_stats(client):
 
 
 @cli.command()
-@click.option("--run-type-filter", help="Filter for log types")
 @click.option(
-    "--max-runs", default=None, help="Maximum number of runs to fetch"
+    "--offset", default=None, help="Pagination offset. Default is None."
 )
+@click.option(
+    "--limit", default=None, help="Pagination limit. Defaults to 100."
+)
+@click.option("--run-type-filter", help="Filter for log types")
 @click.pass_obj
-def logs(client, run_type_filter, max_runs):
+def logs(client, run_type_filter, offset, limit):
     """Retrieve logs with optional type filter."""
     with timer():
-        response = client.logs(run_type_filter, max_runs)
+        response = client.logs(
+            offset=offset, limit=limit, run_type_filter=run_type_filter
+        )
 
     for log in response["results"]:
         click.echo(f"Run ID: {log['run_id']}")
@@ -58,7 +63,7 @@ def logs(client, run_type_filter, max_runs):
             click.echo(f"  - {entry['key']}: {entry['value'][:100]}")
         click.echo("---")
 
-    click.echo(f"Total runs: {len(response)}")
+    click.echo(f"Total runs: {len(response['results'])}")
 
 
 @cli.command()

--- a/py/core/main/api/routes/management/base.py
+++ b/py/core/main/api/routes/management/base.py
@@ -122,7 +122,8 @@ class ManagementRouter(BaseRouter):
         @self.base_endpoint
         async def logs_app(
             run_type_filter: Optional[str] = Query(""),
-            max_runs: int = Query(100, ge=1, le=1000),
+            offset: int = Query(0, ge=0),
+            limit: int = Query(100, ge=1, le=1000),
             auth_user=Depends(self.engine.providers.auth.auth_wrapper),
         ) -> WrappedLogResponse:
             if not auth_user.is_superuser:
@@ -132,7 +133,8 @@ class ManagementRouter(BaseRouter):
 
             return await self.engine.alogs(
                 run_type_filter=run_type_filter,
-                max_runs=min(max(max_runs, 1), 1000),
+                offset=offset,
+                limit=limit,
             )
 
         @self.router.get("/app_settings")

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -44,21 +44,32 @@ class ManagementService(Service):
 
     @telemetry_event("Logs")
     async def alogs(
-        self, run_type_filter: Optional[str] = None, max_runs: int = 100
+        self,
+        offset: int = 0,
+        limit: int = 100,
+        run_type_filter: Optional[str] = None,
     ):
+        logger.info(f"alogs called with offset={offset}, limit={limit}")
         if self.logging_connection is None:
             raise R2RException(
                 status_code=404, message="Logging provider not found."
             )
 
         run_info = await self.logging_connection.get_info_logs(
-            limit=max_runs,
+            offset=offset,
+            limit=limit,
             run_type_filter=run_type_filter,
+        )
+        logger.info(
+            f"get_info_logs returned {len(run_info)} entries and they are: {run_info}"
         )
         run_ids = [run.run_id for run in run_info]
         if not run_ids:
             return []
         logs = await self.logging_connection.get_logs(run_ids)
+        logger.info(
+            f"get_logs returned {len(logs)} entries and they are: {logs}"
+        )
 
         aggregated_logs = []
 

--- a/py/sdk/server.py
+++ b/py/sdk/server.py
@@ -19,22 +19,28 @@ class ServerMethods:
     @staticmethod
     async def logs(
         client,
+        offset: int = None,
+        limit: int = None,
         run_type_filter: Optional[str] = None,
-        max_runs: int = None,
     ) -> dict:
         """
         Get logs from the server.
 
         Args:
+            offset (Optional[int]): The offset to start from.
+            limit (Optional[int]): The maximum number of logs to return.
             run_type_filter (Optional[str]): The run type to filter by.
-            max_runs (int): Specifies the maximum number of runs to return. Values outside the range of 1 to 1000 will be adjusted to the nearest valid value with a default of 100.
 
         Returns:
             dict: The logs from the server.
         """
-        params = {}
-        if run_type_filter is not None:
-            params["run_type_filter"] = run_type_filter
-        if max_runs is not None:
-            params["max_runs"] = max_runs
+        params = {
+            key: value
+            for key, value in {
+                "offset": offset,
+                "limit": limit,
+                "run_type_filter": run_type_filter,
+            }.items()
+            if value is not None
+        }
         return await client._make_request("GET", "logs", params=params)


### PR DESCRIPTION
Checking in for now—will revisit, but the logs that are returned do not seem to be correct.


INFO:     127.0.0.1:51443 - "GET /v2/logs?limit=5 HTTP/1.1" 200 OK
2024-08-30 11:08:37,509 - INFO - core.main.services.management_service - alogs called with offset=0, limit=3
2024-08-30 11:08:37,514 - INFO - core.main.services.management_service - get_info_logs returned 3 entries and they are: [RunInfoLog(run_id=UUID('2e305f25-ad1b-57f2-a0f2-b3bf4cb962cf'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 37), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('1a8ba171-7044-5703-9519-add61dcdcb44'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 3, 44), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('8c6d76ca-42ff-572e-857e-fbb49f98de8d'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 3, 18), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220'))]
2024-08-30 11:08:37,522 - INFO - core.main.services.management_service - get_logs returned 0 entries and they are: []
INFO:     127.0.0.1:51538 - "GET /v2/logs?limit=3 HTTP/1.1" 200 OK
2024-08-30 11:08:43,059 - INFO - core.main.services.management_service - alogs called with offset=0, limit=3
2024-08-30 11:08:43,060 - INFO - core.main.services.management_service - get_info_logs returned 3 entries and they are: [RunInfoLog(run_id=UUID('b6928795-f58f-569e-821f-8c84fba45bac'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 43), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('2e305f25-ad1b-57f2-a0f2-b3bf4cb962cf'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 37), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('1a8ba171-7044-5703-9519-add61dcdcb44'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 3, 44), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220'))]
2024-08-30 11:08:43,061 - INFO - core.main.services.management_service - get_logs returned 0 entries and they are: []
INFO:     127.0.0.1:51543 - "GET /v2/logs?limit=3 HTTP/1.1" 200 OK
2024-08-30 11:08:49,191 - INFO - core.main.services.management_service - alogs called with offset=0, limit=3
2024-08-30 11:08:49,192 - INFO - core.main.services.management_service - get_info_logs returned 3 entries and they are: [RunInfoLog(run_id=UUID('5241de1c-064b-5834-b76f-28c6493e01b5'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 49), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('b6928795-f58f-569e-821f-8c84fba45bac'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 43), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('2e305f25-ad1b-57f2-a0f2-b3bf4cb962cf'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 37), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220'))]
2024-08-30 11:08:49,193 - INFO - core.main.services.management_service - get_logs returned 0 entries and they are: []
INFO:     127.0.0.1:51547 - "GET /v2/logs?offset=0&limit=3 HTTP/1.1" 200 OK
2024-08-30 11:09:03,819 - INFO - core.main.services.management_service - alogs called with offset=1, limit=3
2024-08-30 11:09:03,820 - INFO - core.main.services.management_service - get_info_logs returned 3 entries and they are: [RunInfoLog(run_id=UUID('5241de1c-064b-5834-b76f-28c6493e01b5'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 49), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('b6928795-f58f-569e-821f-8c84fba45bac'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 43), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('2e305f25-ad1b-57f2-a0f2-b3bf4cb962cf'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 37), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220'))]
2024-08-30 11:09:03,822 - INFO - core.main.services.management_service - get_logs returned 0 entries and they are: []
INFO:     127.0.0.1:51557 - "GET /v2/logs?offset=1&limit=3 HTTP/1.1" 200 OK
2024-08-30 11:09:23,461 - INFO - core.main.services.management_service - alogs called with offset=4, limit=3
2024-08-30 11:09:23,462 - INFO - core.main.services.management_service - get_info_logs returned 3 entries and they are: [RunInfoLog(run_id=UUID('2e305f25-ad1b-57f2-a0f2-b3bf4cb962cf'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 8, 37), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('1a8ba171-7044-5703-9519-add61dcdcb44'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 3, 44), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220')), RunInfoLog(run_id=UUID('8c6d76ca-42ff-572e-857e-fbb49f98de8d'), run_type='MANAGEMENT', timestamp=datetime.datetime(2024, 8, 30, 18, 3, 18), user_id=UUID('2acb499e-8428-543b-bd85-0d9098718220'))]
2024-08-30 11:09:23,463 - INFO - core.main.services.management_service - get_logs returned 0 entries and they are: []
INFO:     127.0.0.1:51565 - "GET /v2/logs?offset=4&limit=3 HTTP/1.1" 200 OK
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 73dfae69b32d72d780ced90e37958cf855b1052b  | 
|--------|--------|

### Summary:
This PR adds pagination to logs retrieval across CLI, API, and logging components, and updates GitHub Actions workflows for architecture-specific builds.

**Key points**:
- Added pagination to logs retrieval in `py/cli/commands/server.py` by introducing `offset` and `limit` options.
- Updated `py/core/base/logging/run_logger.py` to support pagination in `get_info_logs` method.
- Modified `py/core/main/api/routes/management/base.py` to include `offset` and `limit` in `/logs` endpoint.
- Enhanced `py/core/main/services/management_service.py` to handle pagination in `alogs` method.
- Adjusted `py/sdk/server.py` to pass pagination parameters in `logs` method.
- Split build jobs by architecture in `.github/workflows/build-main.yml`.
- Changed runner configuration in `.github/workflows/py-ci-cd.yml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->