### PR TITLE
Add statement_cache_size parameter to allow connections to Supabase

### DIFF
--- a/py/compose.full.yaml
+++ b/py/compose.full.yaml
@@ -26,11 +26,11 @@ services:
     image: pgvector/pgvector:pg16
     profiles: [postgres]
     environment:
-      - POSTGRES_USER=${R2R_POSTGRES_USER:-${POSTGRES_USER:-postgres}} # Eventually get rid of POSTGRES_USER, but for now keep it for backwards compatibility
-      - POSTGRES_PASSWORD=${R2R_POSTGRES_PASSWORD:-${POSTGRES_PASSWORD:-postgres}} # Eventually get rid of POSTGRES_PASSWORD, but for now keep it for backwards compatibility
-      - POSTGRES_HOST=${R2R_POSTGRES_HOST:-${POSTGRES_HOST:-postgres}} # Eventually get rid of POSTGRES_HOST, but for now keep it for backwards compatibility
-      - POSTGRES_PORT=${R2R_POSTGRES_PORT:-${POSTGRES_PORT:-5432}} # Eventually get rid of POSTGRES_PORT, but for now keep it for backwards compatibility
-      - POSTGRES_MAX_CONNECTIONS=${R2R_POSTGRES_MAX_CONNECTIONS:-${POSTGRES_MAX_CONNECTIONS:-1024}} # Eventually get rid of POSTGRES_MAX_CONNECTIONS, but for now keep it for backwards compatibility
+      - POSTGRES_USER=${R2R_POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${R2R_POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_HOST=${R2R_POSTGRES_HOST:-postgres}
+      - POSTGRES_PORT=${R2R_POSTGRES_PORT:-5432}
+      - POSTGRES_MAX_CONNECTIONS=${R2R_POSTGRES_MAX_CONNECTIONS:-1024}
       - PGPORT=${R2R_POSTGRES_PORT:-5432}
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -276,7 +276,7 @@ services:
       context: .
       args:
         PORT: ${R2R_PORT:-7272}
-        R2R_PORT: ${R2R_PORT:-${PORT:-7272}}
+        R2R_PORT: ${R2R_PORT:-7272}
         HOST: ${R2R_HOST:-0.0.0.0}
         R2R_HOST: ${R2R_HOST:-0.0.0.0}
     ports:

--- a/py/core/base/providers/database.py
+++ b/py/core/base/providers/database.py
@@ -54,18 +54,6 @@ from .base import ProviderConfig
 logger = logging.getLogger()
 
 
-def escape_braces(s: str) -> str:
-    """
-    Escape braces in a string.
-    This is a placeholder function - implement the actual logic as needed.
-    """
-    # Implement your escape_braces logic here
-    return s.replace("{", "{{").replace("}", "}}")
-
-
-logger = logging.getLogger()
-
-
 class PostgresConfigurationSettings(BaseModel):
     """
     Configuration settings with defaults defined by the PGVector docker image.
@@ -74,23 +62,24 @@ class PostgresConfigurationSettings(BaseModel):
     To tune these settings for a specific deployment, see https://pgtune.leopard.in.ua/
     """
 
-    max_connections: Optional[int] = 256
-    shared_buffers: Optional[int] = 16384
-    effective_cache_size: Optional[int] = 524288
-    maintenance_work_mem: Optional[int] = 65536
     checkpoint_completion_target: Optional[float] = 0.9
-    wal_buffers: Optional[int] = 512
     default_statistics_target: Optional[int] = 100
-    random_page_cost: Optional[float] = 4
     effective_io_concurrency: Optional[int] = 1
-    work_mem: Optional[int] = 4096
+    effective_cache_size: Optional[int] = 524288
     huge_pages: Optional[str] = "try"
-    min_wal_size: Optional[int] = 80
-    max_wal_size: Optional[int] = 1024
-    max_worker_processes: Optional[int] = 8
+    maintenance_work_mem: Optional[int] = 65536
+    max_connections: Optional[int] = 256
     max_parallel_workers_per_gather: Optional[int] = 2
     max_parallel_workers: Optional[int] = 8
     max_parallel_maintenance_workers: Optional[int] = 2
+    max_wal_size: Optional[int] = 1024
+    max_worker_processes: Optional[int] = 8
+    min_wal_size: Optional[int] = 80
+    shared_buffers: Optional[int] = 16384
+    statement_cache_size: Optional[int] = 100
+    random_page_cost: Optional[float] = 4
+    wal_buffers: Optional[int] = 512
+    work_mem: Optional[int] = 4096
 
 
 class DatabaseConfig(ProviderConfig):

--- a/py/core/providers/database/postgres.py
+++ b/py/core/providers/database/postgres.py
@@ -208,31 +208,35 @@ class PostgresDBProvider(DatabaseProvider):
         settings = PostgresConfigurationSettings()
 
         env_mapping = {
-            "max_connections": "R2R_POSTGRES_MAX_CONNECTIONS",
-            "shared_buffers": "R2R_POSTGRES_SHARED_BUFFERS",
-            "effective_cache_size": "R2R_POSTGRES_EFFECTIVE_CACHE_SIZE",
-            "maintenance_work_mem": "R2R_POSTGRES_MAINTENANCE_WORK_MEM",
             "checkpoint_completion_target": "R2R_POSTGRES_CHECKPOINT_COMPLETION_TARGET",
-            "wal_buffers": "R2R_POSTGRES_WAL_BUFFERS",
             "default_statistics_target": "R2R_POSTGRES_DEFAULT_STATISTICS_TARGET",
-            "random_page_cost": "R2R_POSTGRES_RANDOM_PAGE_COST",
+            "effective_cache_size": "R2R_POSTGRES_EFFECTIVE_CACHE_SIZE",
             "effective_io_concurrency": "R2R_POSTGRES_EFFECTIVE_IO_CONCURRENCY",
-            "work_mem": "R2R_POSTGRES_WORK_MEM",
             "huge_pages": "R2R_POSTGRES_HUGE_PAGES",
+            "maintenance_work_mem": "R2R_POSTGRES_MAINTENANCE_WORK_MEM",
             "min_wal_size": "R2R_POSTGRES_MIN_WAL_SIZE",
-            "max_wal_size": "R2R_POSTGRES_MAX_WAL_SIZE",
-            "max_worker_processes": "R2R_POSTGRES_MAX_WORKER_PROCESSES",
+            "max_connections": "R2R_POSTGRES_MAX_CONNECTIONS",
             "max_parallel_workers_per_gather": "R2R_POSTGRES_MAX_PARALLEL_WORKERS_PER_GATHER",
             "max_parallel_workers": "R2R_POSTGRES_MAX_PARALLEL_WORKERS",
             "max_parallel_maintenance_workers": "R2R_POSTGRES_MAX_PARALLEL_MAINTENANCE_WORKERS",
+            "max_wal_size": "R2R_POSTGRES_MAX_WAL_SIZE",
+            "max_worker_processes": "R2R_POSTGRES_MAX_WORKER_PROCESSES",
+            "random_page_cost": "R2R_POSTGRES_RANDOM_PAGE_COST",
+            "statement_cache_size": "R2R_POSTGRES_STATEMENT_CACHE_SIZE",
+            "shared_buffers": "R2R_POSTGRES_SHARED_BUFFERS",
+            "wal_buffers": "R2R_POSTGRES_WAL_BUFFERS",
+            "work_mem": "R2R_POSTGRES_WORK_MEM",
         }
 
         for setting, env_var in env_mapping.items():
             value = getattr(
                 config.postgres_configuration_settings, setting, None
-            ) or os.getenv(env_var)
+            )
+            if value is None:
+                value = os.getenv(env_var)
 
-            if value is not None and value != "":
+            print(f"Setting: {setting}, Value: {value}")
+            if value is not None:
                 field_type = settings.__annotations__[setting]
                 if field_type == Optional[int]:
                     value = int(value)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `statement_cache_size` parameter to database configuration for Supabase compatibility and removes deprecated environment variable support.
> 
>   - **Behavior**:
>     - Adds `statement_cache_size` parameter to `PostgresConfigurationSettings` in `database.py`.
>     - Updates `PostgresConnectionManager` in `base.py` to use `statement_cache_size` when creating connection pools.
>     - Handles `DuplicatePreparedStatementError` in `fetch_query()` in `base.py` by suggesting configuration changes.
>   - **Environment Variables**:
>     - Removes deprecated environment variable support in `compose.full.yaml` for `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_PORT`, and `POSTGRES_MAX_CONNECTIONS`.
>   - **Misc**:
>     - Updates `_get_postgres_configuration_settings()` in `postgres.py` to include `statement_cache_size`.
>     - Removes `escape_braces()` function from `database.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 1adc2277279cd5a160b5724b184c068a6f0b9b6d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->