### PR TITLE
fix prompts, auth, download file

### DIFF
--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -103,7 +103,8 @@ services:
       hatchet-setup-config:
         condition: service_completed_successfully
   r2r:
-    image: ${R2R_IMAGE:-ragtoriches/prod:latest-unstructured}
+    # image: ${R2R_IMAGE:-ragtoriches/prod:latest-unstructured}
+    image: r2r/test
     build:
       context: .
       args:

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -103,8 +103,7 @@ services:
       hatchet-setup-config:
         condition: service_completed_successfully
   r2r:
-    # image: ${R2R_IMAGE:-ragtoriches/prod:latest-unstructured}
-    image: r2r/test
+    image: ${R2R_IMAGE:-ragtoriches/prod:latest-unstructured}
     build:
       context: .
       args:

--- a/py/core/base/abstractions/document.py
+++ b/py/core/base/abstractions/document.py
@@ -1,6 +1,5 @@
 """Abstractions for documents and their extractions."""
 
-import base64
 import json
 import logging
 from datetime import datetime
@@ -147,7 +146,7 @@ class DocumentInfo(R2RSerializable):
     restructuring_status: RestructureStatus = RestructureStatus.PENDING
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    version_number: Optional[int] = None
+    attempt_number: Optional[int] = None
 
     def convert_to_db_entry(self):
         """Prepare the document info for database entry, extracting certain fields from metadata."""
@@ -166,7 +165,7 @@ class DocumentInfo(R2RSerializable):
             "restructuring_status": self.restructuring_status,
             "created_at": self.created_at or now,
             "updated_at": self.updated_at or now,
-            "version_number": self.version_number or 0,
+            "attempt_number": self.attempt_number or 0,
         }
 
 

--- a/py/core/providers/database/document.py
+++ b/py/core/providers/database/document.py
@@ -49,7 +49,7 @@ class DocumentMixin(DatabaseMixin):
             Column("restructuring_status", String),
             Column("created_at", DateTime),
             Column("updated_at", DateTime),
-            Column("version_number", Integer),
+            Column("attempt_number", Integer),
         )
 
     async def create_table(self):
@@ -67,7 +67,7 @@ class DocumentMixin(DatabaseMixin):
             restructuring_status TEXT DEFAULT 'pending',
             created_at TIMESTAMPTZ DEFAULT NOW(),
             updated_at TIMESTAMPTZ DEFAULT NOW(),
-            version_number INT DEFAULT 0
+            attempt_number INT DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_group_ids_{self.collection_name}
         ON {self._get_table_name('document_info')} USING GIN (group_ids);
@@ -80,6 +80,7 @@ class DocumentMixin(DatabaseMixin):
         if isinstance(documents_overview, DocumentInfo):
             documents_overview = [documents_overview]
 
+        # TODO: make this an arg
         max_retries = 20
         for document_info in documents_overview:
             retries = 0
