### PR TITLE
Nolan/ingest chunks js

### DIFF
--- a/docs/cookbooks/graphrag.mdx
+++ b/docs/cookbooks/graphrag.mdx
@@ -117,7 +117,7 @@ tool_names = ["search"]
 
 <Tab title="R2R Full with Docker+Hatchet">
 ```bash
-r2r serve --docker --config-name=full
+r2r serve --full --docker --config-name=full
 ```
 <Accordion icon="gear" title="Configuration: full.toml">
 ``` toml

--- a/docs/documentation/js-sdk/collections.mdx
+++ b/docs/documentation/js-sdk/collections.mdx
@@ -1,6 +1,7 @@
 ---
+
 title: 'Collection Management'
-description: 'Manage collections in the R2R TypeScript client'
+description: 'Manage collections in R2R'
 ---
 
 <Note>
@@ -9,214 +10,406 @@ Occasionally this SDK documentation falls out of date, cross-check with the auto
 
 A collection in R2R is a logical grouping of users and documents that allows for efficient access control and organization. Collections enable you to manage permissions and access to documents at a collection level, rather than individually.
 
-## Overview
+R2R provides a comprehensive set of collection features, allowing you to implement efficient access control and organization of users and documents in your applications.
 
-The R2R TypeScript client provides methods to manage collections, including:
+<Note>
+Collection permissioning in R2R is still under development and as a result the API will likely evolve.
+</Note>
 
-- Creating and deleting collections
-- Updating collection metadata
-- Listing collections
-- Adding and removing users from collections
-- Assigning and removing documents from collections
-- Retrieving users and documents in a collection
+## Collection Creation and Management
 
-## Usage
+### Create a Collection
 
-### Creating a Collection
+Create a new collection with a name and optional description:
 
-To create a new collection, use the `createCollection` method:
+```javascript
+const createCollectionResponse = await client.createCollection(
+  "Marketing Team",
+  "Collection for marketing department"
+);
+const collectionId = createCollectionResponse.results.collection_id; // '123e4567-e89b-12d3-a456-426614174000'
+```
 
-````typescript
-async createCollection(
-  name: string,
-  description?: string
-): Promise<Record<string, any>>
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          collection_id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'Marketing Team',
+          description: 'Collection for marketing department',
+          created_at: '2024-07-16T22:53:47.524794Z',
+          updated_at: '2024-07-16T22:53:47.524794Z'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-Example:
-````typescript
-const newCollection = await r2rClient.createCollection('My Collection', 'A sample collection');
-````
+### Get Collection Details
 
-### Updating a Collection
+Retrieve details about a specific collection:
 
-To update a collection's name or description, use the `updateCollection` method:
+```javascript
+const collectionDetails = await client.getCollection(collectionId);
+```
 
-````typescript
-async updateCollection(
-  collectionId: string,
-  name?: string,
-  description?: string
-): Promise<Record<string, any>>
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          collection_id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'Marketing Team',
+          description: 'Collection for marketing department',
+          created_at: '2024-07-16T22:53:47.524794Z',
+          updated_at: '2024-07-16T22:53:47.524794Z'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-Example:
-````typescript
-await r2rClient.updateCollection('collection_id', 'Updated Name', 'Updated description');
-````
+### Update a Collection
 
-### Deleting a Collection
+Update a collection's name or description:
 
-To delete a collection, use the `deleteCollection` method:
+```javascript
+const updateResult = await client.updateCollection(
+  collectionId,
+  "Updated Marketing Team",
+  "New description for marketing team"
+);
+```
 
-````typescript
-async deleteCollection(collectionId: string): Promise<Record<string, any>>
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          collection_id: '123e4567-e89b-12d3-a456-426614174000',
+          name: 'Updated Marketing Team',
+          description: 'New description for marketing team',
+          created_at: '2024-07-16T22:53:47.524794Z',
+          updated_at: '2024-07-16T23:15:30.123456Z'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-Example:
-````typescript
-await r2rClient.deleteCollection('collection_id');
-````
+### List Collections
 
-### Listing Collections
+Get a list of all collections:
 
-To list all collections, use the `listCollections` method:
+```javascript
+const collectionsList = await client.listCollections();
+```
 
-````typescript
-async listCollections(
-  offset?: number,
-  limit?: number
-): Promise<Record<string, any>>
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: [
+          {
+            collection_id: '123e4567-e89b-12d3-a456-426614174000',
+            name: 'Updated Marketing Team',
+            description: 'New description for marketing team',
+            created_at: '2024-07-16T22:53:47.524794Z',
+            updated_at: '2024-07-16T23:15:30.123456Z'
+          },
+          // ... other collections ...
+        ]
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-Example:
-````typescript
-const collections = await r2rClient.listCollections(0, 10);
-````
+## User Management in Collections
 
-### Adding a User to a Collection
+### Add User to Collection
 
-To add a user to a collection, use the `addUserToCollection` method:
+Add a user to a collection:
 
-````typescript
-async addUserToCollection(
-  userId: string,
-  collectionId: string
-): Promise<Record<string, any>>
-````
+```javascript
+const userId = '456e789f-g01h-34i5-j678-901234567890'; // This should be a valid user ID
+const addUserResult = await client.addUserToCollection(userId, collectionId);
+```
 
-Example:
-````typescript
-await r2rClient.addUserToCollection('user_id', 'collection_id');
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          message: 'User successfully added to the collection'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-### Removing a User from a Collection
+### Remove User from Collection
 
-To remove a user from a collection, use the `removeUserFromCollection` method:
+Remove a user from a collection:
 
-````typescript
-async removeUserFromCollection(
-  userId: string,
-  collectionId: string
-): Promise<Record<string, any>>
-````
+```javascript
+const removeUserResult = await client.removeUserFromCollection(userId, collectionId);
+```
 
-Example:
-````typescript
-await r2rClient.removeUserFromCollection('user_id', 'collection_id');
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          message: 'User successfully removed from the collection'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-### Getting Users in a Collection
+### List Users in Collection
 
-To get all users in a collection, use the `getUsersInCollection` method:
+Get a list of all users in a specific collection:
 
-````typescript
-async getUsersInCollection(
-  collectionId: string,
-  offset?: number,
-  limit?: number
-): Promise<Record<string, any>>
-````
+```javascript
+const usersInCollection = await client.getUsersInCollection(collectionId);
+```
 
-Example:
-````typescript
-const users = await r2rClient.getUsersInCollection('collection_id', 0, 10);
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: [
+          {
+            user_id: '456e789f-g01h-34i5-j678-901234567890',
+            email: 'user@example.com',
+            name: 'John Doe',
+            // ... other user details ...
+          },
+          // ... other users ...
+        ]
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-### Getting Collections for a User
+### Get User's Collections
 
-To get all collections a user belongs to, use the `getCollectionsForUser` method:
+Get all collections that a user is a member of:
 
-````typescript
-async getCollectionsForUser(
-  userId: string,
-  offset?: number,
-  limit?: number
-): Promise<Record<string, any>>
-````
+```javascript
+const userCollections = await client.getCollectionsForUser(userId);
+```
 
-Example:
-````typescript
-const userCollections = await r2rClient.getCollectionsForUser('user_id', 0, 10);
-````
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: [
+          {
+            collection_id: '123e4567-e89b-12d3-a456-426614174000',
+            name: 'Updated Marketing Team',
+            // ... other collection details ...
+          },
+          // ... other collections ...
+        ]
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-### Assigning a Document to a Collection
+## Document Management in Collections
 
-To assign a document to a collection, use the `assignDocumentToCollection` method:
+### Assign Document to Collection
 
-````typescript
-async assignDocumentToCollection(
-  document_id: string,
-  collection_id: string
-): Promise<any>
-````
+Assign a document to a collection:
 
-Example:
-````typescript
-await r2rClient.assignDocumentToCollection('document_id', 'collection_id');
-````
+```javascript
+const documentId = '789g012j-k34l-56m7-n890-123456789012'; // Must be a valid document ID
+const assignDocResult = await client.assignDocumentToCollection(documentId, collectionId);
+```
 
-### Removing a Document from a Collection
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          message: 'Document successfully assigned to the collection'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-To remove a document from a collection, use the `removeDocumentFromCollection` method:
+### Remove Document from Collection
 
-````typescript
-async removeDocumentFromCollection(
-  document_id: string,
-  collection_id: string
-): Promise<any>
-````
+Remove a document from a collection:
 
-Example:
-````typescript
-await r2rClient.removeDocumentFromCollection('document_id', 'collection_id');
-````
+```javascript
+const removeDocResult = await client.removeDocumentFromCollection(documentId, collectionId);
+```
 
-### Getting Collections for a Document
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          message: 'Document successfully removed from the collection'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-To get all collections a document is assigned to, use the `getDocumentCollections` method:
+### List Documents in Collection
 
-````typescript
-async getDocumentCollections(
-  documentId: string,
-  offset?: number,
-  limit?: number
-): Promise<Record<string, any>>
-````
+Get a list of all documents in a specific collection:
 
-Example:
-````typescript
-const documentCollections = await r2rClient.getDocumentCollections('document_id', 0, 10);
-````
+```javascript
+const docsInCollection = await client.getDocumentsInCollection(collectionId);
+```
 
-### Getting Documents in a Collection
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: [
+          {
+            document_id: '789g012j-k34l-56m7-n890-123456789012',
+            title: 'Marketing Strategy 2024',
+            // ... other document details ...
+          },
+          // ... other documents ...
+        ]
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
 
-To get all documents in a collection, use the `getDocumentsInCollection` method:
+### Get Document's Collections
 
-````typescript
-async getDocumentsInCollection(
-  collectionId: string,
-  offset?: number,
-  limit?: number
-): Promise<Record<string, any>>
-````
+Get all collections that a document is assigned to:
 
-Example:
-````typescript
-const collectionDocuments = await r2rClient.getDocumentsInCollection('collection_id', 0, 10);
-````
+```javascript
+const documentCollections = await client.getDocumentCollections(documentId);
+```
 
-## Security Best Practices
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: [
+          {
+            collection_id: '123e4567-e89b-12d3-a456-426614174000',
+            name: 'Updated Marketing Team',
+            // ... other collection details ...
+          },
+          // ... other collections ...
+        ]
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
+
+## Advanced Collection Management
+
+### Collection Overview
+
+Get an overview of collections, including user and document counts:
+
+```javascript
+const collectionsOverview = await client.collectionsOverview();
+```
+
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: [
+          {
+            collection_id: '123e4567-e89b-12d3-a456-426614174000',
+            name: 'Updated Marketing Team',
+            description: 'New description for marketing team',
+            user_count: 5,
+            document_count: 10,
+            created_at: '2024-07-16T22:53:47.524794Z',
+            updated_at: '2024-07-16T23:15:30.123456Z'
+          },
+          // ... other collections ...
+        ]
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
+
+### Delete a Collection
+
+Delete a collection:
+
+```javascript
+const deleteResult = await client.deleteCollection(collectionId);
+```
+
+<AccordionGroup>
+  <Accordion title="Response">
+    <ResponseField name="response" type="object">
+      ```javascript
+      {
+        results: {
+          message: 'Collection successfully deleted'
+        }
+      }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
+
+## Pagination and Filtering
+
+Many collection-related methods support pagination and filtering:
+
+```javascript
+// List collections with pagination
+const paginatedCollections = await client.listCollections(10, 20);
+
+// Get users in a collection with pagination
+const paginatedUsers = await client.getUsersInCollection(collectionId, 5, 10);
+
+// Get documents in a collection with pagination
+const paginatedDocs = await client.getDocumentsInCollection(collectionId, 0, 50);
+
+// Get collections overview with specific collection IDs
+const specificCollectionsOverview = await client.collectionsOverview(['id1', 'id2', 'id3']);
+```
+
+## Security Considerations
 
 When implementing collection permissions, consider the following security best practices:
 

