### PR TITLE
Move to R2R light for JS integration testing

### DIFF
--- a/.github/workflows/r2r-js-sdk-integration-tests.yml
+++ b/.github/workflows/r2r-js-sdk-integration-tests.yml
@@ -9,49 +9,45 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: ./js/sdk
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      TELEMETRY_ENABLED: 'false'
+      R2R_POSTGRES_HOST: localhost
+      R2R_POSTGRES_DBNAME: postgres
+      R2R_POSTGRES_PORT: '5432'
+      R2R_POSTGRES_PASSWORD: postgres
+      R2R_POSTGRES_USER: postgres
+      R2R_PROJECT_NAME: r2r_default
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Set up Python and install dependencies
+        uses: ./.github/actions/setup-python-light
         with:
-          python-version: "3.x"
+          os: ubuntu-latest
 
-      - name: Install R2R
-        run: |
-          python -m pip install --upgrade pip
-          pip install r2r
+      - name: Setup and start PostgreSQL
+        uses: ./.github/actions/setup-postgres-ext
+        with:
+          os: ubuntu-latest
 
-      - name: Start R2R server
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          r2r serve --docker
-          sleep 60
+      - name: Start R2R Light server
+        uses: ./.github/actions/start-r2r-light
 
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "20.x"
 
-      - name: Install dependencies
+      - name: Install JS SDK dependencies
+        working-directory: ./js/sdk
         run: npm ci
 
       - name: Check if R2R server is running
         run: |
           curl http://localhost:7272/v2/health || echo "Server not responding"
 
-      - name: Display R2R server logs if server not responding
-        if: failure()
-        run: docker logs r2r-r2r-1
-
       - name: Run integration tests
+        working-directory: ./js/sdk
         run: npm run test
-
-      - name: Display R2R server logs if tests fail
-        if: failure()
-        run: docker logs r2r-r2r-1

--- a/js/sdk/__tests__/r2rClientIntegrationUser.test.ts
+++ b/js/sdk/__tests__/r2rClientIntegrationUser.test.ts
@@ -182,21 +182,15 @@ describe("r2rClient Integration Tests", () => {
   });
 
   test("Only an authorized user can call server stats", async () => {
-    await expect(client.serverStats()).rejects.toThrow(
-      "Status 403: Only an authorized user can call the `server_stats` endpoint.",
-    );
+    await expect(client.serverStats()).rejects.toThrow(/Status 403/);
   });
 
   test("Only a superuser can call app settings", async () => {
-    await expect(client.appSettings()).rejects.toThrow(
-      "Status 403: Only a superuser can call the `app_settings` endpoint.",
-    );
+    await expect(client.appSettings()).rejects.toThrow(/Status 403/);
   });
 
   test("Only a superuser can call users overview", async () => {
-    await expect(client.usersOverview()).rejects.toThrow(
-      "Status 403: Only a superuser can call the `users_overview` endpoint.",
-    );
+    await expect(client.usersOverview()).rejects.toThrow(/Status 403/);
   });
 
   test("Document chunks", async () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switches JS integration testing to R2R Light and simplifies test error expectations.
> 
>   - **GitHub Actions Workflow**:
>     - Switch from R2R to R2R Light in `r2r-js-sdk-integration-tests.yml`.
>     - Use `setup-python-light` and `setup-postgres-ext` actions.
>     - Remove Docker-based R2R server setup.
>   - **Integration Tests**:
>     - Simplify error message expectations in `r2rClientIntegrationUser.test.ts` by using regex for `toThrow` assertions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 353f73b6a61ca88693b5f835f38e2ef001823270. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->