### PR TITLE
Add support for external Agent Factory

### DIFF
--- a/py/core/main/assembly/builder.py
+++ b/py/core/main/assembly/builder.py
@@ -223,7 +223,7 @@ class R2RBuilder:
         self.kg_enrichment_pipeline = pipeline
         return self
 
-    def with_assistant_factory(self, factory: R2RAgentFactory):
+    def with_assistant_factory(self, factory: Type[R2RAgentFactory]):
         self.assistant_factory_override = factory
         return self
 
@@ -274,7 +274,9 @@ class R2RBuilder:
             **kwargs,
         )
 
-        assistant_factory = self.assistant_factory_override or R2RAgentFactory(
+        assistant_factory = self.assistant_factory_override(
+            self.config, providers, pipelines
+        ) or R2RAgentFactory(
             self.config, providers, pipelines
         )
         agents = assistant_factory.create_agents(


### PR DESCRIPTION
An attempt to fix #1055 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4843353bb6806817be46cfbb9d646f7027446347  | 
|--------|--------|

### Summary:
Adds support for external `Agent Factory` in `R2RBuilder` by modifying `with_assistant_factory` and `build` methods in `py/core/main/assembly/builder.py`.

**Key points**:
- Updated `R2RBuilder.with_assistant_factory` to accept `Type[R2RAgentFactory]`.
- Modified `R2RBuilder.build` to instantiate `assistant_factory` using the override or default `R2RAgentFactory`.
- Enables external `Agent Factory` injection for flexible agent creation.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->