### PR TITLE
Fix Ollama Tool Calling

### DIFF
--- a/docs/cookbooks/graphrag.mdx
+++ b/docs/cookbooks/graphrag.mdx
@@ -117,7 +117,7 @@ tool_names = ["search"]
 
 <Tab title="R2R Full with Docker+Hatchet">
 ```bash
-r2r serve --docker --config-name=full
+r2r serve --full --docker --config-name=full
 ```
 <Accordion icon="gear" title="Configuration: full.toml">
 ``` toml

--- a/py/core/base/agent/agent.py
+++ b/py/core/base/agent/agent.py
@@ -14,6 +14,9 @@ from core.base.abstractions import (
 from core.base.providers import CompletionProvider, PromptProvider
 
 from .base import Tool, ToolResult
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Conversation:
@@ -182,77 +185,59 @@ class Agent(ABC):
         *args,
         **kwargs,
     ) -> ToolResult:
-        (
-            (
-                await self.conversation.add_message(
-                    Message(
-                        role="assistant",
-                        tool_calls=[
-                            {
-                                "id": tool_id,
-                                "function": {
-                                    "name": function_name,
-                                    "arguments": function_arguments,
-                                },
-                            }
-                        ],
-                    )
-                )
-            )
-            if tool_id
-            else (
-                await self.conversation.add_message(
-                    Message(
-                        role="assistant",
-                        function_call={
-                            "name": function_name,
-                            "arguments": function_arguments,
-                        },
-                    )
-                )
+        await self.conversation.add_message(
+            Message(
+                role="assistant",
+                tool_calls=(
+                    [
+                        {
+                            "id": tool_id,
+                            "function": {
+                                "name": function_name,
+                                "arguments": function_arguments,
+                            },
+                        }
+                    ]
+                    if tool_id
+                    else None
+                ),
+                function_call=(
+                    {
+                        "name": function_name,
+                        "arguments": function_arguments,
+                    }
+                    if not tool_id
+                    else None
+                ),
             )
         )
 
-        # TODO - We always use tools, not functions
-        # Think of ways to make this clearer
         if tool := next(
             (t for t in self.tools if t.name == function_name), None
         ):
             merged_kwargs = {**kwargs, **json.loads(function_arguments)}
-
             raw_result = await tool.results_function(*args, **merged_kwargs)
             llm_formatted_result = tool.llm_format_function(raw_result)
-
             tool_result = ToolResult(
                 raw_result=raw_result,
                 llm_formatted_result=llm_formatted_result,
             )
-
             if tool.stream_function:
                 tool_result.stream_result = tool.stream_function(raw_result)
-
-            (
-                (
-                    await self.conversation.add_message(
-                        Message(
-                            role="tool",
-                            content=str(tool_result.llm_formatted_result),
-                            name=function_name,
-                        )
-                    )
-                )
-                if tool_id
-                else (
-                    await self.conversation.add_message(
-                        Message(
-                            role="function",
-                            content=str(tool_result.llm_formatted_result),
-                            name=function_name,
-                        )
-                    )
-                )
+        else:
+            error_message = f"The requested tool '{function_name}' is not available. Available tools: {', '.join(t.name for t in self.tools)}"
+            logger.debug(error_message)
+            tool_result = ToolResult(
+                raw_result=error_message,
+                llm_formatted_result=error_message,
             )
 
-            return tool_result
-        else:
-            raise ValueError(f"Tool {function_name} not found")
+        await self.conversation.add_message(
+            Message(
+                role="tool" if tool_id else "function",
+                content=str(tool_result.llm_formatted_result),
+                name=function_name,
+            )
+        )
+
+        return tool_result

--- a/py/core/providers/llm/litellm.py
+++ b/py/core/providers/llm/litellm.py
@@ -52,8 +52,7 @@ class LiteCompletionProvider(CompletionProvider):
         args["messages"] = messages
         args = {**args, **kwargs}
 
-        response = await self.acompletion(**args)
-        return response
+        return await self.acompletion(**args)
 
     def _execute_task_sync(self, task: dict[str, Any]):
         messages = task["messages"]
@@ -65,9 +64,7 @@ class LiteCompletionProvider(CompletionProvider):
         args = {**args, **kwargs}
 
         try:
-            response = self.completion(**args)
-            logger.debug("Sync LiteLLM task executed successfully")
-            return response
+            return self.completion(**args)
         except Exception as e:
             logger.error(f"Sync LiteLLM task execution failed: {str(e)}")
             raise


### PR DESCRIPTION
It seems like Ollama changed their tool calling response structure, which subsequently broke LiteLLM. Ollama tool calling still  won't work until this change is made in LiteLLM, but merging the changes here in advance doesn't break anything and cleans  some things up.

Hopefully they merge this soon 🤠 --> BerriAI/litellm#6155
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tool calling in LiteLLM by logging missing components and updating tool result handling.
> 
>   - **Behavior**:
>     - Replaces `ValueError` with `logger.info` for missing tool call components in `process_llm_response()` in `base.py` and `agent.py`.
>     - Updates tool result handling to use `results.llm_formatted_result` in `process_llm_response()` in `base.py`.
>     - Adds handling for remaining content after stream ends in `process_llm_response()` in `base.py`.
>   - **Logging**:
>     - Adds logging for unavailable tools in `handle_function_or_tool_call()` in `agent.py`.
>     - Adds logger initialization in `base.py` and `agent.py`.
>   - **Misc**:
>     - Removes redundant code in `_execute_task_sync()` in `litellm.py`.
>     - Updates command in `graphrag.mdx` from `--docker --config-name=full` to `--full --docker --config-name=full`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for b204cefe59c4f28840227e5408d10058def7469c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->