### PR TITLE
Fix document info serialization for Hatchet orchestration

### DIFF
--- a/py/core/main/orchestration/hatchet/ingestion_workflow.py
+++ b/py/core/main/orchestration/hatchet/ingestion_workflow.py
@@ -136,7 +136,7 @@ def hatchet_ingestion_factory(
 
             return {
                 "status": "Successfully finalized ingestion",
-                "document_info": document_info.model_dump(),
+                "document_info": document_info.to_dict(),
             }
 
         @orchestration_provider.failure()


### PR DESCRIPTION
We were calling `.model_dump()` on an object that contained a UUID, rather than using the `R2RSerializable` "`.to_dict()`" method in the embedding step of ingestion. While documents would be upserted to the vector db, they were never marked as successful in Hatchet and would eventually cause the orchestrator to stop accepting new jobs.