### PR TITLE
Fix Database URL in Compose

### DIFF
--- a/py/compose.hatchet.yaml
+++ b/py/compose.hatchet.yaml
@@ -30,7 +30,7 @@ services:
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_DBNAME: "${POSTGRES_DBNAME:-postgres}"
-      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
       DATABASE_POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       DATABASE_POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       DATABASE_POSTGRES_USERNAME: "${POSTGRES_USER:-postgres}"
@@ -51,7 +51,7 @@ services:
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_DBNAME: "${POSTGRES_DBNAME:-postgres}"
-      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
       DATABASE_POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       DATABASE_POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       DATABASE_POSTGRES_USERNAME: "${POSTGRES_USER:-postgres}"
@@ -94,7 +94,7 @@ services:
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_DBNAME: "${POSTGRES_DBNAME:-postgres}"
-      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
       SERVER_GRPC_BROADCAST_ADDRESS: "host.docker.internal:7077"
       SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
       SERVER_GRPC_PORT: 7077
@@ -126,7 +126,7 @@ services:
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_DBNAME: "${POSTGRES_DBNAME:-postgres}"
-      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -85,7 +85,7 @@ services:
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       POSTGRES_DBNAME: "${POSTGRES_DBNAME:-postgres}"
-      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DBNAME:-postgres}?sslmode=disable"
       DATABASE_POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       DATABASE_POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       DATABASE_POSTGRES_USERNAME: "${POSTGRES_USER:-postgres}"

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -267,31 +267,75 @@ class ManagementService(Service):
         """
         Takes a list of filters like
         "{key: {operator: value}, key: {operator: value}, ...}"
-        and deletes entries that match the filters.
-
-        Then, deletes the corresponding entries from the documents overview table.
+        and deletes entries matching the given filters from both vector and relational databases.
 
         NOTE: This method is not atomic and may result in orphaned entries in the documents overview table.
         NOTE: This method assumes that filters delete entire contents of any touched documents.
         """
         logger.info(f"Deleting entries with filters: {filters}")
-        results = self.providers.database.vector.delete(filters)
-        if not results:
+
+        try:
+            vector_delete_results = self.providers.database.vector.delete(
+                filters
+            )
+        except Exception as e:
+            logger.error(f"Error deleting from vector database: {e}")
+            vector_delete_results = {}
+
+        document_ids_to_purge = set()
+        if vector_delete_results:
+            document_ids_to_purge.update(
+                doc_id
+                for doc_id in (
+                    result.get("document_id")
+                    for result in vector_delete_results.values()
+                )
+                if doc_id
+            )
+
+        relational_filters = {}
+        if "document_id" in filters:
+            relational_filters["filter_document_ids"] = [
+                UUID(filters["document_id"])
+            ]
+        if "user_id" in filters:
+            relational_filters["filter_user_ids"] = [UUID(filters["user_id"])]
+        if "group_ids" in filters:
+            relational_filters["filter_group_ids"] = [
+                UUID(group_id) for group_id in filters["group_ids"]
+            ]
+
+        try:
+            documents_overview = await self.providers.database.relational.get_documents_overview(
+                **relational_filters
+            )
+        except Exception as e:
+            logger.error(
+                f"Error fetching documents from relational database: {e}"
+            )
+            documents_overview = []
+
+        if documents_overview:
+            document_ids_to_purge.update(doc.id for doc in documents_overview)
+
+        if not document_ids_to_purge:
             raise R2RException(
                 status_code=404, message="No entries found for deletion."
             )
 
-        document_ids_to_purge = {
-            doc_id
-            for doc_id in [
-                result.get("document_id", None) for result in results.values()
-            ]
-            if doc_id
-        }
         for document_id in document_ids_to_purge:
-            await self.providers.database.relational.delete_from_documents_overview(
-                document_id
-            )
+            try:
+                await self.providers.database.relational.delete_from_documents_overview(
+                    str(document_id)
+                )
+                logger.info(
+                    f"Deleted document ID {document_id} from documents_overview."
+                )
+            except Exception as e:
+                logger.error(
+                    f"Error deleting document ID {document_id} from documents_overview: {e}"
+                )
+
         return None
 
     @telemetry_event("DownloadFile")

--- a/py/core/pipes/retrieval/streaming_rag_pipe.py
+++ b/py/core/pipes/retrieval/streaming_rag_pipe.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 class StreamingSearchRAGPipe(SearchRAGPipe):
-    VECTOR_SEARCH_STREAM_MARKER = "search" # TODO - change this to vector_search in next major release
+    VECTOR_SEARCH_STREAM_MARKER = (
+        "search"  # TODO - change this to vector_search in next major release
+    )
     KG_LOCAL_SEARCH_STREAM_MARKER = "kg_local_search"
     KG_GLOBAL_SEARCH_STREAM_MARKER = "kg_global_search"
     COMPLETION_STREAM_MARKER = "completion"
@@ -76,11 +78,18 @@ class StreamingSearchRAGPipe(SearchRAGPipe):
                 if search_results.kg_search_results[0].local_result:
                     context += "KG Local Search Results:\n"
                     yield f"<{self.KG_LOCAL_SEARCH_STREAM_MARKER}>"
-                    yield json.dumps(search_results.kg_search_results[0].local_result.json())
-                    context += str(search_results.kg_search_results[0].local_result)
+                    yield json.dumps(
+                        search_results.kg_search_results[0].local_result.json()
+                    )
+                    context += str(
+                        search_results.kg_search_results[0].local_result
+                    )
                     yield f"</{self.KG_LOCAL_SEARCH_STREAM_MARKER}>"
 
-                if search_results.kg_search_results and search_results.kg_search_results[0].global_result:
+                if (
+                    search_results.kg_search_results
+                    and search_results.kg_search_results[0].global_result
+                ):
                     context += "KG Global Search Results:\n"
                     yield f"<{self.KG_GLOBAL_SEARCH_STREAM_MARKER}>"
                     for result in search_results.kg_search_results:


### PR DESCRIPTION
Ensures that we pass the right Postgres database URL to Hatchet, but seems to be blocked by issues around Atlas migrations.

The Hatchet migration docker now _attempts_ to connect to the correct database. Once Atlas fixes this issue, #1189.

Related: ariga/atlas#2509
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2df3508d1cf222c92b802072ec723bd6da0b0cc7  | 
|--------|--------|

fix: correct database URL in Compose and improve error handling

### Summary:
Fixes database URL in Compose files and improves error handling in `management_service.py` and search result handling in `streaming_rag_pipe.py`.

**Key points**:
- **Compose Files**:
  - Fix `DATABASE_URL` in `compose.hatchet.yaml` and `compose.yaml` to use `${POSTGRES_HOST}` and `${POSTGRES_PORT}`.
- **Error Handling**:
  - Improve error handling in `delete()` in `management_service.py` for vector and relational database operations.
- **Streaming Logic**:
  - Enhance `_run_logic()` in `streaming_rag_pipe.py` to handle search results more robustly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->