### PR TITLE
Allow env var to set the default R2R deployment for the dashboard

### DIFF
--- a/py/compose.full.yaml
+++ b/py/compose.full.yaml
@@ -372,7 +372,7 @@ services:
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:${R2R_PORT:-7272}/r2r-api
+      - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
     networks:
       - r2r-network
     ports:

--- a/py/compose.yaml
+++ b/py/compose.yaml
@@ -115,7 +115,7 @@ services:
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:${R2R_PORT:-7272}/r2r-api
+      - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
     networks:
       - r2r-network
     ports:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `r2r-dashboard` service to use `R2R_DEPLOYMENT_URL` for setting default deployment URL in `compose.full.yaml` and `compose.yaml`.
> 
>   - **Environment Variable Update**:
>     - Changed `NEXT_PUBLIC_API_URL` to `NEXT_PUBLIC_R2R_DEPLOYMENT_URL` in `r2r-dashboard` service in `compose.full.yaml` and `compose.yaml`.
>     - Allows setting default R2R deployment URL via `R2R_DEPLOYMENT_URL` environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 82a286c2c9667c5f7739a7b2d70bcf8f96bd9d6a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->