### PR TITLE
Standardized Datetime

### DIFF
--- a/py/core/base/abstractions/completion.py
+++ b/py/core/base/abstractions/completion.py
@@ -27,7 +27,7 @@ class MessageType(Enum):
 class CompletionRecord(BaseModel):
     message_id: UUID
     message_type: MessageType
-    timestamp: datetime = (datetime.now(timezone.utc),)
+    timestamp: datetime = datetime.now(timezone.utc)
     feedback: Optional[List[str]] = None
     score: Optional[List[float]] = None
     completion_start_time: Optional[datetime] = None

--- a/py/core/base/abstractions/completion.py
+++ b/py/core/base/abstractions/completion.py
@@ -3,7 +3,7 @@ Abstractions for LLM completions.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Optional
 from uuid import UUID
@@ -27,7 +27,7 @@ class MessageType(Enum):
 class CompletionRecord(BaseModel):
     message_id: UUID
     message_type: MessageType
-    timestamp: datetime = datetime.now()
+    timestamp: datetime = (datetime.now(timezone.utc),)
     feedback: Optional[List[str]] = None
     score: Optional[List[float]] = None
     completion_start_time: Optional[datetime] = None

--- a/py/core/base/abstractions/document.py
+++ b/py/core/base/abstractions/document.py
@@ -1,14 +1,13 @@
 """Abstractions for documents and their extractions."""
 
-import base64
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional, Union
 from uuid import UUID, uuid4
 
-from pydantic import Field, validator
+from pydantic import Field
 
 from .base import R2RSerializable
 
@@ -93,7 +92,7 @@ class DocumentInfo(R2RSerializable):
 
     def convert_to_db_entry(self):
         """Prepare the document info for database entry, extracting certain fields from metadata."""
-        now = datetime.now()
+        now = (datetime.now(timezone.utc),)
 
         return {
             "document_id": self.id,

--- a/py/core/base/abstractions/user.py
+++ b/py/core/base/abstractions/user.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -11,8 +11,8 @@ class Group(BaseModel):
     id: UUID = Field(default=None)
     name: str
     description: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=datetime.now(timezone.utc))
 
     class Config:
         from_attributes = True

--- a/py/core/base/abstractions/user.py
+++ b/py/core/base/abstractions/user.py
@@ -7,12 +7,16 @@ from pydantic import BaseModel, Field
 from ..utils import generate_id_from_label
 
 
+def utc_now():
+    return datetime.now(timezone.utc)
+
+
 class Group(BaseModel):
     id: UUID = Field(default=None)
     name: str
     description: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
-    updated_at: datetime = Field(default_factory=datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
 
     class Config:
         from_attributes = True

--- a/py/core/base/api/models/auth/responses.py
+++ b/py/core/base/api/models/auth/responses.py
@@ -2,11 +2,15 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from core.base.abstractions import Token
 from core.base.abstractions.base import R2RSerializable
 from core.base.api.models.base import ResultsWrapper
+
+
+def utc_now():
+    return datetime.now(timezone.utc)
 
 
 class TokenResponse(BaseModel):
@@ -19,8 +23,8 @@ class UserResponse(R2RSerializable):
     email: str
     is_active: bool = True
     is_superuser: bool = False
-    created_at: datetime = (datetime.now(timezone.utc),)
-    updated_at: datetime = (datetime.now(timezone.utc),)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
     is_verified: bool = False
     group_ids: list[UUID] = []
 

--- a/py/core/base/api/models/auth/responses.py
+++ b/py/core/base/api/models/auth/responses.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -19,8 +19,8 @@ class UserResponse(R2RSerializable):
     email: str
     is_active: bool = True
     is_superuser: bool = False
-    created_at: datetime = datetime.now()
-    updated_at: datetime = datetime.now()
+    created_at: datetime = (datetime.now(timezone.utc),)
+    updated_at: datetime = (datetime.now(timezone.utc),)
     is_verified: bool = False
     group_ids: list[UUID] = []
 

--- a/py/core/base/logging/run_logger.py
+++ b/py/core/base/logging/run_logger.py
@@ -204,7 +204,7 @@ class LocalRunLoggingProvider(RunLoggingProvider):
             RunInfoLog(
                 run_id=UUID(row[0]),
                 run_type=row[1],
-                timestamp=datetime.now(timezone.utc),
+                timestamp=datetime.now(timezone.utc).timestamp(),
                 user_id=UUID(row[3]),
             )
             for row in rows
@@ -569,7 +569,7 @@ class RedisRunLoggingProvider(RunLoggingProvider):
         key: str,
         value: str,
     ):
-        timestamp = datetime.now().timestamp()
+        timestamp = datetime.now(timezone.utc).timestamp()
         log_entry = {
             "timestamp": timestamp,
             "run_id": str(run_id),
@@ -586,7 +586,7 @@ class RedisRunLoggingProvider(RunLoggingProvider):
         run_type: RunType,
         user_id: UUID,
     ):
