### PR TITLE
More V3

### DIFF
--- a/js/sdk/__tests__/CollectionsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/CollectionsIntegrationSuperUser.test.ts
@@ -22,7 +22,7 @@ describe("r2rClient V3 Collections Integration Tests", () => {
       name: "Test Collection",
     });
     expect(response).toBeTruthy();
-    collectionId = response.results.collection_id;
+    collectionId = response.results.id;
   });
 
   test("List collections", async () => {

--- a/js/sdk/__tests__/r2rV2ClientIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/r2rV2ClientIntegrationSuperUser.test.ts
@@ -313,7 +313,7 @@ describe("r2rClient Integration Tests", () => {
       "test_collection",
       "test_description",
     );
-    newCollectionId = response.results.collection_id;
+    newCollectionId = response.results.id;
 
     expect(newCollectionId).toBeDefined();
   });

--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -17,7 +17,7 @@ export interface PaginatedResultsWrapper<T> extends ResultsWrapper<T> {
 
 // Collection types
 export interface CollectionResponse {
-  collection_id: string;
+  id: string;
   user_id?: string;
   name: string;
   description?: string;

--- a/py/core/base/api/models/__init__.py
+++ b/py/core/base/api/models/__init__.py
@@ -49,7 +49,6 @@ from shared.api.models.management.responses import (
     WrappedCollectionsResponse,
     WrappedConversationResponse,
     WrappedConversationsResponse,
-    WrappedDeleteResponse,
     # Document Responses
     WrappedDocumentResponse,
     WrappedDocumentsResponse,
@@ -151,7 +150,6 @@ __all__ = [
     "WrappedBooleanResponse",
     "WrappedGenericMessageResponse",
     # TODO: This needs to be cleaned up
-    "WrappedDeleteResponse",
     # Retrieval Responses
     "CombinedSearchResponse",
     "RAGResponse",

--- a/py/core/main/api/v2/management_router.py
+++ b/py/core/main/api/v2/management_router.py
@@ -21,7 +21,6 @@ from core.base.api.models import (
     WrappedCollectionsResponse,
     WrappedConversationResponse,
     WrappedConversationsResponse,
-    WrappedDeleteResponse,
     WrappedDocumentsResponse,
     WrappedGenericMessageResponse,
     WrappedLogResponse,
@@ -158,7 +157,7 @@ class ManagementRouter(BaseRouter):
         async def delete_prompt_app(
             prompt_name: str = Path(..., description="Prompt name"),
             auth_user=Depends(self.service.providers.auth.auth_wrapper),
-        ) -> WrappedDeleteResponse:
+        ):
             if not auth_user.is_superuser:
                 raise R2RException(
                     "Only a superuser can call the `delete_prompt` endpoint.",
@@ -607,7 +606,7 @@ class ManagementRouter(BaseRouter):
         async def delete_collection_app(
             collection_id: str = Path(..., description="Collection ID"),
             auth_user=Depends(self.service.providers.auth.auth_wrapper),
-        ) -> WrappedDeleteResponse:
+        ):
             collection_uuid = UUID(collection_id)
             if (
                 not auth_user.is_superuser
@@ -753,7 +752,7 @@ class ManagementRouter(BaseRouter):
             document_id: str = Body(..., description="Document ID"),
             collection_id: str = Body(..., description="Collection ID"),
             auth_user=Depends(self.service.providers.auth.auth_wrapper),
-        ) -> WrappedDeleteResponse:
+        ):
             collection_uuid = UUID(collection_id)
             document_uuid = UUID(document_id)
             if (
@@ -1026,6 +1025,6 @@ class ManagementRouter(BaseRouter):
         async def delete_conversation(
             conversation_id: str = Path(..., description="Conversation ID"),
             auth_user=Depends(self.service.providers.auth.auth_wrapper),
-        ) -> WrappedDeleteResponse:
+        ):
             await self.service.delete_conversation(conversation_id)
             return None  # type: ignore

--- a/py/core/providers/database/collection.py
+++ b/py/core/providers/database/collection.py
@@ -98,7 +98,7 @@ class PostgresCollectionHandler(CollectionHandler):
                 )
 
             return CollectionResponse(
-                collection_id=result["collection_id"],
+                id=result["collection_id"],
                 user_id=result["user_id"],
                 name=result["name"],
                 description=result["description"],
@@ -163,7 +163,7 @@ class PostgresCollectionHandler(CollectionHandler):
             raise R2RException(status_code=404, message="Collection not found")
 
         return CollectionResponse(
-            collection_id=result["collection_id"],
+            id=result["collection_id"],
             user_id=result["user_id"],
             name=result["name"],
             description=result["description"],
@@ -346,7 +346,7 @@ class PostgresCollectionHandler(CollectionHandler):
 
             collections = [
                 CollectionResponse(
-                    collection_id=row["collection_id"],
+                    id=row["collection_id"],
                     user_id=row["user_id"],
                     name=row["name"],
                     description=row["description"],

--- a/py/shared/api/models/management/responses.py
+++ b/py/shared/api/models/management/responses.py
@@ -83,7 +83,7 @@ class ChunkResponse(BaseModel):
 
 
 class CollectionResponse(BaseModel):
-    collection_id: UUID
+    id: UUID
     user_id: Optional[UUID]
     name: str
     description: Optional[str]
@@ -162,5 +162,4 @@ WrappedLogResponse = ResultsWrapper[list[LogResponse]]
 WrappedAnalyticsResponse = ResultsWrapper[AnalyticsResponse]
 WrappedAppSettingsResponse = ResultsWrapper[AppSettingsResponse]
 
-WrappedDeleteResponse = ResultsWrapper[None]
 WrappedVerificationResult = ResultsWrapper[VerificationResult]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `WrappedDeleteResponse` and update `CollectionResponse` to use `id` instead of `collection_id` across API models, endpoints, and tests.
> 
>   - **API Models**:
>     - Removed `WrappedDeleteResponse` from `__init__.py` and `management_router.py`.
>     - Changed `CollectionResponse` field `collection_id` to `id` in `responses.py`.
>   - **API Endpoints**:
>     - Updated return type of `delete_prompt_app`, `delete_collection_app`, `remove_document_from_collection_app`, and `delete_conversation` in `management_router.py` to remove `WrappedDeleteResponse`.
>   - **Database Models**:
>     - Changed `CollectionResponse` field `collection_id` to `id` in `collection.py`.
>   - **Tests**:
>     - Updated `CollectionsIntegrationSuperUser.test.ts` to use `id` instead of `collection_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 56b1c4170f2ac2aafd518a63af87dd6d8a9a71ed. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->