--- a/docs/documentation/js-sdk/ingestion.mdx
+++ b/docs/documentation/js-sdk/ingestion.mdx
@@ -196,11 +196,12 @@ const chunks = [
   },
   {
     text: "He was born in 384 BC in Stagira...",
-  }
+  },
 ];
 
-const ingestResponse = await client.ingestChunks(chunks, {
-  metadata: { title: "Aristotle", source: "wikipedia" }
+const ingestResponse = await client.ingestChunks(chunks, undefined, {
+  title: "Aristotle",
+  source: "wikipedia",
 });
 ````
 
@@ -209,24 +210,26 @@ const ingestResponse = await client.ingestChunks(chunks, {
     <ResponseField name="response" type="object">
       The response from the R2R system after ingesting the chunks.
       ```bash
-      {'message': 'Ingest chunks task queued successfully.', 'task_id': '8f27dfca-606d-422d-b73f-2d9e138661c3', 'document_id': 'd4391abf-8a4e-5d9d-80fd-232ef6fd8527'}
+      {
+        'message': 'Ingest chunks task queued successfully.',
+        'task_id': '8f27dfca-606d-422d-b73f-2d9e138661c3',
+        'document_id': 'd4391abf-8a4e-5d9d-80fd-232ef6fd8527'
+      }
       ```
     </ResponseField>
   </Accordion>
 </AccordionGroup>
 
-<ParamField path="chunks" type="Array<{ text: string; metadata?: Record<string, any> }>" required>
-  An array of chunk objects to ingest. Each object should contain at least a "text" property with the chunk text. An optional "metadata" property can contain a dictionary of metadata for the chunk.
+<ParamField path="chunks" type="Array<{ text: string; }>" required>
+  An array of chunk objects to ingest. Each object should contain at least a `text` property with the chunk text.
 </ParamField>
 
-<ParamField path="options" type="object">
-  <ParamField path="document_id" type="string">
-    An optional document ID to assign to the ingested chunks. If not provided, a new document ID will be generated.
-  </ParamField>
+<ParamField path="documentId" type="string">
+  An optional document ID to assign to the ingested chunks. If not provided, a new document ID will be generated.
+</ParamField>
 
-  <ParamField path="metadata" type="Record<string, any>">
-    An optional metadata object for the document.
-  </ParamField>
+<ParamField path="metadata" type="Record<string, any>">
+  An optional metadata object for the document.
 </ParamField>
 
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -122,6 +122,7 @@
                 "documentation/js-sdk/ingestion",
                 "documentation/js-sdk/retrieval",
                 "documentation/js-sdk/auth",
+                "documentation/js-sdk/collections",
                 "documentation/js-sdk/observability"
               ]
             },

--- a/js/sdk/__tests__/r2rClientIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/r2rClientIntegrationSuperUser.test.ts
@@ -9,6 +9,8 @@ let newCollectionId: string;
  * raskolnikov.txt should have an id of `f9f61fc8-079c-52d0-910a-c657958e385b`
  * karamozov.txt should have an id of `73749580-1ade-50c6-8fbe-a5e9e87783c8`
  * myshkin.txt should have an id of `2e05b285-2746-5778-9e4a-e293db92f3be`
+ * The first ingested chunk should have an id of `731030c6-9244-5cfc-a9fd-81e4eb356cd3`
+ * The second ingested chunk should have an id of `bd2cbead-66e0-57bc-acea-2c34711a39b5`
  * The default collection should have an id of `122fdf6a-e116-546b-a8f6-e4cb2e2c0a09`
  */
 
@@ -30,6 +32,7 @@ let newCollectionId: string;
  *    Ingestion:
  *     - ingestFiles
  *     - updateFiles
+ *     - ingestChunks
  *    Management:
  *     - serverStats
  *     X updatePrompt
@@ -119,6 +122,22 @@ describe("r2rClient Integration Tests", () => {
         document_ids: ["2e05b285-2746-5778-9e4a-e293db92f3be"],
         metadatas: [{ title: "updated_karamozov.txt" }],
       }),
+    ).resolves.not.toThrow();
+  });
+
+  test("Ingest chunks with no id or metadata", async () => {
+    await expect(
+      client.ingestChunks([{ text: "test chunks" }]),
+    ).resolves.not.toThrow();
+  });
+
+  test("Ingest chunks", async () => {
+    await expect(
+      client.ingestChunks(
+        [{ text: "chunk 1" }, { text: "chunk 2" }],
+        undefined,
+        { source: "example" },
+      ),
     ).resolves.not.toThrow();
   });
 
