### PR TITLE
fix typos

### DIFF
--- a/docs/cookbooks/graphrag.mdx
+++ b/docs/cookbooks/graphrag.mdx
@@ -179,7 +179,7 @@ This will run a cost estimation step to give you an estimate of the cost of the 
 Time taken: 0.21 seconds
 {
   "results": {
-    "message": "These are estimated ranges, actual values may vary. To run the KG creation process, run `create-graph` with `--run` in the cli, or `run_mode=\"run\"` in the client.",
+    "message": "Ran Graph Creation Estimate (not the actual run). Note that these are estimated ranges, actual values may vary. To run the KG creation process, run `create-graph` with `--run` in the cli, or `run_type=\"run\"` in the client.",
     "document_count": 2,
     "number_of_jobs_created": 3,
     "total_chunks": 29,

--- a/py/core/providers/kg/postgres.py
+++ b/py/core/providers/kg/postgres.py
@@ -805,7 +805,7 @@ class PostgresKGProvider(KGProvider):
         )  # 10 minutes per million tokens
 
         return KGCreationEstimationResponse(
-            message='These are estimated ranges, actual values may vary. To run the KG creation process, run `create-graph` with `--run` in the cli, or `run_mode="run"` in the client.',
+            message='Ran Graph Creation Estimate (not the actual run). Note that these are estimated ranges, actual values may vary. To run the KG creation process, run `create-graph` with `--run` in the cli, or `run_type="run"` in the client.',
             document_count=len(document_ids),
             number_of_jobs_created=len(document_ids) + 1,
             total_chunks=total_chunks,
@@ -879,7 +879,7 @@ class PostgresKGProvider(KGProvider):
         )
 
         return KGEnrichmentEstimationResponse(
-            message='These are estimated ranges, actual values may vary. To run the KG enrichment process, run `enrich-graph` with `--run` in the cli, or `run_mode="run"` in the client.',
+            message='Ran Graph Enrichment Estimate (not the actual run). Note that these are estimated ranges, actual values may vary. To run the KG enrichment process, run `enrich-graph` with `--run` in the cli, or `run_type="run"` in the client.',
             total_entities=entity_count,
             total_triples=triple_count,
             estimated_llm_calls=self._get_str_estimation_output(

--- a/py/shared/abstractions/kg.py
+++ b/py/shared/abstractions/kg.py
@@ -16,11 +16,6 @@ class KGRunType(str, Enum):
 class KGCreationSettings(R2RSerializable):
     """Settings for knowledge graph creation."""
 
-    run_mode: KGRunType = Field(
-        default=KGRunType.ESTIMATE,  # or run
-        description="Run an estimate for the full graph creation process.",
-    )
-
     kg_triples_extraction_prompt: str = Field(
         default="graphrag_triples_extraction_few_shot",
         description="The prompt to use for knowledge graph extraction.",
@@ -64,11 +59,6 @@ class KGCreationSettings(R2RSerializable):
 
 class KGEnrichmentSettings(R2RSerializable):
     """Settings for knowledge graph enrichment."""
-
-    run_mode: str = Field(
-        default="estimate",  # or run
-        description="Run an estimate for the full graph enrichment process.",
-    )
 
     skip_clustering: bool = Field(
         default=False,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typos by changing `run_mode` to `run_type` in documentation and code messages, and remove `run_mode` field from settings classes.
> 
>   - **Documentation**:
>     - Fix typo in `docs/cookbooks/graphrag.mdx` by changing `run_mode` to `run_type` in the message about running KG creation.
>   - **Code**:
>     - Update `message` in `get_creation_estimate()` and `get_enrichment_estimate()` in `postgres.py` to use `run_type` instead of `run_mode`.
>   - **Settings**:
>     - Remove `run_mode` field from `KGCreationSettings` and `KGEnrichmentSettings` in `kg.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for f1678c6d2044eba10e0d1e23695d653d803bfca3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->