### PR TITLE
Allow json fallback

### DIFF
--- a/py/core/parsers/structured/json_parser.py
+++ b/py/core/parsers/structured/json_parser.py
@@ -9,11 +9,28 @@ from core.base.parsers.base_parser import AsyncParser
 class JSONParser(AsyncParser[DataType]):
     """A parser for JSON data."""
 
-    async def ingest(self, data: DataType) -> AsyncGenerator[str, None]:
-        """Ingest JSON data and yield a formatted text representation."""
+    async def ingest(
+        self, data: DataType, **kwargs: Any
+    ) -> AsyncGenerator[str, None]:
+        """
+        Ingest JSON data and yield a formatted text representation.
+
+        :param data: The JSON data to parse.
+        :param kwargs: Additional keyword arguments.
+        """
         if isinstance(data, bytes):
             data = data.decode("utf-8")
-        yield self._parse_json(json.loads(data))
+        parsed_json = json.loads(data)
+        formatted_text = self._parse_json(parsed_json)
+
+        chunk_size = kwargs.get("chunk_size")
+        if chunk_size and isinstance(chunk_size, int):
+            # If chunk_size is provided and is an integer, yield the formatted text in chunks
+            for i in range(0, len(formatted_text), chunk_size):
+                yield formatted_text[i : i + chunk_size]
+        else:
+            # If no valid chunk_size is provided, yield the entire formatted text
+            yield formatted_text
 
     def _parse_json(self, data: dict) -> str:
         def remove_objects_with_null(obj):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `ingest()` in `JSONParser` to support chunked output via `chunk_size` argument.
> 
>   - **Behavior**:
>     - `ingest()` in `JSONParser` now accepts `chunk_size` as a keyword argument to yield formatted text in chunks.
>     - If `chunk_size` is not provided or invalid, yields entire formatted text.
>   - **Functionality**:
>     - No changes to `_parse_json()` method, which formats JSON data as text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 3477e4781cd2f42068d355602fc034557733d2e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->