### PR TITLE
Separate File Provider and Relational Database Provider

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -8,7 +8,7 @@
 
 <img width="1041" alt="r2r" src="https://github.com/user-attachments/assets/b6ee6a78-5d37-496d-ae10-ce18eee7a1d6">
 <h3 align="center">
-The Elasticsearch for RAG. 
+The Elasticsearch for RAG.
 
 Build, scale, and deploy production-ready Retrieval-Augmented Generation applications.
 </h3>

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -103,8 +103,7 @@ services:
       hatchet-setup-config:
         condition: service_completed_successfully
   r2r:
-    # image: ${R2R_IMAGE:-ragtoriches/prod:main-unstructured}
-    image: r2r/test
+    image: ${R2R_IMAGE:-ragtoriches/prod:main-unstructured}
     build:
       context: .
       args:

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -103,7 +103,8 @@ services:
       hatchet-setup-config:
         condition: service_completed_successfully
   r2r:
-    image: ${R2R_IMAGE:-ragtoriches/prod:main-unstructured}
+    # image: ${R2R_IMAGE:-ragtoriches/prod:main-unstructured}
+    image: r2r/test
     build:
       context: .
       args:

--- a/py/core/base/__init__.py
+++ b/py/core/base/__init__.py
@@ -31,6 +31,8 @@ __all__ = [
     # Exception abstractions
     "R2RDocumentProcessingError",
     "R2RException",
+    # File abstractions
+    "FileConfig",
     # KG abstractions
     "Entity",
     "KGExtraction",

--- a/py/core/base/__init__.py
+++ b/py/core/base/__init__.py
@@ -31,8 +31,6 @@ __all__ = [
     # Exception abstractions
     "R2RDocumentProcessingError",
     "R2RException",
-    # File abstractions
-    "FileConfig",
     # KG abstractions
     "Entity",
     "KGExtraction",
@@ -130,6 +128,9 @@ __all__ = [
     # Embedding provider
     "EmbeddingConfig",
     "EmbeddingProvider",
+    # File provider
+    "FileConfig",
+    "FileProvider",
     # Knowledge Graph provider
     "KGConfig",
     "KGProvider",

--- a/py/core/main/api/ingestion_router.py
+++ b/py/core/main/api/ingestion_router.py
@@ -142,7 +142,7 @@ class IngestionRouter(BaseRouter):
                 )
 
                 file_name = file_data["filename"]
-                self.service.providers.database.relational.store_file(
+                self.service.providers.file.store_file(
                     document_id,
                     file_name,
                     file_content,

--- a/py/core/main/assembly/factory.py
+++ b/py/core/main/assembly/factory.py
@@ -199,6 +199,29 @@ class R2RProviderFactory:
         return embedding_provider
 
     @staticmethod
+    def create_file_provider(
+        file_config: FileConfig,
+        db_provider: Any,
+        *args,
+        **kwargs,
+    ) -> FileProvider:
+        file_provider: Optional[FileProvider] = None
+        if file_config.provider == "postgres":
+            from core.providers import PostgresFileProvider
+
+            logger.info("Initializing PostgresFileProvider")
+
+            file_provider = PostgresFileProvider(db_provider)
+        elif file_config.provider is None:
+            return None
+        else:
+            raise ValueError(
+                f"File provider {file_config.provider} not supported."
+            )
+
+        return file_provider
+
+    @staticmethod
     def create_llm_provider(
         llm_config: CompletionConfig, *args, **kwargs
     ) -> CompletionProvider:
@@ -245,28 +268,6 @@ class R2RProviderFactory:
         else:
             raise ValueError(
                 f"KG provider {kg_config.provider} not supported."
-            )
-
-    @staticmethod
-    def create_file_provider(
-        file_config: FileConfig,
-        database_provider: DatabaseProvider,
-        *args,
-        **kwargs,
-    ) -> FileProvider:
-        if file_config.provider == "postgres":
-            from core.providers.database.file import PostgresFileProvider
-
-            return PostgresFileProvider(
-                file_config,
-                database_provider.vx,
-                database_provider.collection_name,
-            )
-        elif file_config.provider is None:
-            return None
-        else:
-            raise ValueError(
-                f"File provider {file_config.provider} not supported."
             )
 
     def create_providers(

--- a/py/core/main/assembly/factory.py
+++ b/py/core/main/assembly/factory.py
@@ -211,7 +211,7 @@ class R2RProviderFactory:
 
             logger.info("Initializing PostgresFileProvider")
 
-            file_provider = PostgresFileProvider(db_provider)
+            file_provider = PostgresFileProvider(file_config, db_provider)
         elif file_config.provider is None:
             return None
         else:

--- a/py/core/providers/__init__.py
+++ b/py/core/providers/__init__.py
@@ -7,6 +7,7 @@ from .embeddings import (
     OllamaEmbeddingProvider,
     OpenAIEmbeddingProvider,
 )
+from .file import PostgresFileProvider
 from .kg import Neo4jKGProvider
 from .llm import LiteCompletionProvider, OpenAICompletionProvider
 from .orchestration import HatchetOrchestrationProvider
@@ -28,6 +29,8 @@ __all__ = [
     "LiteLLMEmbeddingProvider",
     "OllamaEmbeddingProvider",
     "OpenAIEmbeddingProvider",
+    # File
+    "PostgresFileProvider",
     # KG
     "Neo4jKGProvider",
     # Orchestration

--- a/py/core/providers/database/base.py
+++ b/py/core/providers/database/base.py
@@ -2,9 +2,8 @@ from contextlib import contextmanager
 from typing import Any, Callable, Iterator, Optional, Union
 
 from psycopg2.extensions import connection as pg_connection
-from sqlalchemy import text
-
-from uuid import UUID
+from psycopg2.extensions import lobject
+from sqlalchemy import TextClause, text
 
 from .vecs import Client
 
@@ -76,7 +75,6 @@ class QueryBuilder:
             query += f" LIMIT {self.limit_value}"
 
         return query, self.params
-    
 
 
 class DatabaseMixin:
@@ -116,3 +114,36 @@ class DatabaseMixin:
 
     def create_table(self):
         raise NotImplementedError("Subclasses must implement this method")
+
+    @contextmanager
+    def get_lobject(self, oid: int = 0, mode: str = "rb") -> Iterator[lobject]:
+        with self.get_connection() as conn:
+            lobj = conn.lobject(oid, mode)
+            try:
+                yield lobj
+            finally:
+                lobj.close()
+
+    def read_lob(self, oid: int) -> bytes:
+        with self.get_lobject(oid, "rb") as lobj:
+            return lobj.read()
+
+    def delete_lob(self, oid: int) -> None:
+        with self.get_connection() as conn:
+            conn.lobject(oid, "wb").unlink()
+
+    def execute_lob_query(
+        self,
+        query: Union[str, TextClause],
+        params: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                if isinstance(query, TextClause):
+                    query = query.text
+                elif not isinstance(query, str):
+                    raise TypeError(
+                        "Query must be a string or SQLAlchemy TextClause object"
+                    )
+                cur.execute(query, params or {})
+                return cur.fetchone()

--- a/py/core/providers/database/base.py
+++ b/py/core/providers/database/base.py
@@ -77,27 +77,6 @@ class QueryBuilder:
 
         return query, self.params
     
-    def upsert_file(self, document_id: UUID, file_name: str, file_oid: int, file_size: int, file_type: Optional[str] = None) -> None:
-        query_builder = QueryBuilder(self._get_table_name('file_storage'))
-        query, params = query_builder.insert({
-            "document_id": document_id,
-            "file_name": file_name,
-            "file_oid": file_oid,
-            "file_size": file_size,
-            "file_type": file_type
-        }).build()
-        
-        # Add ON CONFLICT clause
-        query += " ON CONFLICT (document_id) DO UPDATE SET " \
-                "file_name = EXCLUDED.file_name, " \
-                "file_oid = EXCLUDED.file_oid, " \
-                "file_size = EXCLUDED.file_size, " \
-                "file_type = EXCLUDED.file_type, " \
-                "updated_at = NOW()"
-        
-        result = self.execute_query(text(query), params)
-        if not result:
-            raise R2RException(status_code=500, message=f"Failed to upsert file for document {document_id}")
 
 
 class DatabaseMixin:

--- a/py/core/providers/database/base.py
+++ b/py/core/providers/database/base.py
@@ -1,9 +1,6 @@
-from contextlib import contextmanager
-from typing import Any, Callable, Iterator, Optional, Union
+from typing import Any, Optional, Union
 
-from psycopg2.extensions import connection as pg_connection
-from psycopg2.extensions import lobject
-from sqlalchemy import TextClause, text
+from sqlalchemy import text
 
 from .vecs import Client
 
@@ -78,72 +75,13 @@ class QueryBuilder:
 
 
 class DatabaseMixin:
-    vx: Client
-
     def _get_table_name(self, base_name: str) -> str:
-        raise NotImplementedError("Subclasses must implement this method")
-
-    @contextmanager
-    def get_session(self) -> Iterator[Any]:
         raise NotImplementedError("Subclasses must implement this method")
 
     def execute_query(
         self, query: Union[str, text], params: Optional[dict[str, Any]] = None
-    ) -> Any:
-        with self.get_session() as sess:
-            if isinstance(query, str):
-                query = text(query)
-            result = sess.execute(query, params or {})
-            sess.commit()
-            return result
-
-    @contextmanager
-    def get_connection(self) -> Iterator[pg_connection]:
-        with self.get_session() as sess:
-            connection = sess.connection().connection
-            try:
-                yield connection
-            finally:
-                connection.close()
-
-    def execute_with_connection(
-        self, operation: Callable[[pg_connection], Any]
-    ) -> Any:
-        with self.get_connection() as conn:
-            return operation(conn)
+    ):
+        raise NotImplementedError("Subclasses must implement this method")
 
     def create_table(self):
         raise NotImplementedError("Subclasses must implement this method")
-
-    @contextmanager
-    def get_lobject(self, oid: int = 0, mode: str = "rb") -> Iterator[lobject]:
-        with self.get_connection() as conn:
-            lobj = conn.lobject(oid, mode)
-            try:
-                yield lobj
-            finally:
-                lobj.close()
-
-    def read_lob(self, oid: int) -> bytes:
-        with self.get_lobject(oid, "rb") as lobj:
-            return lobj.read()
-
-    def delete_lob(self, oid: int) -> None:
-        with self.get_connection() as conn:
-            conn.lobject(oid, "wb").unlink()
-
-    def execute_lob_query(
-        self,
-        query: Union[str, TextClause],
-        params: Optional[dict[str, Any]] = None,
-    ) -> Any:
-        with self.get_connection() as conn:
-            with conn.cursor() as cur:
-                if isinstance(query, TextClause):
-                    query = query.text
-                elif not isinstance(query, str):
-                    raise TypeError(
-                        "Query must be a string or SQLAlchemy TextClause object"
-                    )
-                cur.execute(query, params or {})
-                return cur.fetchone()

--- a/py/core/providers/database/base.py
+++ b/py/core/providers/database/base.py
@@ -1,6 +1,10 @@
-from typing import Any, Optional, Union
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional, Union
 
+from psycopg2.extensions import connection as pg_connection
 from sqlalchemy import text
+
+from uuid import UUID
 
 from .vecs import Client
 
@@ -72,16 +76,64 @@ class QueryBuilder:
             query += f" LIMIT {self.limit_value}"
 
         return query, self.params
+    
+    def upsert_file(self, document_id: UUID, file_name: str, file_oid: int, file_size: int, file_type: Optional[str] = None) -> None:
+        query_builder = QueryBuilder(self._get_table_name('file_storage'))
+        query, params = query_builder.insert({
+            "document_id": document_id,
+            "file_name": file_name,
+            "file_oid": file_oid,
+            "file_size": file_size,
+            "file_type": file_type
+        }).build()
+        
+        # Add ON CONFLICT clause
+        query += " ON CONFLICT (document_id) DO UPDATE SET " \
+                "file_name = EXCLUDED.file_name, " \
+                "file_oid = EXCLUDED.file_oid, " \
+                "file_size = EXCLUDED.file_size, " \
+                "file_type = EXCLUDED.file_type, " \
+                "updated_at = NOW()"
+        
+        result = self.execute_query(text(query), params)
+        if not result:
+            raise R2RException(status_code=500, message=f"Failed to upsert file for document {document_id}")
 
 
 class DatabaseMixin:
+    vx: Client
+
     def _get_table_name(self, base_name: str) -> str:
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @contextmanager
+    def get_session(self) -> Iterator[Any]:
         raise NotImplementedError("Subclasses must implement this method")
 
     def execute_query(
         self, query: Union[str, text], params: Optional[dict[str, Any]] = None
-    ):
-        raise NotImplementedError("Subclasses must implement this method")
+    ) -> Any:
+        with self.get_session() as sess:
+            if isinstance(query, str):
+                query = text(query)
+            result = sess.execute(query, params or {})
+            sess.commit()
+            return result
+
+    @contextmanager
+    def get_connection(self) -> Iterator[pg_connection]:
+        with self.get_session() as sess:
+            connection = sess.connection().connection
+            try:
+                yield connection
+            finally:
+                connection.close()
+
+    def execute_with_connection(
+        self, operation: Callable[[pg_connection], Any]
+    ) -> Any:
+        with self.get_connection() as conn:
+            return operation(conn)
 
     def create_table(self):
         raise NotImplementedError("Subclasses must implement this method")

--- a/py/core/providers/database/postgres.py
+++ b/py/core/providers/database/postgres.py
@@ -6,12 +6,10 @@ from core.base import (
     CryptoProvider,
     DatabaseConfig,
     DatabaseProvider,
-    FileProvider,
     RelationalDBProvider,
     VectorDBProvider,
 )
 
-from .file import PostgresFileProvider
 from .relational import PostgresRelationalDBProvider
 from .vecs import Client, create_client
 from .vector import PostgresVectorDBProvider
@@ -107,12 +105,5 @@ class PostgresDBProvider(DatabaseProvider):
             self.config,
             vx=self.vx,
             crypto_provider=self.crypto_provider,
-            collection_name=self.collection_name,
-        )
-
-    def _initialize_file_provider(self) -> FileProvider:
-        return PostgresFileProvider(
-            self.config,
-            vx=self.vx,
             collection_name=self.collection_name,
         )

--- a/py/core/providers/database/relational.py
+++ b/py/core/providers/database/relational.py
@@ -4,7 +4,6 @@ from sqlalchemy import text
 
 from core.providers.database.base import DatabaseMixin, execute_query
 from core.providers.database.document import DocumentMixin
-from core.providers.database.file import FileMixin
 from core.providers.database.group import GroupMixin
 from core.providers.database.tokens import BlacklistedTokensMixin
 from core.providers.database.user import UserMixin
@@ -17,7 +16,6 @@ class PostgresRelationalDBProvider(
     UserMixin,
     BlacklistedTokensMixin,
     DocumentMixin,
-    FileMixin,
 ):
     def __init__(self, config, vx, crypto_provider, collection_name):
         self.config = config

--- a/py/core/providers/file/__init__.py
+++ b/py/core/providers/file/__init__.py
@@ -1,0 +1,3 @@
+from .postgres import PostgresFileProvider
+
+__all__ = ["PostgresFileProvider"]

--- a/py/core/providers/file/postgres.py
+++ b/py/core/providers/file/postgres.py
@@ -1,53 +1,100 @@
 import io
 import logging
 from contextlib import contextmanager
-from typing import BinaryIO, Optional
+from typing import Any, BinaryIO, Callable, Iterator, Optional, Union
 from uuid import UUID
 
 from psycopg2 import Error as PostgresError
+from psycopg2.extensions import connection as pg_connection
+from psycopg2.extensions import lobject
 from sqlalchemy import text
+from sqlalchemy.sql.elements import TextClause
 
 from core.base import R2RException
-from core.base.providers import DatabaseConfig, FileProvider
-from core.providers.database.vecs import Client
-
-from .base import DatabaseMixin
+from core.base.providers import FileProvider
+from core.providers.database.postgres import PostgresDBProvider
 
 logger = logging.getLogger(__name__)
 
 
-class FileInfo:
-    def __init__(
+class PostgresFileProvider(FileProvider):
+    def __init__(self, db_provider: PostgresDBProvider):
+        super().__init__()
+        self.db_provider = db_provider
+        self.vx = db_provider.vx
+        self.create_table()
+
+    def _get_table_name(self, base_name: str) -> str:
+        return f"{base_name}"
+
+    @contextmanager
+    def get_session(self) -> Iterator[Any]:
+        with self.vx.Session() as sess:
+            yield sess
+
+    def execute_query(
+        self, query: Union[str, text], params: Optional[dict[str, Any]] = None
+    ) -> Any:
+        with self.get_session() as sess:
+            if isinstance(query, str):
+                query = text(query)
+            result = sess.execute(query, params or {})
+            sess.commit()
+            return result
+
+    @contextmanager
+    def get_connection(self) -> Iterator[pg_connection]:
+        with self.get_session() as sess:
+            connection = sess.connection().connection
+            try:
+                yield connection
+            finally:
+                connection.close()
+
+    def execute_with_connection(
+        self, operation: Callable[[pg_connection], Any]
+    ) -> Any:
+        with self.get_connection() as conn:
+            return operation(conn)
+
+    @contextmanager
+    def get_lobject(self, oid: int = 0, mode: str = "rb") -> Iterator[lobject]:
+        with self.get_connection() as conn:
+            lobj = conn.lobject(oid, mode)
+            try:
+                yield lobj
+            finally:
+                lobj.close()
+
+    def read_lob(self, oid: int) -> bytes:
+        with self.get_lobject(oid, "rb") as lobj:
+            return lobj.read()
+
+    def delete_lob(self, oid: int) -> None:
+        with self.get_connection() as conn:
+            conn.lobject(oid, "wb").unlink()
+
+    def execute_lob_query(
         self,
-        document_id: UUID,
-        file_name: str,
-        file_oid: int,
-        file_size: int,
-        file_type: Optional[str],
-        created_at: str,
-        updated_at: str,
-    ):
-        self.document_id = document_id
-        self.file_name = file_name
-        self.file_oid = file_oid
-        self.file_size = file_size
-        self.file_type = file_type
-        self.created_at = created_at
-        self.updated_at = updated_at
+        query: Union[str, TextClause],
+        params: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                if isinstance(query, TextClause):
+                    query = query.text
+                elif not isinstance(query, str):
+                    raise TypeError(
+                        "Query must be a string or SQLAlchemy TextClause object"
+                    )
+                cur.execute(query, params or {})
+                return cur.fetchone()
 
-    def convert_to_db_entry(self):
-        return {
-            "document_id": self.document_id,
-            "file_name": self.file_name,
-            "file_oid": self.file_oid,
-            "file_size": self.file_size,
-            "file_type": self.file_type,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-        }
+    @contextmanager
+    def get_session(self):
+        with self.vx.Session() as sess:
+            yield sess
 
-
-class FileMixin(DatabaseMixin):
     def create_table(self):
         query = text(
             f"""
@@ -60,8 +107,6 @@ class FileMixin(DatabaseMixin):
             created_at TIMESTAMPTZ DEFAULT NOW(),
             updated_at TIMESTAMPTZ DEFAULT NOW()
         );
-        CREATE INDEX IF NOT EXISTS idx_file_name_{self.collection_name}
-        ON {self._get_table_name('file_storage')} (file_name);
         """
         )
         try:
@@ -110,7 +155,6 @@ class FileMixin(DatabaseMixin):
                 message=f"Failed to upsert file for document {document_id}",
             )
 
-    # TODO: Move this to the DatabaseMixin class. Causing problems due to async context management with lobjects
     def store_file(self, document_id, file_name, file_content, file_type=None):
         file_size = file_content.getbuffer().nbytes
 
@@ -137,7 +181,7 @@ class FileMixin(DatabaseMixin):
             raise R2RException(
                 status_code=500,
                 message=f"Failed to store file for document {document_id}: {e}",
-            )
+            ) from e
 
     def retrieve_file(
         self, document_id: UUID
@@ -240,45 +284,3 @@ class FileMixin(DatabaseMixin):
             }
             for row in results
         ]
-
-
-class PostgresFileProvider(FileProvider, FileMixin):
-    def __init__(
-        self, config: DatabaseConfig, vx: Client, collection_name: str
-    ):
-        FileProvider.__init__(self, config)
-        self.vx = vx
-        self.collection_name = collection_name
-
-    @contextmanager
-    def get_session(self):
-        with self.vx.Session() as sess:
-            yield sess
-
-    def create_table(self):
-        return FileMixin.create_table(self)
-
-    def store_file(self, document_id, file_name, file_content, file_type=None):
-        return FileMixin.store_file(
-            self, document_id, file_name, file_content, file_type
-        )
-
-    def retrieve_file(self, document_id):
-        return FileMixin.retrieve_file(self, document_id)
-
-    def delete_file(self, document_id):
-        return self.delete_file(document_id)
-
-    def get_files_overview(
-        self,
-        filter_document_ids=None,
-        filter_file_names=None,
-        offset=0,
-        limit=100,
-    ):
-        return FileMixin.get_files_overview(
-            self, filter_document_ids, filter_file_names, offset, limit
-        )
-
-    def _get_table_name(self, base_name: str) -> str:
-        return f"{base_name}_{self.collection_name}"

--- a/py/core/providers/file/postgres.py
+++ b/py/core/providers/file/postgres.py
@@ -10,7 +10,7 @@ from psycopg2.extensions import lobject
 from sqlalchemy import text
 from sqlalchemy.sql.elements import TextClause
 
-from core.base import R2RException
+from core.base import FileConfig, R2RException
 from core.base.providers import FileProvider
 from core.providers.database.postgres import PostgresDBProvider
 
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 
 
 class PostgresFileProvider(FileProvider):
-    def __init__(self, db_provider: PostgresDBProvider):
+    def __init__(self, config: FileConfig, db_provider: PostgresDBProvider):
         super().__init__()
+        self.config = config
         self.db_provider = db_provider
         self.vx = db_provider.vx
         self.create_table()
@@ -89,11 +90,6 @@ class PostgresFileProvider(FileProvider):
                     )
                 cur.execute(query, params or {})
                 return cur.fetchone()
-
-    @contextmanager
-    def get_session(self):
-        with self.vx.Session() as sess:
-            yield sess
 
     def create_table(self):
         query = text(

--- a/py/r2r.toml
+++ b/py/r2r.toml
@@ -8,8 +8,8 @@ default_admin_email = "admin@example.com"
 default_admin_password = "change_me_immediately"
 
 [chunking]
-provider = "unstructured_local"
-method = "by_title"
+provider = "r2r"
+method = "recursive"
 
 [chunking.chunking_config]
 
@@ -54,7 +54,7 @@ log_table = "logs"
 log_info_table = "log_info"
 
 [parsing]
-provider = "unstructured_local"
+provider = "r2r"
 excluded_parsers = ["mp4"]
 
 [prompt]

--- a/py/r2r.toml
+++ b/py/r2r.toml
@@ -8,8 +8,8 @@ default_admin_email = "admin@example.com"
 default_admin_password = "change_me_immediately"
 
 [chunking]
-provider = "r2r"
-method = "recursive"
+provider = "unstructured_local"
+method = "by_title"
 
 [chunking.chunking_config]
 
@@ -54,7 +54,7 @@ log_table = "logs"
 log_info_table = "log_info"
 
 [parsing]
-provider = "r2r"
+provider = "unstructured_local"
 excluded_parsers = ["mp4"]
 
 [prompt]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 58875bc10e094fd16658d2594d7ebf20634f2824  | 
|--------|--------|

### Summary:
Refactor `FileMixin` and `DatabaseMixin` for improved error handling and large object management, introducing `PostgresFileProvider` and updating `IngestionRouter`.

**Key points**:
- Refactor `FileMixin` for better error handling using `R2RException`.
- Use `self.execute_query` for database operations in `FileMixin`.
- Introduce `PostgresFileProvider` for file handling in `py/core/providers/file/postgres.py`.
- Update `DatabaseMixin` with large object handling methods: `get_lobject`, `read_lob`, `delete_lob`, `execute_lob_query`.
- Remove session handling in `FileMixin` methods.
- Update `IngestionRouter` to use `self.service.providers.file.store_file`.
- Remove `FileMixin` from `PostgresRelationalDBProvider`.
- Minor updates in `py/compose.yaml` and `py/r2r.toml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->