### PR TITLE
bug fix: triples extraction chunk sort without chunk_order

### DIFF
--- a/py/core/pipes/kg/triples_extraction.py
+++ b/py/core/pipes/kg/triples_extraction.py
@@ -289,7 +289,7 @@ class KGTriplesExtractionPipe(AsyncPipe[dict]):
 
         # sort the extractions accroding to chunk_order field in metadata in ascending order
         extractions = sorted(
-            extractions, key=lambda x: x.metadata["chunk_order"]
+            extractions, key=lambda x: x.metadata.get("chunk_order", float('inf'))
         )
 
         # group these extractions into groups of extraction_merge_count


### PR DESCRIPTION
For thoese chunks added directly (without ducments), there are no chunk_order in metadata.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix sorting of `extractions` in `triples_extraction.py` to handle missing `chunk_order` in metadata.
> 
>   - **Bug Fix**:
>     - Fix sorting of `extractions` in `_run_logic` in `triples_extraction.py` by using `metadata.get("chunk_order", float('inf'))` to handle missing `chunk_order` in metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for c6ee132d9ac7f22cb7c3ff9ca2b01af0231d8a5f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->