### PR TITLE
Add Exclusion Flag for Postgres

### DIFF
--- a/py/cli/commands/server.py
+++ b/py/cli/commands/server.py
@@ -224,6 +224,12 @@ def generate_report():
     default="prod",
     help="Which dev environment to pull the image from?",
 )
+@click.option(
+    "--exclude-postgres",
+    is_flag=True,
+    default=False,
+    help="Excludes creating a Postgres container in the Docker setup.",
+)
 async def serve(
     host,
     port,
@@ -235,6 +241,7 @@ async def serve(
     build,
     image,
     image_env,
+    exclude_postgres,
 ):
     """Start the R2R server."""
     load_dotenv()
@@ -334,6 +341,7 @@ async def serve(
             image,
             config_name,
             config_path,
+            exclude_postgres,
         )
         if (
             "pytest" in sys.modules

--- a/py/compose.full.yaml
+++ b/py/compose.full.yaml
@@ -21,6 +21,7 @@ volumes:
 services:
   postgres:
     image: pgvector/pgvector:pg16
+    profiles: [postgres]
     environment:
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
@@ -86,9 +87,6 @@ services:
       POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       HATCHET_POSTGRES_DBNAME: "${HATCHET_POSTGRES_DBNAME:-hatchet}"
-    depends_on:
-      postgres:
-        condition: service_healthy
     networks:
       - r2r-network
 
@@ -109,8 +107,6 @@ services:
     depends_on:
       hatchet-create-db:
         condition: service_completed_successfully
-      postgres:
-        condition: service_healthy
     networks:
       - r2r-network
 
@@ -146,8 +142,6 @@ services:
       hatchet-migration:
         condition: service_completed_successfully
       hatchet-rabbitmq:
-        condition: service_healthy
-      postgres:
         condition: service_healthy
     networks:
       - r2r-network
@@ -283,8 +277,6 @@ services:
       - hatchet_config:/hatchet/config
       - hatchet_api_key:/hatchet_api_key
     depends_on:
-      postgres:
-        condition: service_healthy
       hatchet-setup-config:
         condition: service_completed_successfully
 
@@ -377,8 +369,6 @@ services:
     depends_on:
       setup-token:
         condition: service_completed_successfully
-      postgres:
-        condition: service_healthy
       unstructured:
         condition: service_healthy
 

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -13,6 +13,7 @@ networks:
 services:
   postgres:
     image: pgvector/pgvector:pg16
+    profiles: [postgres]
     environment:
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
@@ -120,9 +121,6 @@ services:
       - "traefik.http.middlewares.r2r-headers.headers.customresponseheaders.Access-Control-Expose-Headers=Content-Length,Content-Range"
     extra_hosts:
       - host.docker.internal:host-gateway
-    depends_on:
-      postgres:
-        condition: service_healthy
 
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `--exclude-postgres` flag to Docker setup to optionally skip Postgres container creation.
> 
>   - **Behavior**:
>     - Add `--exclude-postgres` flag to `serve` command in `server.py` to skip creating a Postgres container.
>     - Modify `run_docker_serve()` in `docker_utils.py` to handle `exclude_postgres` flag.
>     - Update `check_set_docker_env_vars()` in `docker_utils.py` to conditionally set Postgres environment variables.
>   - **Docker Compose**:
>     - Add `profiles: [postgres]` to Postgres service in `compose.full.yaml` and `compose.yaml`.
>     - Modify Docker commands in `build_docker_command()` in `docker_utils.py` to include/exclude Postgres profile based on flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for f9d5f417a1485198cebc2ffe1f72457e9a6d03df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->