### PR TITLE
Utilize Bundled Hatchet API/Dashboard

### DIFF
--- a/py/compose.full.yaml
+++ b/py/compose.full.yaml
@@ -93,7 +93,7 @@ services:
       - r2r-network
 
   hatchet-migration:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-migrate:v0.49.0-alpha.4
     environment:
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
@@ -115,7 +115,7 @@ services:
       - r2r-network
 
   hatchet-setup-config:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:v0.49.0-alpha.4
     command: /hatchet/hatchet-admin quickstart --skip certs --generated-config-dir /hatchet/config --overwrite=false
     environment:
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
@@ -153,7 +153,7 @@ services:
       - r2r-network
 
   hatchet-engine:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-engine:v0.49.0-alpha.4
     command: /hatchet/hatchet-engine --config /hatchet/config
     restart: on-failure
     depends_on:
@@ -186,9 +186,9 @@ services:
       timeout: 5s
       retries: 5
 
-  hatchet-api:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-api:latest
-    command: /hatchet/hatchet-api --config /hatchet/config
+  hatchet-dashboard:
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:v0.49.0-alpha.4
+    command: sh ./entrypoint.sh --config /hatchet/config
     restart: on-failure
     depends_on:
       hatchet-setup-config:
@@ -196,23 +196,13 @@ services:
     environment:
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
-      POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
+      POSTGRES_HOST: host.docker.internal
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       HATCHET_POSTGRES_DBNAME: "${HATCHET_POSTGRES_DBNAME:-hatchet}"
-      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${HATCHET_POSTGRES_DBNAME:-hatchet}?sslmode=disable"
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-host.docker.internal}:${POSTGRES_PORT:-5432}/${HATCHET_POSTGRES_DBNAME:-hatchet}?sslmode=disable"
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
-    networks:
-      - r2r-network
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.hatchet-api.rule=PathPrefix(`/api`)"
-      - "traefik.http.services.hatchet-api.loadbalancer.server.port=8080"
-      - "traefik.http.routers.hatchet-api.entrypoints=hatchet"
-
-  hatchet-dashboard:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest
     networks:
       - r2r-network
     labels:
@@ -222,7 +212,7 @@ services:
       - "traefik.http.routers.hatchet-dashboard.entrypoints=hatchet"
 
   setup-token:
-    image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:v0.49.0-alpha.4
     command: >
       sh -c "
         set -e
@@ -424,4 +414,3 @@ services:
       - r2r-network
     labels:
       - "traefik.http.middlewares.no-cache-headers.headers.customResponseHeaders.Cache-Control=no-cache, no-store, must-revalidate"
-      - "traefik.http.routers.hatchet-api.middlewares=no-cache-headers"

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -154,7 +154,6 @@ services:
       - r2r-network
     labels:
       - "traefik.http.middlewares.no-cache-headers.headers.customResponseHeaders.Cache-Control=no-cache, no-store, must-revalidate"
-      - "traefik.http.routers.hatchet-api.middlewares=no-cache-headers"
 
 volumes:
   postgres_data:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Docker Compose to use specific Hatchet version and consolidate API/Dashboard services.
> 
>   - **Docker Compose Configuration**:
>     - Update Hatchet service images to `v0.49.0-alpha.4` in `compose.full.yaml`.
>     - Consolidate `hatchet-api` and `hatchet-dashboard` into a single `hatchet-dashboard` service.
>     - Remove `traefik` labels related to `hatchet-api`.
>   - **Environment Variables**:
>     - Change `POSTGRES_HOST` to `host.docker.internal` for `hatchet-dashboard` service in `compose.full.yaml`.
>   - **Misc**:
>     - Remove `traefik` middleware label for `hatchet-api` in `compose.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 62e5aef117085e47667d8f723a3a031fa6835de9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->