-        timestamp = datetime.now().timestamp()
+        timestamp = datetime.now(timezone.utc).timestamp()
         log_entry = {
             "timestamp": timestamp,
             "run_id": str(run_id),

--- a/py/core/base/logging/run_logger.py
+++ b/py/core/base/logging/run_logger.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from abc import abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -204,7 +204,7 @@ class LocalRunLoggingProvider(RunLoggingProvider):
             RunInfoLog(
                 run_id=UUID(row[0]),
                 run_type=row[1],
-                timestamp=datetime.fromisoformat(row[2]),
+                timestamp=datetime.now(timezone.utc),
                 user_id=UUID(row[3]),
             )
             for row in rows

--- a/py/core/main/services/ingestion_service.py
+++ b/py/core/main/services/ingestion_service.py
@@ -2,7 +2,7 @@ import base64
 import functools
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from typing import Any, Callable, Coroutine, Optional
 from uuid import UUID
@@ -203,8 +203,8 @@ class IngestionService(Service):
             version=version,
             size_in_bytes=file_size,
             ingestion_status="pending",
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         )
 
     @ingestion_step("parsing")

--- a/py/core/main/services/restructure_service.py
+++ b/py/core/main/services/restructure_service.py
@@ -4,12 +4,11 @@ from uuid import UUID
 
 from core.base import RunLoggingSingleton, RunManager
 from core.base.abstractions import GenerationConfig
+from core.telemetry.telemetry_decorator import telemetry_event
 
 from ..abstractions import R2RAgents, R2RPipelines, R2RPipes, R2RProviders
 from ..config import R2RConfig
 from .base import Service
-
-from core.telemetry.telemetry_decorator import telemetry_event
 
 logger = logging.getLogger(__name__)
 

--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -135,7 +135,7 @@ class RetrievalService(Service):
                     if isinstance(value, UUID):
                         vector_search_settings.filters[filter] = str(value)
 
-                completion_start_time = datetime.now()
+                completion_start_time = datetime.now(timezone.utc)
                 message_id = generate_id_from_label(
                     f"{query}-{completion_start_time.isoformat()}"
                 )
@@ -187,7 +187,9 @@ class RetrievalService(Service):
                     if hasattr(results[0], "completion")
                     else None
                 )
