### PR TITLE
Add warning for broken Docker Compose version, clean up docker build

### DIFF
--- a/py/Dockerfile
+++ b/py/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Expose the port and set environment variables
 ARG PORT=8000 HOST=0.0.0.0
-ENV PORT=$PORT HOST=$HOST TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
+ENV PORT=$PORT HOST=$HOST
 EXPOSE $PORT
 
 COPY . /app

--- a/py/cli/commands/server.py
+++ b/py/cli/commands/server.py
@@ -302,9 +302,10 @@ async def serve(
 
         # For Windows, convert backslashes to forward slashes and prepend /host_mnt/
         if platform.system() == "Windows":
-            config_path = "/host_mnt/" + config_path.replace(
-                "\\", "/"
-            ).replace(":", "")
+            drive, path = os.path.splitdrive(config_path)
+            config_path = (
+                f"/host_mnt/{drive[0].lower()}{path.replace('\\', '/')}"
+            )
 
     if docker:
         run_docker_serve(

--- a/py/cli/utils/docker_utils.py
+++ b/py/cli/utils/docker_utils.py
@@ -467,11 +467,21 @@ def check_docker_compose_version():
         compose_version = version_match[1]
         min_version = "2.25.0"
 
+        # 2.29.6 throws an `invalid mount config` https://github.com/docker/compose/issues/12139
+        incompatible_versions = ["2.29.6"]
+
         if parse_version(compose_version) < parse_version(min_version):
             click.secho(
                 f"Warning: Docker Compose version {compose_version} is outdated. "
                 f"Please upgrade to version {min_version} or higher.",
                 fg="yellow",
+                bold=True,
+            )
+        elif compose_version in incompatible_versions:
+            click.secho(
+                f"Warning: Docker Compose version {compose_version} is known to be incompatible."
+                f"Please upgrade to a newer version.",
+                fg="red",
                 bold=True,
             )
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -22,29 +22,30 @@ packages = [
 # Python Versions
 python = ">=3.10,<3.13"
 
+apscheduler = "^3.10.4"
+asyncclick = "^8.1.7.2"
 boto3 = "^1.35.17" # for AWS bedrock support
 click = "^8.0.0"
 fastapi = "^0.114.0"
+hatchet-sdk = "^0.36.17"
 httpx = "^0.27.0"
 nest-asyncio = "^1.6.0"
 numpy = ">=1.22.4,<1.29.0"
 openai =  "^1.11.1"
 python-dotenv = "^1.0.1"
-hatchet-sdk = "^0.36.17"
 requests = "^2.31.0"
 toml = "^0.10.2"
 types-requests = "^2.31.0"
 unstructured-client = "^0.25.5"
-apscheduler = "^3.10.4"
 
 # Core dependencies (optional)
 future = { version = "^1.0.0", optional = true }
 pydantic = { extras = ["email"], version = "^2.8.2", optional = true }
-python-multipart = { version = "^0.0.9", optional = true }
 fire = { version = "^0.5.0", optional = true }
 gunicorn = { version = "^21.2.0", optional = true }
 uvicorn = { version = "^0.27.0.post1", optional = true }
 aiosqlite = { version = "^0.20.0", optional = true }
+python-multipart = { version = "^0.0.9", optional = true }
 asyncpg = { version = "^0.29.0", optional = true }
 redis = { version = "^5.0.4", optional = true }
 beautifulsoup4 = { version = "^4.12.3", optional = true }
@@ -53,8 +54,6 @@ markdown = { version = "^3.6", optional = true }
 pypdf = { version = "^4.2.0", optional = true }
 python-pptx = { version = "^1.0.1", optional = true }
 python-docx = { version = "^1.1.0", optional = true }
-opencv-python = { version = "^4.10.0.82", optional = true }
-moviepy = { version = "^1.0.3", optional = true }
 vecs = { version = "^0.4.0", optional = true }
 litellm = { version = "^1.42.3", optional = true }
 fsspec = { version = "^2024.6.0", optional = true }
@@ -66,20 +65,20 @@ passlib = { version = "^1.7.4", optional = true }
 bcrypt = { version = "^4.1.3", optional = true }
 pyjwt = { version = "^2.8.0", optional = true }
 pyyaml = { version = "^6.0.1", optional = true }
-poppler-utils = { version = "^0.1.0", optional = true }
 psutil = { version = "^6.0.0", optional = true }
 deepdiff = { version = "^7.0.1", optional = true }
-tokenizers = { version = "0.19", optional = true }
-unstructured = {version = "^0.15.10", optional = true, extras = ["all-docs"]}
-asyncclick = "^8.1.7.2"
+tokenizers = { version = "^0.19", optional = true }
+
+opencv-python = { version = "^4.10.0.82", optional = true }
+moviepy = { version = "^1.0.3", optional = true }
 
 [tool.poetry.extras]
 core = [
-    "future", "pydantic", "python-multipart", "fire", "gunicorn", "unstructured", "unstructured-client",
-    "uvicorn", "aiosqlite", "asyncpg", "redis", "beautifulsoup4", "openpyxl",
-    "markdown", "pypdf", "python-pptx", "python-docx", "vecs", "litellm",
+    "future", "pydantic", "fire", "gunicorn", "uvicorn", "aiosqlite",
+    "asyncpg", "redis", "beautifulsoup4", "openpyxl", "markdown", "pypdf",
+    "python-pptx", "python-docx", "vecs", "litellm", "python-multipart",
     "fsspec", "posthog", "sqlalchemy", "ollama", "neo4j", "passlib", "bcrypt",
-    "pyjwt", "toml", "pyyaml", "poppler-utils", "psutil", "deepdiff",
+    "pyjwt", "pyyaml", "psutil", "deepdiff", "tokenizers"
 ]
 core-ingest-movies = ["opencv-python", "moviepy"]
 


### PR DESCRIPTION
Should fix the error in #1245.

Makes tokenizers ^0.19 for #1242.

And adds a warning for users with Docker Compose v2.29.6, preventing #1220.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds warning for incompatible Docker Compose version and cleans up Docker build process, including dependency reorganization.
> 
>   - **Docker Compose Version Check**:
>     - Adds warning for Docker Compose version `2.29.6` in `check_docker_compose_version()` in `docker_utils.py` due to known incompatibility.
>   - **Docker Build Cleanup**:
>     - Removes `TESSDATA_PREFIX` environment variable from `Dockerfile`.
>     - Fixes Windows path conversion in `serve()` in `server.py`.
>   - **Dependency Management**:
>     - Reorganizes dependencies in `pyproject.toml` for better clarity and management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for dc19b53697b4a517645df3a1f9c87dc9e5435d13. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->