@@ -232,14 +251,19 @@ describe("r2rClient Integration Tests", () => {
   });
 
   test("Create collection", async () => {
-    const response = await client.createCollection("test_collection", "test_description");
+    const response = await client.createCollection(
+      "test_collection",
+      "test_description",
+    );
     newCollectionId = response.results.collection_id;
 
     expect(newCollectionId).toBeDefined();
   });
 
   test("Get default collection", async () => {
-    await expect(client.getCollection("122fdf6a-e116-546b-a8f6-e4cb2e2c0a09")).resolves.not.toThrow();
+    await expect(
+      client.getCollection("122fdf6a-e116-546b-a8f6-e4cb2e2c0a09"),
+    ).resolves.not.toThrow();
   });
 
   test("Get newly created collection", async () => {
@@ -247,32 +271,40 @@ describe("r2rClient Integration Tests", () => {
   });
 
   test("Update collection", async () => {
-      await expect(
-        client.updateCollection(
-          newCollectionId,
-          "updated_test_collection",
-          "updated_test_description"
-        ),
-      ).resolves.not.toThrow();
-    });
+    await expect(
+      client.updateCollection(
+        newCollectionId,
+        "updated_test_collection",
+        "updated_test_description",
+      ),
+    ).resolves.not.toThrow();
+  });
 
