### PR TITLE
Remove await from prompt docs, update js delete method

### DIFF
--- a/docs/documentation/configuration/prompts.mdx
+++ b/docs/documentation/configuration/prompts.mdx
@@ -105,7 +105,7 @@ from r2r import R2RClient
 
 client = R2RClient()
 
-response = await client.add_prompt(
+response = client.add_prompt(
     name="my_new_prompt",
     template="Hello, {name}! Welcome to {service}.",
     input_types={"name": "str", "service": "str"}
@@ -117,7 +117,7 @@ response = await client.add_prompt(
 To update an existing prompt:
 
 ```python
-response = await client.update_prompt(
+response = client.update_prompt(
     name="my_existing_prompt",
     template="Updated template: {variable}",
     input_types={"variable": "str"}
@@ -129,7 +129,7 @@ response = await client.update_prompt(
 To get a specific prompt:
 
 ```python
-response = await client.get_prompt(
+response = client.get_prompt(
     prompt_name="my_prompt",
     inputs={"variable": "example"},
     prompt_override="Optional override text"
@@ -141,7 +141,7 @@ response = await client.get_prompt(
 To retrieve all prompts:
 
 ```python
-response = await client.get_all_prompts()
+response = client.get_all_prompts()
 ```
 
 ### Deleting a Prompt
@@ -149,7 +149,7 @@ response = await client.get_all_prompts()
 To delete a prompt:
 
 ```python
-response = await client.delete_prompt("prompt_to_delete")
+response = client.delete_prompt("prompt_to_delete")
 ```
 
 ## Security Considerations

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/js/sdk/src/r2rClient.ts
+++ b/js/sdk/src/r2rClient.ts
@@ -772,19 +772,17 @@ export class r2rClient {
   /**
    * Delete data from the database given a set of filters.
    * @param filters The filters to delete by.
-   * @returns
+   * @returns The results of the deletion.
    */
   @feature("delete")
-  async delete(filters: { [key: string]: string | string[] }): Promise<any> {
+  async delete(filters: { [key: string]: any }): Promise<any> {
     this._ensureAuthenticated();
 
     const params = {
       filters: JSON.stringify(filters),
     };
 
-    return this._makeRequest("DELETE", "delete", {
-      params,
-    });
+    return this._makeRequest("DELETE", "delete", { params }) || { results: {} };
   }
 
   /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `await` from prompt management docs and update JS SDK delete method to handle empty results.
> 
>   - **Documentation**:
>     - Remove `await` from `add_prompt`, `update_prompt`, `get_prompt`, `get_all_prompts`, and `delete_prompt` examples in `prompts.mdx`.
>   - **JavaScript SDK**:
>     - Update `delete()` method in `r2rClient.ts` to return an empty object if no results are returned.
>   - **Versioning**:
>     - Increment version in `package.json` from `0.3.3` to `0.3.4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 8b7b1b0f49306f21a4d30c38a62732d82bb7f2f9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->