### PR TITLE
Fix type error on port argument of CLI

### DIFF
--- a/py/cli/commands/server.py
+++ b/py/cli/commands/server.py
@@ -203,7 +203,9 @@ def generate_report():
 
 @cli.command()
 @click.option("--host", default=None, help="Host to run the server on")
-@click.option("--port", default=None, help="Port to run the server on")
+@click.option(
+    "--port", default=None, type=int, help="Port to run the server on"
+)
 @click.option("--docker", is_flag=True, help="Run using Docker")
 @click.option(
     "--full",

--- a/py/cli/utils/docker_utils.py
+++ b/py/cli/utils/docker_utils.py
@@ -334,7 +334,7 @@ def get_compose_files():
     return compose_files
 
 
-def find_available_port(start_port):
+def find_available_port(start_port: int):
     port = start_port
     while True:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix type error in CLI `--port` option and add type annotation to `find_available_port()` function.
> 
>   - **CLI Changes**:
>     - In `server.py`, specify `type=int` for `--port` option in `@click.option` to fix type error.
>   - **Function Annotations**:
>     - Add type annotation `start_port: int` to `find_available_port()` in `docker_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 1846db79f948e25b7c15ef0141f2884615090ce4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->