-                completion_record.completion_end_time = datetime.now()
+                completion_record.completion_end_time = datetime.now(
+                    timezone.utc
+                )
 
                 await self.logging_connection.log(
                     run_id=run_id,

--- a/py/core/pipes/retrieval/streaming_rag_pipe.py
+++ b/py/core/pipes/retrieval/streaming_rag_pipe.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Generator, Optional
 from uuid import UUID
 
@@ -89,7 +89,7 @@ class StreamingSearchRAGPipe(SearchRAGPipe):
 
             completion_record.search_results = search_results
             completion_record.llm_response = response
-            completion_record.completion_end_time = datetime.now()
+            completion_record.completion_end_time = datetime.now(timezone.utc)
             await self.log_completion_record(run_id, completion_record)
 
     async def _yield_chunks(

--- a/py/core/providers/database/group.py
+++ b/py/core/providers/database/group.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
@@ -36,7 +36,7 @@ class GroupMixin(DatabaseMixin):
         return bool(result)
 
     def create_group(self, name: str, description: str = "") -> GroupResponse:
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         query = f"""
             INSERT INTO {self._get_table_name('groups')} (name, description, created_at, updated_at)
             VALUES (:name, :description, :created_at, :updated_at)

--- a/py/core/providers/database/tokens.py
+++ b/py/core/providers/database/tokens.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from .base import DatabaseMixin, QueryBuilder
@@ -21,7 +21,7 @@ class BlacklistedTokensMixin(DatabaseMixin):
 
     def blacklist_token(self, token: str, current_time: datetime = None):
         if current_time is None:
-            current_time = datetime.utcnow()
+            current_time = datetime.now(timezone.utc)
 
         query, params = (
             QueryBuilder(self._get_table_name("blacklisted_tokens"))
@@ -47,7 +47,7 @@ class BlacklistedTokensMixin(DatabaseMixin):
         current_time: Optional[datetime] = None,
     ):
         if current_time is None:
-            current_time = datetime.utcnow()
+            current_time = datetime.now(timezone.utc)
         expiry_time = current_time - timedelta(hours=max_age_hours)
 
         query, params = (

--- a/py/sdk/models.py
+++ b/py/sdk/models.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, ClassVar, Dict, Optional, Type, Union
 from uuid import UUID
@@ -429,8 +429,8 @@ class UserResponse(BaseModel):
     email: str
     is_active: bool = True
     is_superuser: bool = False
-    created_at: datetime = datetime.now()
-    updated_at: datetime = datetime.now()
+    created_at: datetime = datetime.now(timezone.utc)
+    updated_at: datetime = datetime.now(timezone.utc)
     is_verified: bool = False
     group_ids: list[UUID] = []
 

--- a/py/tests/test_client.py
+++ b/py/tests/test_client.py
@@ -1,9 +1,9 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import Body, Depends
+from fastapi import Depends
 from fastapi.security import OAuth2PasswordBearer
 from fastapi.testclient import TestClient
 
@@ -33,8 +33,8 @@ def create_user(email: str, password: str):
         name="Test User",
         bio="Test Bio",
         profile_picture="http://example.com/pic.jpg",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
 
 
@@ -107,8 +107,8 @@ def mock_db():
             title=f"Document {i}",
             type="txt",
             group_ids=[uuid.uuid4()],
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
             version="1",
             metadata={},
             size_in_bytes=1000,

--- a/py/tests/test_groups.py
+++ b/py/tests/test_groups.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 import pytest
@@ -64,7 +64,7 @@ def test_group(pg_db):
 def test_user(pg_db):
 
     created_user = pg_db.relational.create_user(
-        email=f"test_{datetime.now().timestamp()}@example.com",
+        email=f"test_{datetime.now(timezone.utc).timestamp()}@example.com",
         password="password",
     )
     yield created_user

--- a/py/tests/test_groups_client.py
+++ b/py/tests/test_groups_client.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,7 +7,7 @@ from fastapi import Depends
 from fastapi.security import OAuth2PasswordBearer
 from fastapi.testclient import TestClient
 
-from core import R2RApp, R2RBuilder, R2REngine, Token, UserResponse
+from core import R2RApp, R2RBuilder, Token, UserResponse
 from core.base import GroupResponse
 from r2r import R2RClient
 
@@ -25,8 +25,8 @@ def create_superuser(email: str, password: str):
         name="Test Superuser",
         bio="Test Superuser Bio",
         profile_picture="http://example.com/superuser_pic.jpg",
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
 
 
@@ -66,8 +66,8 @@ def mock_db():
             name=user.name,
             bio=user.bio,
             profile_picture=user.profile_picture,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         )
 
     db.relational.update_user.side_effect = mock_update_user
@@ -77,8 +77,8 @@ def mock_db():
             group_id=uuid.uuid4(),
             name=kwargs.get("name", "Test Group"),
             description=kwargs.get("description", "A test group"),
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         ).dict()
 
     db.relational.create_group = MagicMock(side_effect=mock_create_group)
@@ -88,8 +88,8 @@ def mock_db():
             group_id=group_id,
             name="Test Group",
             description="A test group",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         ).dict()
 
     db.relational.get_group = MagicMock(side_effect=mock_get_group)
@@ -99,8 +99,8 @@ def mock_db():
             group_id=group_id,
             name=name,
             description=description,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         ).dict()
 
     db.relational.update_group = MagicMock(side_effect=mock_update_group)
@@ -113,8 +113,8 @@ def mock_db():
                 group_id=uuid.uuid4(),
                 name=f"Group {i}",
                 description=f"Description {i}",
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             ).dict()
             for i in range(1, 3)
         ]
@@ -132,8 +132,8 @@ def mock_db():
                 is_active=True,
                 is_superuser=True,
                 is_verified=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             ),
             UserResponse(
                 id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
@@ -142,8 +142,8 @@ def mock_db():
                 is_active=True,
                 is_superuser=True,
                 is_verified=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             ),
         ]
     )
@@ -155,8 +155,8 @@ def mock_db():
                 "group_id": str(uuid.uuid4()),
                 "name": f"Group {i}",
                 "description": f"Description {i}",
-                "created_at": datetime.utcnow(),
-                "updated_at": datetime.utcnow(),
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
                 "user_count": i * 2,
                 "document_count": i * 2,
             }

--- a/py/tests/test_ingestion_service.py
+++ b/py/tests/test_ingestion_service.py
@@ -2,7 +2,7 @@ import asyncio
 import io
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -126,8 +126,8 @@ async def test_ingest_duplicate_document(ingestion_service, mock_vector_db):
             metadata={},
             title=str(document.id),
             type="txt",
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
             ingestion_status="success",
         )
     ]


### PR DESCRIPTION
Standardizes how we define time across the codebase to use `datetime.now(timezone.utc)`, as recommended per the [Python 3.9 documentation](https://docs.python.org/3.9/library/datetime.html).
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4122dabb29f10cd20a6008d56af1047a957370aa  | 
|--------|--------|

### Summary:
Standardized datetime usage to `datetime.now(timezone.utc)` and introduced `utc_now` function for consistent timezone handling across the codebase.

**Key points**:
- Standardized datetime usage to `datetime.now(timezone.utc)` across the codebase for consistent timezone-aware handling.
- Added `utc_now` function in `py/core/base/abstractions/user.py` and `py/core/base/api/models/auth/responses.py`.
- Updated `Group` class in `py/core/base/abstractions/user.py` to use `utc_now` for `created_at` and `updated_at`.
- Modified `UserResponse` class in `py/core/base/api/models/auth/responses.py` to use `utc_now` for `created_at` and `updated_at`.
- Replaced `datetime.now()` with `datetime.now(timezone.utc)` in various files for consistent handling.
- Updated test files to use `datetime.now(timezone.utc)` for creating mock data with timestamps.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->