### PR TITLE
Introducing R2R Guru on Gurubase.io

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -4,6 +4,7 @@
   <a href="https://github.com/SciPhi-AI"><img src="https://img.shields.io/github/stars/SciPhi-AI/R2R" alt="Github Stars"></a>
   <a href="https://github.com/SciPhi-AI/R2R/pulse"><img src="https://img.shields.io/github/commit-activity/w/SciPhi-AI/R2R" alt="Commits-per-week"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-purple.svg" alt="License: MIT"></a>
+  <a href="https://gurubase.io/g/r2r"><img src="https://img.shields.io/badge/Gurubase-Ask%20R2R%20Guru-006BFF" alt="Gurubase: R2R Guru"></a>
 </p>
 
 <img width="1041" alt="r2r" src="https://github.com/user-attachments/assets/b6ee6a78-5d37-496d-ae10-ce18eee7a1d6">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [R2R Guru](https://gurubase.io/g/r2r) to Gurubase. R2R Guru uses the data from this repo and data from the [docs](https://r2r-docs.sciphi.ai/introduction) to answer questions by leveraging the LLM.

In this PR, I showcased the "R2R Guru" badge, which highlights that R2R now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable R2R Guru in Gurubase, just let me know that's totally fine.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds "R2R Guru" badge to `README.md` linking to Gurubase.io for AI assistance.
> 
>   - **README Update**:
>     - Adds "R2R Guru" badge to `README.md` linking to Gurubase.io, indicating AI assistance availability for R2R users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 3be8b14f3fc80799afca9a8f4d659c79bd7a8537. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->