### PR TITLE
Fix docker commands

### DIFF
--- a/py/cli/commands/server.py
+++ b/py/cli/commands/server.py
@@ -262,36 +262,6 @@ def serve(
             import time
             import webbrowser
 
-            # Wait for R2R service to be healthy
-            click.echo("Waiting for R2R service to be ready...")
-            while True:
-                result = subprocess.run(
-                    ["docker", "compose", "-p", project_name, "ps", "-q", "r2r"],
-                    capture_output=True,
-                    text=True,
-                )
-                print("result = ", result)
-                if result.returncode == 0 and result.stdout.strip():
-                    container_id = result.stdout.strip()
-                    health_check = subprocess.run(
-                        [
-                            "docker",
-                            "inspect",
-                            "--format",
-                            "{{.State.Health.Status}}",
-                            container_id,
-                        ],
-                        capture_output=True,
-                        text=True,
-                    )
-                    if health_check.stdout.strip() == "healthy":
-                        click.echo("R2R service is ready!")
-                        break
-                else:
-                    click.echo(
-                        f"R2R service not found or not ready. Error: {result.stderr}"
-                    )
-                time.sleep(5)
             for i in range(3, 0, -1):
                 print(f"Navigating to dashboard in {i} seconds...")
                 time.sleep(1)

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "r2r"
 readme = "README.md"
-version = "3.1.2"
+version = "3.1.12"
 description = "SciPhi R2R"
 authors = ["Owen Colegrove <owen@sciphi.ai>"]
 license = "MIT"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ae85c95f0813eff03fe68ca01329a68157e472ee  | 
|--------|--------|

### Summary:
This PR refactors Docker command execution by removing the R2R service health check loop and splitting the command into separate pull and up commands, while updating the project version.

**Key points**:
- Removed R2R service health check loop in `py/cli/commands/server.py`.
- Split Docker command into `pull_command` and `up_command` in `py/cli/utils/docker_utils.py`.
- Updated `run_docker_serve` to execute `pull_command` and `up_command` separately.
- Changed version from `3.1.2` to `3.1.12` in `py/pyproject.toml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->