### PR TITLE
Fix Restructure Enum

### DIFF
--- a/py/cli/commands/server.py
+++ b/py/cli/commands/server.py
@@ -223,9 +223,10 @@ def serve(
     """Start the R2R server."""
     load_dotenv()
 
-    if image and build:
+    if image:
         os.environ["R2R_IMAGE"] = image
-        os.system(f"docker build -t {image} -f Dockerfile.unstructured .")
+        if build:
+            os.system(f"docker build -t {image} -f Dockerfile.unstructured .")
 
     if config_path:
         config_path = os.path.abspath(config_path)

--- a/py/core/providers/database/document.py
+++ b/py/core/providers/database/document.py
@@ -1,7 +1,12 @@
 from typing import Optional, Union
 from uuid import UUID
 
-from core.base import DocumentInfo, DocumentType, IngestionStatus
+from core.base import (
+    DocumentInfo,
+    DocumentType,
+    IngestionStatus,
+    RestructureStatus,
+)
 
 from .base import DatabaseMixin
 
@@ -123,7 +128,7 @@ class DocumentMixin(DatabaseMixin):
                 ingestion_status=IngestionStatus(row[8]),
                 created_at=row[9],
                 updated_at=row[10],
-                restructuring_status=row[11],
+                restructuring_status=RestructureStatus(row[11]),
             )
             for row in results
         ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 70d275dd33912c273cc79d4db178e9a7f9b3d60f  | 
|--------|--------|

### Summary:
Modified `serve` function to conditionally build Docker image and updated `get_documents_overview` to use `RestructureStatus` enum.

**Key points**:
- In `py/cli/commands/server.py`, modified `serve` function to build Docker image only if `build` flag is set.
- In `py/core/providers/database/document.py`, updated `get_documents_overview` to use `RestructureStatus` enum for `restructuring_status`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->