-    test("List collections", async () => {
-      await expect(client.listCollections()).resolves.not.toThrow();
-    });
+  test("List collections", async () => {
+    await expect(client.listCollections()).resolves.not.toThrow();
+  });
 
-    test("Delete collection", async () => {
-      await expect(
-        client.deleteCollection(newCollectionId),
-      ).resolves.not.toThrow();
-    });
+  test("Delete collection", async () => {
+    await expect(
+      client.deleteCollection(newCollectionId),
+    ).resolves.not.toThrow();
+  });
 
-    test("Get users in collection", async () => {
-      await expect(client.getUsersInCollection("122fdf6a-e116-546b-a8f6-e4cb2e2c0a09")).resolves.not.toThrow();
-    });
+  test("Get users in collection", async () => {
+    await expect(
+      client.getUsersInCollection("122fdf6a-e116-546b-a8f6-e4cb2e2c0a09"),
+    ).resolves.not.toThrow();
+  });
 
-    test("Get users in collection with pagination", async () => {
-      await expect(client.getUsersInCollection("122fdf6a-e116-546b-a8f6-e4cb2e2c0a09", 10, 10)).resolves.not.toThrow();
-    });
+  test("Get users in collection with pagination", async () => {
+    await expect(
+      client.getUsersInCollection(
+        "122fdf6a-e116-546b-a8f6-e4cb2e2c0a09",
+        10,
+        10,
+      ),
+    ).resolves.not.toThrow();
+  });
 
   test("Clean up remaining documents", async () => {
     // Deletes karamozov.txt
@@ -289,6 +321,24 @@ describe("r2rClient Integration Tests", () => {
       client.delete({
         document_id: {
           $eq: "2e05b285-2746-5778-9e4a-e293db92f3be",
+        },
+      }),
+    ).resolves.toBe("");
+
+    // Deletes Ingested chunk 1
+    await expect(
+      client.delete({
+        document_id: {
+          $eq: "731030c6-9244-5cfc-a9fd-81e4eb356cd3",
+        },
+      }),
+    ).resolves.toBe("");
+
+    // Deletes Ingseted chunk 2
+    await expect(
+      client.delete({
+        document_id: {
+          $eq: "bd2cbead-66e0-57bc-acea-2c34711a39b5",
         },
       }),
     ).resolves.toBe("");

--- a/js/sdk/__tests__/r2rClientIntegrationUser.test.ts
+++ b/js/sdk/__tests__/r2rClientIntegrationUser.test.ts
@@ -28,6 +28,7 @@ const baseUrl = "http://localhost:7272";
  *    Ingestion:
  *     - ingestFiles
  *     - updateFiles
+ *     X ingestChunks
  *    Management:
  *     - serverStats
  *     X updatePrompt

--- a/js/sdk/src/models.tsx
+++ b/js/sdk/src/models.tsx
@@ -98,3 +98,7 @@ export enum IndexMeasure {
   L2_DISTANCE = "l2_distance",
   MAX_INNER_PRODUCT = "max_inner_product",
 }
+
+export interface RawChunk {
+  text: string;
+}

--- a/js/sdk/src/r2rClient.ts
+++ b/js/sdk/src/r2rClient.ts
@@ -22,6 +22,7 @@ import {
   VectorSearchSettings,
   KGSearchSettings,
   GenerationConfig,
+  RawChunk,
 } from "./models";
 
 function handleRequestError(response: AxiosResponse): void {
@@ -641,6 +642,26 @@ export class r2rClient {
           return data;
         },
       ],
+    });
+  }
+
+  @feature("ingestChunks")
+  async ingestChunks(
+    chunks: RawChunk[],
+    documentId?: string,
+    metadata?: Record<string, any>,
+  ): Promise<Record<string, any>> {
+    this._ensureAuthenticated();
+
+    return await this._makeRequest("POST", "ingest_chunks", {
+      data: {
+        chunks: chunks,
+        document_id: documentId,
+        metadata: metadata,
+      },
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
   }
 

--- a/py/core/main/api/ingestion_router.py
+++ b/py/core/main/api/ingestion_router.py
@@ -268,13 +268,13 @@ class IngestionRouter(BaseRouter):
         )
         @self.base_endpoint
         async def ingest_chunks_app(
-            chunks: Json[list[RawChunk]] = Body(
+            chunks: list[RawChunk] = Body(
                 {}, description=ingest_chunks_descriptions.get("chunks")
             ),
-            document_id: Optional[UUID] = Body(
+            document_id: Optional[str] = Body(
                 None, description=ingest_chunks_descriptions.get("document_id")
             ),
-            metadata: Optional[Json[dict]] = Body(
+            metadata: Optional[dict] = Body(
                 None, description=ingest_files_descriptions.get("metadata")
             ),
             auth_user=Depends(self.service.providers.auth.auth_wrapper),
@@ -286,13 +286,22 @@ class IngestionRouter(BaseRouter):
 
             A valid user authentication token is required to access this endpoint, as regular users can only ingest chunks for their own access. More expansive collection permissioning is under development.
             """
+
+            if document_id:
+                try:
+                    document_uuid = UUID(document_id)
+                except ValueError:
+                    raise R2RException(
+                        status_code=422, message="Invalid document ID format."
+                    )
+
             if not document_id:
-                document_id = generate_document_id(
+                document_uuid = generate_document_id(
                     chunks[0].text[:20], auth_user.id
                 )
 
             workflow_input = {
-                "document_id": str(document_id),
+                "document_id": str(document_uuid),
                 "chunks": [chunk.model_dump() for chunk in chunks],
                 "metadata": metadata or {},
                 "user": auth_user.model_dump_json(),
@@ -303,12 +312,13 @@ class IngestionRouter(BaseRouter):
                 {"request": workflow_input},
                 options={
                     "additional_metadata": {
-                        "document_id": str(document_id),
+                        "document_id": str(document_uuid),
                     }
                 },
             )
-            raw_message["document_id"] = str(document_id)
-            return raw_message  # type: ignore
+            raw_message["document_id"] = str(document_uuid)
+
+            return [raw_message]  # type: ignore
 
     @staticmethod
     async def _process_files(files):

--- a/py/core/main/api/management_router.py
+++ b/py/core/main/api/management_router.py
@@ -288,7 +288,7 @@ class ManagementRouter(BaseRouter):
                 document_uuid = UUID(document_id)
             except ValueError:
                 raise R2RException(
-                    status_code=400, message="Invalid document ID format."
+                    status_code=422, message="Invalid document ID format."
                 )
 
             file_tuple = await self.service.download_file(document_uuid)

--- a/py/core/main/orchestration/simple/ingestion_workflow.py
+++ b/py/core/main/orchestration/simple/ingestion_workflow.py
@@ -168,6 +168,7 @@ def simple_ingestion_factory(service: IngestionService):
         await asyncio.gather(*results)
 
     async def ingest_chunks(input_data):
+        document_info = None
         try:
             from core.base import IngestionStatus
             from core.main import IngestionServiceAdapter

--- a/py/shared/api/models/ingestion/responses.py
+++ b/py/shared/api/models/ingestion/responses.py
@@ -14,7 +14,7 @@ class IngestionResponse(BaseModel):
         description="A message describing the result of the ingestion request.",
     )
     task_id: Optional[UUID] = Field(
-        ...,
+        None,
         description="The task ID of the ingestion request.",
     )
     document_id: UUID = Field(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ingestChunks` feature to `r2rClient` and API, with tests and documentation updates.
> 
>   - **Behavior**:
>     - Add `ingestChunks` method to `r2rClient` class in `r2rClient.ts` for ingesting text chunks.
>     - Add `ingest_chunks` endpoint to `ingestion_router.py` for handling chunk ingestion.
>     - Update `ingestion_workflow.py` to process chunk ingestion.
>   - **Tests**:
>     - Add tests for `ingestChunks` in `r2rClientIntegrationSuperUser.test.ts` and `r2rClientIntegrationUser.test.ts`.
>     - Ensure chunk ingestion tests cover cases with and without document IDs and metadata.
>   - **Documentation**:
>     - Update `graphrag.mdx` to reflect new `r2r serve` command usage.
>   - **Misc**:
>     - Change status code for invalid document ID format from 400 to 422 in `management_router.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 7e3101e4fcee3708f96fa00e7479d85319af77c3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->