### PR TITLE
Pull request to resolve issue with initial Docker Compose script not recognizing spaces in user profile file paths

### DIFF
--- a/py/cli/utils/docker_utils.py
+++ b/py/cli/utils/docker_utils.py
@@ -287,9 +287,11 @@ def check_set_docker_env_vars(
 
 def set_config_env_vars(obj):
     if config_path := obj.get("config_path"):
-        os.environ["CONFIG_PATH"] = config_path
+        os.environ["CONFIG_PATH"] = f'"{config_path}"'
     else:
-        os.environ["CONFIG_NAME"] = obj.get("config_name") or "default"
+        config_name = obj.get("config_name") or "default"
+        os.environ["CONFIG_NAME"] = f'"{config_name}"'
+        
 
 
 def get_compose_files():


### PR DESCRIPTION
Origin of the issue came from an attempted initial installation that failed on the 

`r2r serve --docker --config-name=local_llm`

installation command that failed due to the local user's profile having a space in the file path

`docker compose C:\Users\userName withSpace\AppData\Local\Programs\Python\Python312\Lib\site-packages\cli\utils....\compose.yaml`

causing the Docker Compose script to break due to the space causing the command to become unrecognized.

Proposed fix modifies the 

`def set_config_env_vars(obj):
    if config_path := obj.get("config_path"):
        os.environ["CONFIG_PATH"] = config_path
    else:
        os.environ["CONFIG_NAME"] = obj.get("config_name") or "default"`

method to wrap the resulting strings from os.environ inside quotation marks.

`def set_config_env_vars(obj):
    if config_path := obj.get("config_path"):
        os.environ["CONFIG_PATH"] = f'"{config_path}"'
    else:
        config_name = obj.get("config_name") or "default"
        os.environ["CONFIG_NAME"] = f'"{config_name}"'`
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 57e6df7f7b2f6ff8731ea5e36ffb018b26a09c30  | 
|--------|--------|

fix: handle spaces in Docker Compose file paths by quoting env vars

### Summary:
Fixes Docker Compose file path space issue by quoting `CONFIG_PATH` and `CONFIG_NAME` in `set_config_env_vars()`.

**Key points**:
- **Behavior**:
  - Fixes issue with Docker Compose not recognizing spaces in file paths by wrapping `CONFIG_PATH` and `CONFIG_NAME` in quotes in `set_config_env_vars()` in `docker_utils.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->