### PR TITLE
minor fix + typos

### DIFF
--- a/docs/cookbooks/graphrag.mdx
+++ b/docs/cookbooks/graphrag.mdx
@@ -42,7 +42,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
-    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
+    max_description_input_length = 65536 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536 # increase if you want more comprehensive summaries
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params here: https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/
@@ -106,7 +106,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "ollama/llama3.1" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
-    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
+    max_description_input_length = 65536 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536
     generation_config = { model = "ollama/llama3.1" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params here: https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/

--- a/docs/documentation/configuration/knowledge-graph/enrichment.mdx
+++ b/docs/documentation/configuration/knowledge-graph/enrichment.mdx
@@ -21,7 +21,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "gpt-4o-mini" } # and other generation params
 
   [kg.kg_enrichment_settings]
-    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
+    max_description_input_length = 65536 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536
     generation_config = { model = "gpt-4o-mini" } # and other generation params
     leiden_params = { max_levels = 10 } # more params in graspologic/partition/leiden.py

--- a/docs/documentation/configuration/knowledge-graph/overview.mdx
+++ b/docs/documentation/configuration/knowledge-graph/overview.mdx
@@ -25,7 +25,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     fragment_merge_count = 4 # number of fragments to merge into a single extraction
 
   [kg.kg_enrichment_settings]
-    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
+    max_description_input_length = 65536 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536
     generation_config = { model = "gpt-4o-mini" } # and other generation params below
     leiden_params = { max_levels = 10 } # more params in https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/

--- a/docs/documentation/deep-dive/providers/knowledge-graph.mdx
+++ b/docs/documentation/deep-dive/providers/knowledge-graph.mdx
@@ -43,7 +43,7 @@ database = "your_neo4j_database"
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
-    max_description_input_length = 8192 # increase if you want more comprehensive descriptions
+    max_description_input_length = 65536 # increase if you want more comprehensive descriptions
     max_summary_input_length = 65536 # increase if you want more comprehensive summaries
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params here: https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/

--- a/py/core/base/abstractions/restructure.py
+++ b/py/core/base/abstractions/restructure.py
@@ -39,7 +39,7 @@ class KGEnrichmentSettings(R2RSerializable):
     """Settings for knowledge graph enrichment."""
 
     max_description_input_length: int = Field(
-        default=8192,
+        default=65536,
         description="The maximum length of the description for a node in the graph.",
     )
 

--- a/py/core/main/services/restructure_service.py
+++ b/py/core/main/services/restructure_service.py
@@ -74,14 +74,14 @@ class RestructureService(Service):
 
     @telemetry_event("kg_node_creation")
     async def kg_node_creation(self, max_description_input_length: int):
-        node_extrations = await self.pipes.kg_node_extraction_pipe.run(
+        node_extractions = await self.pipes.kg_node_extraction_pipe.run(
             input=self.pipes.kg_node_extraction_pipe.Input(message=None),
             run_manager=self.run_manager,
         )
         result_gen = await self.pipes.kg_node_description_pipe.run(
             input=self.pipes.kg_node_description_pipe.Input(
                 message={
-                    "node_extrations": node_extrations,
+                    "node_extractions": node_extractions,
                     "max_description_input_length": max_description_input_length,
                 }
             ),

--- a/py/core/pipes/kg/node_extraction.py
+++ b/py/core/pipes/kg/node_extraction.py
@@ -74,7 +74,7 @@ class KGNodeDescriptionPipe(AsyncPipe):
     """
 
     class Input(AsyncPipe.Input):
-        message: AsyncGenerator[tuple[Entity, list[Triple]], None]
+        message: dict[str, Any]
 
     def __init__(
         self,
@@ -200,11 +200,11 @@ class KGNodeDescriptionPipe(AsyncPipe):
         max_description_input_length = input.message[
             "max_description_input_length"
         ]
-        node_extrations = input.message["node_extrations"]
+        node_extractions = input.message["node_extractions"]
 
         tasks = []
         count = 0
-        async for entity, triples in node_extrations:
+        async for entity, triples in node_extractions:
             tasks.append(
                 asyncio.create_task(
                     process_entity(

--- a/py/r2r.toml
+++ b/py/r2r.toml
@@ -56,6 +56,7 @@ kg_extraction_prompt = "graphrag_triplet_extraction_zero_shot"
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for triplet extraction
 
   [kg.kg_enrichment_settings]
+    max_description_input_length = 65536
     generation_config = { model = "gpt-4o-mini" } # and other params, model used for node description and graph clustering
     leiden_params = { max_levels = 10 } # more params here: https://neo4j.com/docs/graph-data-science/current/algorithms/leiden/
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 052793fca5bb11fb6f4d8063bed0350e6ccae3f8  | 
|--------|--------|

fix: increase max_description_input_length and correct typos

### Summary:
Increase `max_description_input_length` to 65536 and fix typos in node extraction logic.

**Key points**:
- **Configuration Changes**:
  - Increase `max_description_input_length` from 8192 to 65536 in `graphrag.mdx`, `enrichment.mdx`, `overview.mdx`, `knowledge-graph.mdx`, `restructure.py`, and `r2r.toml`.

- **Typo Fixes**:
  - Correct 'node_extrations' to 'node_extractions' in `restructure_service.py` and `node_extraction.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->