### PR TITLE
Improve CLI to better handle delay in services becoming available

### DIFF
--- a/py/cli/commands/server.py
+++ b/py/cli/commands/server.py
@@ -13,6 +13,7 @@ from cli.utils.docker_utils import (
     remove_r2r_network,
     run_docker_serve,
     run_local_serve,
+    wait_for_container_health,
 )
 from cli.utils.timer import timer
 
@@ -259,16 +260,19 @@ def serve(
             click.echo("Test environment detected. Skipping browser open.")
         else:
             # Open browser after Docker setup is complete
-            import time
             import webbrowser
 
-            for i in range(3, 0, -1):
-                print(f"Navigating to dashboard in {i} seconds...")
-                time.sleep(1)
+            click.echo("Waiting for all services to become healthy...")
+
+            if not wait_for_container_health(project_name, "r2r"):
+                click.secho(
+                    "r2r container failed to become healthy.", fg="red"
+                )
 
             traefik_port = os.environ.get("R2R_DASHBOARD_PORT", "80")
             url = f"http://localhost:{traefik_port}"
-            click.echo(f"Opening browser to {url}")
+
+            click.secho(f"Navigating to R2R application at {url}.", fg="blue")
             webbrowser.open(url)
     else:
         run_local_serve(host, port, config_name, config_path)

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -185,7 +185,7 @@ services:
       - r2r-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${PORT:-7272}/v2/health"]
-      interval: 10s
+      interval: 6s
       timeout: 5s
       retries: 5
     restart: on-failure
@@ -218,8 +218,6 @@ services:
     image: emrgntcmplxty/r2r-dashboard:latest
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:${R2R_DASHBOARD_PORT:-8001}/r2r-api
-    depends_on:
-      - r2r
     networks:
       - r2r-network
     labels:

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "r2r"
 readme = "README.md"
-version = "3.1.12"
+version = "3.1.13"
 description = "SciPhi R2R"
 authors = ["Owen Colegrove <owen@sciphi.ai>"]
 license = "MIT"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 87d435522693efc7d2c358dfcb647e9fe9555725  | 
|--------|--------|

### Summary:
Improved CLI to wait for Docker container health before proceeding, adjusted health check intervals, and updated project version.

**Key points**:
- Added `wait_for_container_health` function in `py/cli/utils/docker_utils.py` to check Docker container health status.
- Modified `serve` function in `py/cli/commands/server.py` to wait for container health before opening the browser.
- Changed health check interval from 10s to 6s in `py/compose.yaml` for faster service readiness.
- Removed `depends_on` for `r2r-dashboard` in `py/compose.yaml`.
- Updated version to `3.1.13` in `py/pyproject.toml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->