### PR TITLE
minor kg-search bug

### DIFF
--- a/py/core/providers/kg/postgres.py
+++ b/py/core/providers/kg/postgres.py
@@ -508,7 +508,7 @@ class PostgresKGProvider(KGProvider):
             SELECT {property_names_str} FROM {self._get_table_name(table_name)} {filter_query} ORDER BY {embedding_type} <=> $1 LIMIT $2;
         """
 
-        if not filter_query:
+        if filter_query != "":
             results = await self.fetch_query(
                 QUERY, (str(query_embedding), limit, filter_ids)
             )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix condition in `vector_query` in `postgres.py` to correctly handle empty `filter_query` strings.
> 
>   - **Bug Fix**:
>     - Fix condition in `vector_query` in `postgres.py` to correctly handle empty `filter_query` strings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 6031b50df29653311d12636822de27cde8231261. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->