### PR TITLE
Prevent errors if config name is reserved name in Postgres

### DIFF
--- a/py/core/providers/database/vecs/client.py
+++ b/py/core/providers/database/vecs/client.py
@@ -232,7 +232,7 @@ class Client:
             join pg_attribute pa
                 on pc.oid = pa.attrelid
         where
-            pc.relnamespace = '{self.project_name}'::regnamespace
+            pc.relnamespace = "{self.project_name}"::regnamespace
             and pc.relkind = 'r'
             and pa.attname = 'vec'
             and not pc.relname ^@ '_'

--- a/py/core/providers/database/vector.py
+++ b/py/core/providers/database/vector.py
@@ -301,11 +301,21 @@ class PostgresVectorDBProvider(VectorDBProvider):
                 m=16, ef_construction=64
             )  # Default HNSW parameters
 
+        index_name = f"ix_{self.project_name}_{self.collection.name}_hnsw"
+
+        sql = f"""
+        CREATE INDEX {index_name}
+        ON "{self.project_name}"."{self.collection.name}"
+        USING hnsw (vec {measure})
+        WITH (m={index_options.m}, ef_construction={index_options.ef_construction});
+        """
+
         self.collection.create_index(
             method=index_type,
             measure=measure,
             index_arguments=index_options,
             replace=True,
+            sql=sql,
         )
 
     def delete(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes SQL queries in `client.py` and `vector.py` to handle reserved Postgres names by using double quotes for identifiers.
> 
>   - **Behavior**:
>     - Fixes SQL query in `get_collection()` in `client.py` to use double quotes for `relnamespace` to handle reserved names.
>     - Constructs `index_name` and `sql` in `create_index()` in `vector.py` with double quotes for `project_name` and `collection.name` to prevent errors with reserved names.
>   - **Misc**:
>     - No changes to logic or functionality beyond handling reserved names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for ec2db56ee04f05ac1522df92bdcca4cb2928cd0a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->