### PR TITLE
Download file endpoint for PDF viewing

### DIFF
--- a/js/sdk/src/r2rClient.ts
+++ b/js/sdk/src/r2rClient.ts
@@ -772,6 +772,18 @@ export class r2rClient {
   }
 
   /**
+   * Download the raw file associated with a document.
+   * @param documentId The ID of the document to retrieve.
+   * @returns A promise that resolves to a Blob representing the PDF.
+   */
+  @feature("downloadFile")
+  async downloadFile(documentId: string): Promise<Blob> {
+    return await this._makeRequest<Blob>("GET", `download_file/${documentId}`, {
+      responseType: "blob",
+    });
+  }
+
+  /**
    * Get an overview of documents in the R2R deployment.
    * @param document_ids List of document IDs to get an overview for.
    * @returns A promise that resolves to the response from the server.

--- a/py/core/providers/prompts/r2r_prompts.py
+++ b/py/core/providers/prompts/r2r_prompts.py
@@ -287,10 +287,6 @@ class R2RPromptProvider(PromptProvider):
                 "created_at = NOW()," if modify_created_at else ""
             )
 
-            logger.info(
-                f"Saving prompt '{prompt.name}' with input_types: {prompt.input_types} (type: {type(prompt.input_types)})"
-            )
-
             query = f"""
             INSERT INTO {self._get_table_name('prompts')}
             (prompt_id, name, template, input_types)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b00d409dee0e41ca0289f6110cf1a0c0017ea22e  | 
|--------|--------|

feat: add PDF download endpoint and client method

### Summary:
Add file download functionality for PDFs in `r2rClient` and `management_router.py`, with MIME type handling and error checks.

**Key points**:
- **Behavior**:
  - Add `downloadFile` method to `r2rClient` in `r2rClient.ts` to download files as PDFs.
  - Update `download_file_app` in `management_router.py` to handle file download requests, including MIME type detection and error handling for invalid document IDs.
- **Misc**:
  - Remove logging statement in `_save_prompt_to_database` in `r2r_prompts.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->