### PR TITLE
Fix loading of changed prompts

### DIFF
--- a/py/core/base/abstractions/prompt.py
+++ b/py/core/base/abstractions/prompt.py
@@ -2,18 +2,19 @@
 
 from datetime import datetime
 from typing import Any
-
-from pydantic import BaseModel
+from uuid import UUID, uuid4
+from pydantic import BaseModel, Field
 
 
 class Prompt(BaseModel):
     """A prompt that can be formatted with inputs."""
 
+    prompt_id: UUID = Field(default_factory=uuid4)
     name: str
     template: str
-    created_at: datetime = datetime.now()
-    updated_at: datetime = datetime.now()
     input_types: dict[str, str]
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
 
     def format_prompt(self, inputs: dict[str, Any]) -> str:
         self._validate_inputs(inputs)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4c380cac75485f3ee881ba4b2f6e43b08a6735f5  | 
|--------|--------|

fix: add prompt_id and improve input type handling in prompts

### Summary:
Add `prompt_id` to `Prompt` and improve input type handling in `R2RPromptProvider`.

**Key points**:
- **Prompt Class**:
  - Add `prompt_id` field with default UUID in `Prompt` class.
  - Change `created_at` and `updated_at` to use `datetime.utcnow`.
- **R2RPromptProvider**:
  - Use `json.loads` for `input_types` in `_load_prompts_from_database()`.
  - Add `prompt_id` generation in `add_prompt()` using `generate_id_from_label()`.
  - Add logging for saving prompts in `_save_prompt_to_database()`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->