### PR TITLE
Bump JS

### DIFF
--- a/js/sdk/__tests__/r2rClientIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/r2rClientIntegrationSuperUser.test.ts
@@ -197,7 +197,7 @@ describe("r2rClient Integration Tests", () => {
         fullResponse += new TextDecoder().decode(value);
       }
     } else {
-      throw new Error('Stream is not a ReadableStream');
+      throw new Error("Stream is not a ReadableStream");
     }
 
     expect(fullResponse.length).toBeGreaterThan(0);

--- a/js/sdk/package-lock.json
+++ b/js/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/py/compose.full.yaml
+++ b/py/compose.full.yaml
@@ -373,6 +373,7 @@ services:
     image: emrgntcmplxty/r2r-dashboard:latest
     environment:
       - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
+      - NEXT_PUBLIC_HATCHET_DASHBOARD_URL=${HATCHET_DASHBOARD_URL:-http://localhost:${R2R_HATCHET_DASHBOARD_PORT:-7274}}
     networks:
       - r2r-network
     ports:

--- a/py/compose.full.yaml
+++ b/py/compose.full.yaml
@@ -138,7 +138,7 @@ services:
       SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
       SERVER_GRPC_INSECURE: "t"
       SERVER_GRPC_BROADCAST_ADDRESS: "hatchet-engine:7077"
-      SERVER_GRPC_MAX_MSG_SIZE: 13421772800
+      SERVER_GRPC_MAX_MSG_SIZE: 134217728
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
@@ -165,7 +165,7 @@ services:
       SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
       SERVER_GRPC_PORT: "7077"
       SERVER_GRPC_INSECURE: "t"
-      SERVER_GRPC_MAX_MSG_SIZE: 13421772800
+      SERVER_GRPC_MAX_MSG_SIZE: 134217728
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce gRPC message size limit in `compose.full.yaml`, bump version in `package.json`, and update error message in test file.
> 
>   - **Configuration**:
>     - Reduce `SERVER_GRPC_MAX_MSG_SIZE` from `13421772800` to `134217728` in `compose.full.yaml` for `hatchet-setup-config` and `hatchet-engine` services.
>     - Add `NEXT_PUBLIC_HATCHET_DASHBOARD_URL` to `r2r-dashboard` service in `compose.full.yaml`.
>   - **Versioning**:
>     - Bump version in `package.json` from `0.3.9` to `0.3.10`.
>   - **Testing**:
>     - Change error message in `r2rClientIntegrationSuperUser.test.ts` from single to double quotes for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for daf8ae6e4881c86bdaf6fcdac4f3c25ba2bb7318. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->