### PR TITLE
allow `search_settings` or `settings`

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "r2r"
 readme = "README.md"
-version = "3.2.7"
+version = "3.2.8"
 
 description = "SciPhi R2R"
 authors = ["Owen Colegrove <owen@sciphi.ai>"]

--- a/py/shared/abstractions/search.py
+++ b/py/shared/abstractions/search.py
@@ -207,6 +207,11 @@ class VectorSearchSettings(R2RSerializable):
     filters: dict[str, Any] = Field(
         default_factory=dict,
         description="Filters to apply to the vector search",
+        deprecated=True,
+    )
+    search_filters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Filters to apply to the vector search",
     )
     search_limit: int = Field(
         default=10,
@@ -283,12 +288,29 @@ class VectorSearchSettings(R2RSerializable):
         ]
         return dump
 
+    def __init__(self, **data):
+        # Either filters or search filters is supported
+        data["filters"] = {
+            **data.get("filters", {}),
+            **data.get("search_filters", {}),
+        }
+        data["search_filters"] = {
+            **data.get("filters", {}),
+            **data.get("search_filters", {}),
+        }
+        super().__init__(**data)
+
 
 class KGSearchSettings(R2RSerializable):
 
     filters: dict[str, Any] = Field(
         default_factory=dict,
-        description="Filters to apply to the KG search",
+        description="Filters to apply to the vector search",
+        deprecated=True,
+    )
+    search_filters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Filters to apply to the vector search",
     )
 
     selected_collection_ids: list[UUID] = Field(
@@ -346,3 +368,15 @@ class KGSearchSettings(R2RSerializable):
                 "__Community__": 20,
             },
         }
+
+    def __init__(self, **data):
+        # Either filters or search filters is supported
+        data["filters"] = {
+            **data.get("filters", {}),
+            **data.get("search_filters", {}),
+        }
+        data["search_filters"] = {
+            **data.get("filters", {}),
+            **data.get("search_filters", {}),
+        }
+        super().__init__(**data)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Support for both `filters` and `search_filters` in `VectorSearchSettings` and `KGSearchSettings`, with `filters` deprecated.
> 
>   - **Behavior**:
>     - `VectorSearchSettings` and `KGSearchSettings` now support both `filters` and `search_filters` fields.
>     - `filters` field is marked as deprecated in both classes.
>     - `__init__` method in both classes combines data from `filters` and `search_filters`.
>   - **Versioning**:
>     - Update version in `pyproject.toml` from 3.2.7 to 3.2.8.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 3208333c4c55154f8132320c050a30cadcca01e6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->