@@ -89,7 +90,7 @@ class DocumentMixin(DatabaseMixin):
                         async with conn.transaction():
                             # Lock the row for update
                             check_query = f"""
-                            SELECT version_number, ingestion_status FROM {self._get_table_name('document_info')}
+                            SELECT attempt_number, ingestion_status FROM {self._get_table_name('document_info')}
                             WHERE document_id = $1 FOR UPDATE
                             """
                             existing_doc = await conn.fetchrow(
@@ -99,9 +100,9 @@ class DocumentMixin(DatabaseMixin):
                             db_entry = document_info.convert_to_db_entry()
 
                             if existing_doc:
-                                db_version = existing_doc["version_number"]
+                                db_version = existing_doc["attempt_number"]
                                 db_status = existing_doc["ingestion_status"]
-                                new_version = db_entry["version_number"]
+                                new_version = db_entry["attempt_number"]
 
                                 # Only increment version if status is changing to 'success' or if it's a new version
                                 if (
@@ -109,17 +110,17 @@ class DocumentMixin(DatabaseMixin):
                                     and db_entry["ingestion_status"]
                                     == "success"
                                 ) or (new_version > db_version):
-                                    new_version_number = db_version + 1
+                                    new_attempt_number = db_version + 1
                                 else:
-                                    new_version_number = db_version
+                                    new_attempt_number = db_version
 
-                                db_entry["version_number"] = new_version_number
+                                db_entry["attempt_number"] = new_attempt_number
 
                                 update_query = f"""
                                 UPDATE {self._get_table_name('document_info')}
                                 SET group_ids = $1, user_id = $2, type = $3, metadata = $4,
                                     title = $5, version = $6, size_in_bytes = $7, ingestion_status = $8,
-                                    restructuring_status = $9, updated_at = $10, version_number = $11
+                                    restructuring_status = $9, updated_at = $10, attempt_number = $11
                                 WHERE document_id = $12
                                 """
                                 await conn.execute(
@@ -134,7 +135,7 @@ class DocumentMixin(DatabaseMixin):
                                     db_entry["ingestion_status"],
                                     db_entry["restructuring_status"],
                                     db_entry["updated_at"],
-                                    new_version_number,
+                                    new_attempt_number,
                                     document_info.id,
                                 )
                             else:
@@ -142,7 +143,7 @@ class DocumentMixin(DatabaseMixin):
                                 INSERT INTO {self._get_table_name('document_info')}
                                 (document_id, group_ids, user_id, type, metadata, title, version,
                                 size_in_bytes, ingestion_status, restructuring_status, created_at,
-                                updated_at, version_number)
+                                updated_at, attempt_number)
                                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                                 """
                                 await conn.execute(
@@ -159,7 +160,7 @@ class DocumentMixin(DatabaseMixin):
                                     db_entry["restructuring_status"],
                                     db_entry["created_at"],
                                     db_entry["updated_at"],
-                                    db_entry["version_number"],
+                                    db_entry["attempt_number"],
                                 )
 
                     break  # Success, exit the retry loop

--- a/py/core/providers/parsing/unstructured_parsing.py
+++ b/py/core/providers/parsing/unstructured_parsing.py
@@ -217,8 +217,9 @@ class UnstructuredParsingProvider(ParsingProvider):
                 metadata=metadata,
             )
 
-        if iteration == 0:
-            raise ValueError(f"No chunks found for document {document.id}")
+        # TODO: explore why this is throwing inadvertedly
+        # if iteration == 0:
+        #     raise ValueError(f"No chunks found for document {document.id}")
 
         logger.debug(
             f"Parsed document with id={document.id}, title={document.metadata.get('title', None)}, "

--- a/py/core/providers/prompts/r2r_prompts.py
+++ b/py/core/providers/prompts/r2r_prompts.py
@@ -277,7 +277,7 @@ class R2RPromptProvider(PromptProvider):
     ):
         try:
             created_at_clause = (
-                ", created_at = NOW()" if modify_created_at else ""
+                "created_at = NOW()," if modify_created_at else ""
             )
 
             query = f"""
@@ -287,8 +287,8 @@ class R2RPromptProvider(PromptProvider):
             ON CONFLICT (name) DO UPDATE SET
                 template = EXCLUDED.template,
                 input_types = EXCLUDED.input_types,
-                updated_at = NOW()
-                {created_at_clause};
+                {created_at_clause}
+                updated_at = NOW();
             """
             await self.execute_query(
                 query,

--- a/py/sdk/management.py
+++ b/py/sdk/management.py
@@ -241,6 +241,24 @@ class ManagementMethods:
         ) or {"results": {}}
 
     @staticmethod
+    async def download_file(
+        client,
+        document_id: Union[str, UUID],
+    ):
+        """
+        Download a file from the R2R deployment.
+
+        Args:
+            document_id (str): The ID of the document to download.
+
+        Returns:
+            dict: The response from the server.
+        """
+        return await client._make_request(
+            "GET", f"download_file/{str(document_id)}"
+        )
+
+    @staticmethod
     async def documents_overview(
         client,
         document_ids: Optional[list[Union[UUID, str]]] = None,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 456de8af16dc2081934b23eea072534e073e67bb  | 
|--------|--------|

feat: add file download endpoint and async prompt operations

### Summary:
This PR adds a file download endpoint, renames a database field, and makes prompt operations asynchronous.

**Key points**:
- **Behavior**:
  - Add `download_file_app` endpoint in `management_router.py` for streaming file downloads by document ID.
  - Change Docker image for `r2r` service in `compose.yaml` to `r2r/test`.
- **Database**:
  - Rename `version_number` to `attempt_number` in `DocumentInfo` and related database operations in `document.py`.
- **Prompts**:
  - Make prompt operations (`add_prompt`, `get_prompt`, `update_prompt`, `delete_prompt`) asynchronous in `management_service.py` and `r2r_prompts.py`.
- **Misc**:
  - Comment out error raising for no chunks found in `unstructured_parsing.py`.
  - Fix SQL query syntax in `r2r_prompts.py` for prompt updates.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->