### PR TITLE
add max_description_input_length

### DIFF
--- a/docs/cookbooks/graphrag.mdx
+++ b/docs/cookbooks/graphrag.mdx
@@ -42,6 +42,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
+    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536 # increase if you want more comprehensive summaries
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params here: https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/
@@ -105,6 +106,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "ollama/llama3.1" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
+    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536
     generation_config = { model = "ollama/llama3.1" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params here: https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/

--- a/docs/documentation/configuration/knowledge-graph/enrichment.mdx
+++ b/docs/documentation/configuration/knowledge-graph/enrichment.mdx
@@ -21,6 +21,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "gpt-4o-mini" } # and other generation params
 
   [kg.kg_enrichment_settings]
+    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536
     generation_config = { model = "gpt-4o-mini" } # and other generation params
     leiden_params = { max_levels = 10 } # more params in graspologic/partition/leiden.py

--- a/docs/documentation/configuration/knowledge-graph/overview.mdx
+++ b/docs/documentation/configuration/knowledge-graph/overview.mdx
@@ -25,6 +25,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     fragment_merge_count = 4 # number of fragments to merge into a single extraction
 
   [kg.kg_enrichment_settings]
+    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536
     generation_config = { model = "gpt-4o-mini" } # and other generation params below
     leiden_params = { max_levels = 10 } # more params in https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/

--- a/docs/documentation/deep-dive/providers/knowledge-graph.mdx
+++ b/docs/documentation/deep-dive/providers/knowledge-graph.mdx
@@ -43,6 +43,7 @@ database = "your_neo4j_database"
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
+    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536 # increase if you want more comprehensive summaries
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params here: https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/

--- a/py/core/base/abstractions/restructure.py
+++ b/py/core/base/abstractions/restructure.py
@@ -38,6 +38,11 @@ class KGCreationSettings(R2RSerializable):
 class KGEnrichmentSettings(R2RSerializable):
     """Settings for knowledge graph enrichment."""
 
+    max_description_input_length: int = Field(
+        default=8192,
+        description="The maximum length of the description for a node in the graph.",
+    )
+
     max_summary_input_length: int = Field(
         default=65536,
         description="The maximum length of the summary for a community.",

--- a/py/core/configs/local_llm_neo4j_kg.toml
+++ b/py/core/configs/local_llm_neo4j_kg.toml
@@ -43,6 +43,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "ollama/llama3.1" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
+    max_description_input_length = 8192
     max_summary_input_length = 65536
     generation_config = { model = "ollama/llama3.1" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params in https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/

--- a/py/core/main/api/restructure_router.py
+++ b/py/core/main/api/restructure_router.py
@@ -151,7 +151,9 @@ class RestructureRouter(BaseRouter):
                 "skip_clustering": skip_clustering,
                 "force_enrichment": force_enrichment,
                 "generation_config": kg_enrichment_settings.generation_config.to_dict(),
+                "max_description_input_length": kg_enrichment_settings.max_description_input_length,
                 "max_summary_input_length": kg_enrichment_settings.max_summary_input_length,
+                "max_description_input_length": kg_enrichment_settings.max_description_input_length,
                 "leiden_params": kg_enrichment_settings.leiden_params,
                 "user": auth_user.json(),
             }

--- a/py/core/main/hatchet/restructure_workflow.py
+++ b/py/core/main/hatchet/restructure_workflow.py
@@ -168,7 +168,11 @@ class EnrichGraphWorkflow:
 
     @r2r_hatchet.step(retries=3, timeout="60m")
     async def kg_node_creation(self, context: Context) -> None:
-        await self.restructure_service.kg_node_creation()
+        input_data = context.workflow_input()["request"]
+        max_description_input_length = input_data["max_description_input_length"]
+        await self.restructure_service.kg_node_creation(
+            max_description_input_length=max_description_input_length
+        )
         return {"result": None}
 
     @r2r_hatchet.step(retries=3, parents=["kg_node_creation"], timeout="60m")

--- a/py/core/main/services/restructure_service.py
+++ b/py/core/main/services/restructure_service.py
@@ -73,14 +73,17 @@ class RestructureService(Service):
         return await _collect_results(result_gen)
 
     @telemetry_event("kg_node_creation")
-    async def kg_node_creation(self):
+    async def kg_node_creation(self, max_description_input_length: int):
         node_extrations = await self.pipes.kg_node_extraction_pipe.run(
             input=self.pipes.kg_node_extraction_pipe.Input(message=None),
             run_manager=self.run_manager,
         )
         result_gen = await self.pipes.kg_node_description_pipe.run(
             input=self.pipes.kg_node_description_pipe.Input(
-                message=node_extrations
+                message={
+                    "node_extrations": node_extrations,
+                    "max_description_input_length": max_description_input_length,
+                }
             ),
             run_manager=self.run_manager,
         )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8db60fa16c160f7f3d3ebbd6ecba72414f856dc8  | 
|--------|--------|

feat: add max_description_input_length for KG node descriptions

### Summary:
Add `max_description_input_length` to control node description length in knowledge graphs, updating configurations, API endpoints, workflows, and pipes accordingly.

**Key points**:
- **Configuration**:
  - Add `max_description_input_length` parameter to `KGEnrichmentSettings` in `restructure.py`.
  - Update `local_llm_neo4j_kg.toml` to include `max_description_input_length`.
  - Modify `enrichment.mdx`, `overview.mdx`, and `knowledge-graph.mdx` to document `max_description_input_length`.
- **API and Workflows**:
  - Update `enrich_graph` endpoint in `restructure_router.py` to handle `max_description_input_length`.
  - Modify `EnrichGraphWorkflow` in `restructure_workflow.py` to pass `max_description_input_length` to `kg_node_creation`.
  - Update `kg_node_creation` method in `restructure_service.py` to use `max_description_input_length`.
- **Pipes**:
  - Modify `KGNodeDescriptionPipe` in `node_extraction.py` to truncate descriptions based on `max_description_input_length`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->