### PR TITLE
Deprecate /users/register for /users, retrieval bug in list chunks

### DIFF
--- a/js/sdk/__tests__/ConversationsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/ConversationsIntegrationSuperUser.test.ts
@@ -47,13 +47,6 @@ describe("r2rClient V3 Collections Integration Tests", () => {
   //   expect(response.results).toBeDefined();
   // });
 
-  test("List branches in a conversation", async () => {
-    const response = await client.conversations.listBranches({
-      id: conversationId,
-    });
-    expect(response.results).toBeDefined();
-  });
-
   test("Delete a conversation", async () => {
     const response = await client.conversations.delete({ id: conversationId });
     expect(response.results).toBeDefined();

--- a/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
+++ b/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
@@ -32,7 +32,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
   });
 
   test("Register user 1", async () => {
-    const response = await client.users.register({
+    const response = await client.users.create({
       email: "user_1@example.com",
       password: "change_me_immediately",
     });
@@ -52,7 +52,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
   });
 
   test("Register user 2", async () => {
-    const response = await client.users.register({
+    const response = await client.users.create({
       email: "user_2@example.com",
       password: "change_me_immediately",
     });
@@ -158,6 +158,36 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     expect(response.results).toBeDefined();
     expect(Array.isArray(response.results)).toBe(true);
+  });
+
+  test("List document chunks as user 1", async () => {
+    const response = await user1Client.documents.listChunks({
+      id: user1DocumentId,
+    });
+
+    expect(response.results).toBeDefined();
+    expect(Array.isArray(response.results)).toBe(true);
+  });
+
+  test("List document chunks as user 2", async () => {
+    const response = await user2Client.documents.listChunks({
+      id: user2DocumentId,
+    });
+
+    expect(response.results).toBeDefined();
+    expect(Array.isArray(response.results)).toBe(true);
+  });
+
+  test("User 2 should not be able to list user 1's document chunks", async () => {
+    await expect(
+      user2Client.documents.listChunks({ id: user1DocumentId }),
+    ).rejects.toThrow(/Status 403/);
+  });
+
+  test("User 1 should not be able to list user 2's document chunks", async () => {
+    await expect(
+      user1Client.documents.listChunks({ id: user2DocumentId }),
+    ).rejects.toThrow(/Status 403/);
   });
 
   test("Delete document as user 1", async () => {

--- a/js/sdk/__tests__/GraphsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/GraphsIntegrationSuperUser.test.ts
@@ -237,7 +237,9 @@ describe("r2rClient V3 Graphs Integration Tests", () => {
     expect(response.results.subject).toBe("Razumikhin");
     expect(response.results.object).toBe("Dunia");
     expect(response.results.predicate).toBe("falls in love with");
-    expect(response.results.description).toBe("Razumikhn and Dunia are central to the story");
+    expect(response.results.description).toBe(
+      "Razumikhn and Dunia are central to the story",
+    );
   });
 
   test("Retrieve the relationship", async () => {

--- a/js/sdk/__tests__/SystemIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/SystemIntegrationSuperUser.test.ts
@@ -19,11 +19,6 @@ describe("r2rClient V3 Collections Integration Tests", () => {
     expect(response.results).toBeDefined();
   });
 
-  test("Get system logs", async () => {
-    const response = await client.system.logs({});
-    expect(response.results).toBeDefined();
-  });
-
   test("Get the settings of the system", async () => {
     const response = await client.system.settings();
     expect(response.results).toBeDefined();

--- a/js/sdk/__tests__/SystemIntegrationUser.test.ts
+++ b/js/sdk/__tests__/SystemIntegrationUser.test.ts
@@ -41,10 +41,6 @@ describe("r2rClient V3 System Integration Tests User", () => {
     expect(response.results).toBeDefined();
   });
 
-  test("Only a superuser can call the `system/logs` endpoint.", async () => {
-    await expect(client.system.logs({})).rejects.toThrow(/Status 403/);
-  });
-
   test("Only a superuser can call the `system/settings` endpoint.", async () => {
     await expect(client.system.settings()).rejects.toThrow(/Status 403/);
   });

--- a/js/sdk/__tests__/SystemIntegrationUser.test.ts
+++ b/js/sdk/__tests__/SystemIntegrationUser.test.ts
@@ -13,16 +13,19 @@ describe("r2rClient V3 System Integration Tests User", () => {
   });
 
   test("Register a new user", async () => {
-    const response = await client.users.register({
+    const response = await client.users.create({
       email: "system_integration_test_user@example.com",
       password: "change_me_immediately",
+      name: "Test User",
+      bio: "This is the bio of the test user.",
     });
 
     userId = response.results.id;
     name = response.results.name;
     expect(response.results).toBeDefined();
     expect(response.results.is_superuser).toBe(false);
-    expect(response.results.name).toBe(null);
+    expect(response.results.name).toBe("Test User");
+    expect(response.results.bio).toBe("This is the bio of the test user.");
   });
 
   test("Login as a user", async () => {

--- a/js/sdk/__tests__/UsersIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/UsersIntegrationSuperUser.test.ts
@@ -13,7 +13,7 @@ describe("r2rClient V3 Users Integration Tests", () => {
   });
 
   test("Register a new user", async () => {
-    const response = await client.users.register({
+    const response = await client.users.create({
       email: "new_user@example.com",
       password: "change_me_immediately",
     });

--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -77,15 +77,6 @@ export interface MessageResponse {
   metadata: Record<string, any>;
 }
 
-export interface BranchResponse {
-  branch_id: string;
-  branch_point_id?: string;
-  content?: string;
-  created_at: string;
-  user_id?: string;
-  name?: string;
-}
-
 // Document types
 export interface DocumentResponse {
   id: string;
@@ -266,13 +257,6 @@ export interface CombinedSearchResponse {
 }
 
 // System types
-export interface LogsResponse {
-  run_id: string;
-  run_type: string;
-  entries: Record<string, any>[];
-  timestamp?: string;
-  user_id?: string;
-}
 
 export interface ServerStats {
   start_time: string;
@@ -344,8 +328,6 @@ export type WrappedMessageResponse = ResultsWrapper<MessageResponse>;
 export type WrappedMessagesResponse = PaginatedResultsWrapper<
   MessageResponse[]
 >;
-export type WrappedBranchResponse = ResultsWrapper<BranchResponse>;
-export type WrappedBranchesResponse = PaginatedResultsWrapper<BranchResponse[]>;
 
 // Document Responses
 export type WrappedDocumentResponse = ResultsWrapper<DocumentResponse>;
@@ -383,7 +365,6 @@ export type WrappedSearchResponse = ResultsWrapper<CombinedSearchResponse>;
 
 // System Responses
 export type WrappedSettingsResponse = ResultsWrapper<SettingsResponse>;
-export type WrappedLogsResponse = PaginatedResultsWrapper<LogsResponse[]>;
 export type WrappedServerStatsResponse = ResultsWrapper<ServerStats>;
 
 // User Responses

--- a/js/sdk/src/v3/clients/conversations.ts
+++ b/js/sdk/src/v3/clients/conversations.ts
@@ -2,7 +2,6 @@ import { feature } from "../../feature";
 import { r2rClient } from "../../r2rClient";
 import {
   WrappedBooleanResponse,
-  WrappedBranchesResponse,
   WrappedConversationMessagesResponse,
   WrappedConversationResponse,
   WrappedConversationsResponse,
@@ -51,21 +50,13 @@ export class ConversationsClient {
   /**
    * Get detailed information about a specific conversation.
    * @param id The ID of the conversation to retrieve
-   * @param branchID The ID of the branch to retrieve
    * @returns
    */
   @feature("conversations.retrieve")
   async retrieve(options: {
     id: string;
-    branchID?: string;
   }): Promise<WrappedConversationMessagesResponse> {
-    const params: Record<string, any> = {
-      branchID: options.branchID,
-    };
-
-    return this.client.makeRequest("GET", `conversations/${options.id}`, {
-      params,
-    });
+    return this.client.makeRequest("GET", `conversations/${options.id}`);
   }
 
   /**
@@ -133,31 +124,6 @@ export class ConversationsClient {
       `conversations/${options.id}/messages/${options.messageID}`,
       {
         data,
-      },
-    );
-  }
-
-  /**
-   * List all branches in a conversation.
-   * @param id The ID of the conversation to list branches for
-   * @returns
-   */
-  @feature("conversations.listBranches")
-  async listBranches(options: {
-    id: string;
-    offset?: number;
-    limit?: number;
-  }): Promise<WrappedBranchesResponse> {
-    const params: Record<string, any> = {
-      offset: options?.offset ?? 0,
-      limit: options?.limit ?? 100,
-    };
-
-    return this.client.makeRequest(
-      "GET",
-      `conversations/${options.id}/branches`,
-      {
-        params,
       },
     );
   }

--- a/js/sdk/src/v3/clients/retrieval.ts
+++ b/js/sdk/src/v3/clients/retrieval.ts
@@ -139,7 +139,6 @@ export class RetrievalClient {
    *    - Customizable generation parameters for response style and length
    *    - Source document citation with optional title inclusion
    *    - Streaming support for real-time responses
-   *    - Branch management for exploring different conversation paths
    *
    * Common Use Cases:
    *    - Research assistance and literature review
@@ -157,7 +156,6 @@ export class RetrievalClient {
    * @param taskPromptOverride Optional custom prompt to override default
    * @param includeTitleIfAvailable Include document titles in responses when available
    * @param conversationId ID of the conversation
-   * @param branchId ID of the conversation branch
    * @returns
    */
   @feature("retrieval.agent")
@@ -169,7 +167,6 @@ export class RetrievalClient {
     taskPromptOverride?: string;
     includeTitleIfAvailable?: boolean;
     conversationId?: string;
-    branchId?: string;
   }): Promise<any | AsyncGenerator<string, void, unknown>> {
     const data: Record<string, any> = {
       message: options.message,
@@ -190,9 +187,6 @@ export class RetrievalClient {
       }),
       ...(options.conversationId && {
         conversation_id: options.conversationId,
-      }),
-      ...(options.branchId && {
-        branch_id: options.branchId,
       }),
     };
 

--- a/js/sdk/src/v3/clients/system.ts
+++ b/js/sdk/src/v3/clients/system.ts
@@ -2,7 +2,6 @@ import { feature } from "../../feature";
 import { r2rClient } from "../../r2rClient";
 import {
   WrappedGenericMessageResponse,
-  WrappedLogsResponse,
   WrappedServerStatsResponse,
   WrappedSettingsResponse,
 } from "../../types";
@@ -16,29 +15,6 @@ export class SystemClient {
   @feature("system.health")
   async health(): Promise<WrappedGenericMessageResponse> {
     return await this.client.makeRequest("GET", "health");
-  }
-
-  /**
-   * Get logs from the server.
-   * @param options
-   * @returns
-   */
-  @feature("system.logs")
-  async logs(options: {
-    runTypeFilter?: string;
-    offset?: number;
-    limit?: number;
-  }): Promise<WrappedLogsResponse> {
-    const params: Record<string, any> = {
-      offset: options.offset ?? 0,
-      limit: options.limit ?? 100,
-    };
-
-    if (options.runTypeFilter) {
-      params.runTypeFilter = options.runTypeFilter;
-    }
-
-    return this.client.makeRequest("GET", "system/logs", { params });
   }
 
   /**

--- a/js/sdk/src/v3/clients/users.ts
+++ b/js/sdk/src/v3/clients/users.ts
@@ -13,10 +13,43 @@ export class UsersClient {
   constructor(private client: r2rClient) {}
 
   /**
+   * Create a new user.
+   * @param email User's email address
+   * @param password User's password
+   * @param name The name for the new user
+   * @param bio The bio for the new user
+   * @param profilePicture The profile picture for the new user
+   * @returns WrappedUserResponse
+   */
+  @feature("users.create")
+  async create(options: {
+    email: string;
+    password: string;
+    name?: string;
+    bio?: string;
+    profilePicture?: string;
+  }): Promise<WrappedUserResponse> {
+    const data = {
+      ...(options.email && { email: options.email }),
+      ...(options.password && { password: options.password }),
+      ...(options.name && { name: options.name }),
+      ...(options.bio && { bio: options.bio }),
+      ...(options.profilePicture && {
+        profile_picture: options.profilePicture,
+      }),
+    };
+
+    return this.client.makeRequest("POST", "users", {
+      data: data,
+    });
+  }
+
+  /**
    * Register a new user.
    * @param email User's email address
    * @param password User's password
-   * @returns
+   * @returns WrappedUserResponse
+   * @deprecated Use `client.users.create` instead.
    */
   @feature("users.register")
   async register(options: {

--- a/py/cli/commands/users.py
+++ b/py/cli/commands/users.py
@@ -17,12 +17,12 @@ def users():
 @click.argument("email", required=True, type=str)
 @click.argument("password", required=True, type=str)
 @pass_context
-async def register(ctx, email, password):
+async def create(ctx, email, password):
     """Create a new user."""
     client: R2RAsyncClient = ctx.obj
 
     with timer():
-        response = await client.users.register(email=email, password=password)
+        response = await client.users.create(email=email, password=password)
 
     click.echo(json.dumps(response, indent=2))
 

--- a/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_chunks.py
+++ b/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_chunks.py
@@ -28,7 +28,7 @@ client = R2RClient("http://localhost:7276", prefix="/v3")
 
 # First create and authenticate a user if not already done
 try:
-    new_user = client.users.register(
+    new_user = client.users.create(
         email=user_email, password="new_secure_password123"
     )
     print("New user created:", new_user)

--- a/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_collections.py
+++ b/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_collections.py
@@ -6,7 +6,7 @@ client = R2RClient("http://localhost:7276", prefix="/v3")
 
 # First create and authenticate a user if not already done
 try:
-    new_user = client.users.register(
+    new_user = client.users.create(
         email=user_email, password="new_secure_password123"
     )
     print("New user created:", new_user)

--- a/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_conversations.py
+++ b/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_conversations.py
@@ -8,7 +8,7 @@ client = R2RClient("http://localhost:7276", prefix="/v3")
 
 # First create and authenticate a user if not already done
 try:
-    new_user = client.users.register(
+    new_user = client.users.create(
         email=user_email, password="new_secure_password123"
     )
     print("New user created:", new_user)

--- a/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_documents.py
+++ b/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_documents.py
@@ -8,7 +8,7 @@ client = R2RClient("http://localhost:7276", prefix="/v3")
 
 # First create and authenticate a user if not already done
 try:
-    new_user = client.users.register(
+    new_user = client.users.create(
         email=user_email, password="new_secure_password123"
     )
     print("New user created:", new_user)

--- a/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_graph.py
+++ b/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_graph.py
@@ -13,7 +13,7 @@ def setup_prerequisites():
 
     # # Login
     # try:
-    #     client.users.register(email=user_email, password="new_secure_password123")
+    #     client.users.create(email=user_email, password="new_secure_password123")
     # except Exception as e:
     #     print("User might already exist:", str(e))
 

--- a/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_prompts.py
+++ b/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_prompts.py
@@ -7,7 +7,7 @@ client = R2RClient("http://localhost:7276", prefix="/v3")
 
 # # First create and authenticate a user if not already done
 # try:
-#     new_user = client.users.register(
+#     new_user = client.users.create(
 #         email=user_email, password="new_secure_password123"
 #     )
 #     print("New user created:", new_user)

--- a/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_users.py
+++ b/py/core/examples/scripts/test_v3_sdk/test_v3_sdk_users.py
@@ -26,7 +26,7 @@ client = R2RClient("http://localhost:7276", prefix="/v3")
 
 # Test 1: Register user
 print("\n=== Test 1: Register User ===")
-register_result = client.users.register(
+register_result = client.users.create(
     email=user_email, password="secure_password123"
 )
 print("Registered user:", register_result)

--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -823,10 +823,7 @@ class DocumentsRouter(BaseRouterV3):
             user_has_access = (
                 is_owner
                 or set(auth_user.collection_ids).intersection(
-                    {
-                        ele.collection_id
-                        for ele in document_collections["results"]
-                    }
+                    {ele.id for ele in document_collections["results"]}
                 )
                 != set()
             )

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -31,7 +31,97 @@ class UsersRouter(BaseRouterV3):
 
     def _setup_routes(self):
 
-        # New authentication routes
+        @self.router.post(
+            "/users",
+            response_model=WrappedUserResponse,
+            openapi_extra={
+                "x-codeSamples": [
+                    {
+                        "lang": "Python",
+                        "source": textwrap.dedent(
+                            """
+                            from r2r import R2RClient
+
+                            client = R2RClient("http://localhost:7272")
+                            new_user = client.users.create(
+                                email="jane.doe@example.com",
+                                password="secure_password123"
+                            )"""
+                        ),
+                    },
+                    {
+                        "lang": "JavaScript",
+                        "source": textwrap.dedent(
+                            """
+                            const { r2rClient } = require("r2r-js");
+
+                            const client = new r2rClient("http://localhost:7272");
+
+                            function main() {
+                                const response = await client.users.create({
+                                    email: "jane.doe@example.com",
+                                    password: "secure_password123"
+                                });
+                            }
+
+                            main();
+                            """
+                        ),
+                    },
+                    {
+                        "lang": "CLI",
+                        "source": textwrap.dedent(
+                            """
+                            r2r users create jane.doe@example.com secure_password123
+                            """
+                        ),
+                    },
+                    {
+                        "lang": "cURL",
+                        "source": textwrap.dedent(
+                            """
+                            curl -X POST "https://api.example.com/v3/users" \\
+                                -H "Content-Type: application/json" \\
+                                -d '{
+                                    "email": "jane.doe@example.com",
+                                    "password": "secure_password123"
+                                }'"""
+                        ),
+                    },
+                ]
+            },
+        )
+        @self.base_endpoint
+        async def register(
+            email: EmailStr = Body(..., description="User's email address"),
+            password: str = Body(..., description="User's password"),
+            name: str | None = Body(
+                None, description="The name for the new user"
+            ),
+            bio: str | None = Body(
+                None, description="The bio for the new user"
+            ),
+            profile_picture: str | None = Body(
+                None, description="Updated user profile picture"
+            ),
+            auth_user=Depends(self.providers.auth.auth_wrapper),
+        ) -> WrappedUserResponse:
+            """Register a new user with the given email and password."""
+            registration_response = await self.services["auth"].register(
+                email, password
+            )
+
+            if name or bio or profile_picture:
+                return await self.services["auth"].update_user(
+                    user_id=registration_response.id,
+                    name=name,
+                    bio=bio,
+                    profile_picture=profile_picture,
+                )
+
+            return registration_response
+
+        # TODO: deprecated, remove in next release
         @self.router.post(
             "/users/register",
             response_model=WrappedUserResponse,

--- a/py/core/main/services/auth_service.py
+++ b/py/core/main/services/auth_service.py
@@ -176,8 +176,13 @@ class AuthService(Service):
         # Delete user's default collection
         # TODO: We need to better define what happens to the user's data when they are deleted
         collection_id = generate_default_user_collection_id(user_id)
+
+        await self.providers.database.graph_handler.delete_graph_for_collection(
+            collection_id=collection_id,
+        )
+
         await self.providers.database.delete_collection_relational(
-            collection_id
+            collection_id=collection_id,
         )
 
         if delete_vector_data:

--- a/py/core/providers/database/graph.py
+++ b/py/core/providers/database/graph.py
@@ -2067,7 +2067,7 @@ class PostgresGraphHandler(GraphHandler):
 
         # don't delete if status is PROCESSING.
         QUERY = f"""
-            SELECT graph_cluster_status FROM {self._get_table_name("collections")} WHERE collection_id = $1
+            SELECT graph_cluster_status FROM {self._get_table_name("collections")} WHERE id = $1
         """
         status = (
             await self.connection_manager.fetch_query(QUERY, [collection_id])
@@ -2108,19 +2108,20 @@ class PostgresGraphHandler(GraphHandler):
                 QUERY, [KGExtractionStatus.PENDING, collection_id]
             )
 
-        for query in DELETE_QUERIES:
-            if "community" in query or "graphs_entities" in query:
-                await self.connection_manager.execute_query(
-                    query, [collection_id]
-                )
-            else:
-                await self.connection_manager.execute_query(
-                    query, [document_ids]
-                )
+        if document_ids:
+            for query in DELETE_QUERIES:
+                if "community" in query or "graphs_entities" in query:
+                    await self.connection_manager.execute_query(
+                        query, [collection_id]
+                    )
+                else:
+                    await self.connection_manager.execute_query(
+                        query, [document_ids]
+                    )
 
         # set status to PENDING for this collection.
         QUERY = f"""
-            UPDATE {self._get_table_name("collections")} SET graph_cluster_status = $1 WHERE collection_id = $2
+            UPDATE {self._get_table_name("collections")} SET graph_cluster_status = $1 WHERE id = $2
         """
         await self.connection_manager.execute_query(
             QUERY, [KGExtractionStatus.PENDING, collection_id]

--- a/py/sdk/v2/auth.py
+++ b/py/sdk/v2/auth.py
@@ -9,7 +9,7 @@ from ..models import Token, User
 
 
 class AuthMixins:
-    @deprecated("Use client.users.register() instead")
+    @deprecated("Use client.users.create() instead")
     async def register(self, email: str, password: str) -> User:
         """
         Registers a new user with the given email and password.

--- a/py/sdk/v2/sync_auth.py
+++ b/py/sdk/v2/sync_auth.py
@@ -9,7 +9,7 @@ from ..models import Token, User
 
 
 class SyncAuthMixins:
-    @deprecated("Use client.users.register() instead")
+    @deprecated("Use client.users.create() instead")
     def register(self, email: str, password: str) -> User:
         """
         Registers a new user with the given email and password.

--- a/py/sdk/v3/users.py
+++ b/py/sdk/v3/users.py
@@ -1,3 +1,5 @@
+from __future__ import annotations  # for Python 3.10+
+from typing_extensions import deprecated
 from typing import Optional
 from uuid import UUID
 
@@ -19,6 +21,45 @@ class UsersSDK:
     def __init__(self, client):
         self.client = client
 
+    async def create(
+        self,
+        email: str,
+        password: str,
+        name: Optional[str] = None,
+        bio: Optional[str] = None,
+        profile_picture: Optional[str] = None,
+    ) -> WrappedUserResponse:
+        """
+        Register a new user.
+
+        Args:
+            email (str): User's email address
+            password (str): User's password
+            name (Optional[str]): The name for the new user
+            bio (Optional[str]): The bio for the new user
+            profile_picture (Optional[str]): New user profile picture
+
+        Returns:
+            UserResponse: New user information
+        """
+
+        data: dict = {"email": email, "password": password}
+
+        if name is not None:
+            data["name"] = name
+        if bio is not None:
+            data["bio"] = bio
+        if profile_picture is not None:
+            data["profile_picture"] = profile_picture
+
+        return await self.client._make_request(
+            "POST",
+            "users",
+            json=data,
+            version="v3",
+        )
+
+    @deprecated("Use client.users.create() instead")
     async def register(self, email: str, password: str) -> WrappedUserResponse:
         """
         Register a new user.
@@ -302,7 +343,9 @@ class UsersSDK:
             id (str | UUID): User ID to update
             username (Optional[str]): New username
             is_superuser (Optional[bool]): Update superuser status
-            metadata (Optional[Dict[str, Any]]): Update user metadata
+            name (Optional[str]): New name
+            bio (Optional[str]): New bio
+            profile_picture (Optional[str]): New profile picture
 
         Returns:
             dict: Updated user information

--- a/py/tests/integration/runner_chunks.py
+++ b/py/tests/integration/runner_chunks.py
@@ -188,7 +188,7 @@ def test_unauthorized_chunk_access():
     # Simulate non-owner client (no auth)
     client_non_owner = create_client("http://localhost:7272")
     random_string = str(uuid.uuid4())
-    client_non_owner.users.register(f"{random_string}@me.com", "password")
+    client_non_owner.users.create(f"{random_string}@me.com", "password")
     client_non_owner.users.login(f"{random_string}@me.com", "password")
 
     try:

--- a/py/tests/integration/runner_collections.py
+++ b/py/tests/integration/runner_collections.py
@@ -150,7 +150,7 @@ def test_remove_non_member_user_from_collection():
     # Setup: Create a user and a collection
     user_email = f"user_{uuid.uuid4()}@test.com"
     password = "pwd123"
-    client.users.register(user_email, password)
+    client.users.create(user_email, password)
     client.users.login(user_email, password)
 
     # Create a collection by the same user
@@ -162,7 +162,7 @@ def test_remove_non_member_user_from_collection():
 
     # Create another user who will not be added to the collection
     another_user_email = f"user2_{uuid.uuid4()}@test.com"
-    client.users.register(another_user_email, "pass456")
+    client.users.create(another_user_email, "pass456")
     another_user_id = client.users.me()["results"]["id"]
     client.users.logout()
 
@@ -212,7 +212,7 @@ def test_add_user_to_non_existent_collection():
     # Create a regular user
     user_email = f"test_user_{uuid.uuid4()}@test.com"
     user_password = "test_password"
-    client.users.register(user_email, user_password)
+    client.users.create(user_email, user_password)
     client.users.login(user_email, user_password)
     user_id = client.users.me()["results"]["id"]
     client.users.logout()
@@ -245,7 +245,7 @@ def test_remove_non_member_user_from_collection():
     # Create a user (Owner)
     owner_email = f"owner_{uuid.uuid4()}@test.com"
     owner_password = "password123"
-    client.users.register(owner_email, owner_password)
+    client.users.create(owner_email, owner_password)
     client.users.login(owner_email, owner_password)
 
     # Create a collection by this owner
@@ -256,7 +256,7 @@ def test_remove_non_member_user_from_collection():
     # Create another user who will NOT be added to this collection
     other_user_email = f"other_{uuid.uuid4()}@test.com"
     other_password = "password456"
-    client.users.register(other_user_email, other_password)
+    client.users.create(other_user_email, other_password)
     # Need the other user's ID but no need to keep them logged in
     client.users.login(other_user_email, other_password)
     other_user_id = client.users.me()["results"]["id"]
@@ -287,7 +287,7 @@ def test_non_owner_delete_collection():
     # Create owner user
     owner_email = f"owner_{uuid.uuid4()}@test.com"
     owner_password = "pwd123"
-    client.users.register(owner_email, owner_password)
+    client.users.create(owner_email, owner_password)
     client.users.login(owner_email, owner_password)
     coll = client.collections.create(name="Owner Collection")["results"]
     coll_id = coll["id"]
@@ -296,7 +296,7 @@ def test_non_owner_delete_collection():
     non_owner_email = f"nonowner_{uuid.uuid4()}@test.com"
     non_owner_password = "pwd1234"
     client.users.logout()
-    client.users.register(non_owner_email, non_owner_password)
+    client.users.create(non_owner_email, non_owner_password)
     client.users.login(non_owner_email, non_owner_password)
     non_owner_id = client.users.me()["results"]["id"]
     client.users.logout()

--- a/py/tests/integration/runner_documents.py
+++ b/py/tests/integration/runner_documents.py
@@ -377,7 +377,7 @@ def test_extract_document_unauthorized():
     # In reality, you'd do something like client_non_superuser.login("user", "pass")
     client_non_superuser = create_client("http://localhost:7272")
     random_string = str(uuid.uuid4())
-    client_non_superuser.users.register(f"{random_string}@me.com", "password")
+    client_non_superuser.users.create(f"{random_string}@me.com", "password")
     client_non_superuser.users.login(f"{random_string}@me.com", "password")
 
     document_id = "db02076e-989a-59cd-98d5-e24e15a0bd27"
@@ -433,7 +433,7 @@ def test_get_document_collections_non_superuser():
     print("Testing: Collections endpoint as non-superuser")
     client_non_superuser = create_client("http://localhost:7272")
     random_string = str(uuid.uuid4())
-    client_non_superuser.users.register(f"{random_string}@me.com", "password")
+    client_non_superuser.users.create(f"{random_string}@me.com", "password")
     client_non_superuser.users.login(f"{random_string}@me.com", "password")
 
     # Without superuser perms, should fail
@@ -460,7 +460,7 @@ def test_access_document_not_owned():
     # Now try to retrieve with a non-superuser client
     client_non_superuser = create_client("http://localhost:7272")
     random_string = str(uuid.uuid4())
-    client_non_superuser.users.register(f"{random_string}@me.com", "password")
+    client_non_superuser.users.create(f"{random_string}@me.com", "password")
     client_non_superuser.users.login(f"{random_string}@me.com", "password")
 
     try:

--- a/py/tests/integration/runner_user_documents_collections.py
+++ b/py/tests/integration/runner_user_documents_collections.py
@@ -30,7 +30,7 @@ def create_test_user(base_url: str) -> TestUser:
     password = f"pass_{random_string}"
 
     client = R2RClient(base_url)
-    user = client.users.register(email, password)["results"]
+    user = client.users.create(email, password)["results"]
     client.users.login(email, password)
 
     return TestUser(
@@ -68,13 +68,13 @@ def test_document_sharing_via_collections():
 
     f1 = random.randint(1, 1_000_000)
     f2 = random.randint(1, 1_000_000)
-    client.users.register(f"user2_{f2}@test.com", "password123")
+    client.users.create(f"user2_{f2}@test.com", "password123")
     client.users.login(f"user2_{f2}@test.com", "password123")
     user2_id = client.users.me()["results"]["id"]
     client.users.logout()
     print("user2_id = ", user2_id)
 
-    client.users.register(f"user1_{f1}@test.com", "password123")
+    client.users.create(f"user1_{f1}@test.com", "password123")
     client.users.login(f"user1_{f1}@test.com", "password123")
     user1_id = client.users.me()["results"]["id"]
     print("user1_id = ", user1_id)
@@ -123,14 +123,14 @@ def test_collection_document_removal():
     f2 = random.randint(1, 1_000_000)
 
     # Create and get user2 first
-    client.users.register(f"user2_{f2}@test.com", "password123")
+    client.users.create(f"user2_{f2}@test.com", "password123")
     client.users.login(f"user2_{f2}@test.com", "password123")
     user2_id = client.users.me()["results"]["id"]
     client.users.logout()
     print("user2_id = ", user2_id)
 
     # Create and login as user1
-    client.users.register(f"user1_{f1}@test.com", "password123")
+    client.users.create(f"user1_{f1}@test.com", "password123")
     client.users.login(f"user1_{f1}@test.com", "password123")
     user1_id = client.users.me()["results"]["id"]
     print("user1_id = ", user1_id)
@@ -197,13 +197,13 @@ def test_document_access_restrictions():
     f2 = random.randint(1, 1_000_000)
 
     # Create and get user2 first
-    client.users.register(f"user2_{f2}@test.com", "password123")
+    client.users.create(f"user2_{f2}@test.com", "password123")
     client.users.login(f"user2_{f2}@test.com", "password123")
     user2_id = client.users.me()["results"]["id"]
     client.users.logout()
 
     # Create and login as user1
-    client.users.register(f"user1_{f1}@test.com", "password123")
+    client.users.create(f"user1_{f1}@test.com", "password123")
     client.users.login(f"user1_{f1}@test.com", "password123")
     user1_id = client.users.me()["results"]["id"]
 
@@ -239,13 +239,13 @@ def test_document_search_across_users():
     f2 = random.randint(1, 1_000_000)
 
     # Create and get user2 first
-    client.users.register(f"user2_{f2}@test.com", "password123")
+    client.users.create(f"user2_{f2}@test.com", "password123")
     client.users.login(f"user2_{f2}@test.com", "password123")
     user2_id = client.users.me()["results"]["id"]
     client.users.logout()
 
     # Create and login as user1
-    client.users.register(f"user1_{f1}@test.com", "password123")
+    client.users.create(f"user1_{f1}@test.com", "password123")
     client.users.login(f"user1_{f1}@test.com", "password123")
     user1_id = client.users.me()["results"]["id"]
 
@@ -299,7 +299,7 @@ def test_concurrent_document_access():
     # Create three users with random IDs
     for i in range(3):
         f = random.randint(1, 1_000_000)
-        client.users.register(f"user{i}_{f}@test.com", "password123")
+        client.users.create(f"user{i}_{f}@test.com", "password123")
         client.users.login(f"user{i}_{f}@test.com", "password123")
         user_ids.append(client.users.me()["results"]["id"])
         credentials.append((f"user{i}_{f}@test.com", "password123"))
@@ -350,7 +350,7 @@ def test_multiple_collections_document_access():
     owner_password = "password"
     client = R2RClient(args.base_url)
 
-    client.users.register(owner_email, owner_password)
+    client.users.create(owner_email, owner_password)
     client.users.login(owner_email, owner_password)
 
     coll1 = client.collections.create(name="Collection One")["results"]["id"]
@@ -367,7 +367,7 @@ def test_multiple_collections_document_access():
     other_email = f"other_{uuid.uuid4()}@test.com"
     other_password = "password123"
     client.users.logout()
-    client.users.register(other_email, other_password)
+    client.users.create(other_email, other_password)
     client.users.login(other_email, other_password)
     other_user_id = client.users.me()["results"]["id"]
     client.users.logout()

--- a/py/tests/integration/runner_users.py
+++ b/py/tests/integration/runner_users.py
@@ -32,7 +32,7 @@ def superuser_login():
 
 def register_and_verify_user(email, password):
     # Register
-    user = client.users.register(email, password)["results"]
+    user = client.users.create(email, password)["results"]
     user_id = user["id"]
     # In a real scenario, you'd have to retrieve the verification code from an email box or a test hook.
     # For the sake of testing, we might have a method in dev to auto-verify.
@@ -52,7 +52,7 @@ def test_register_user():
     print("Testing: User registration")
     random_email = f"{uuid.uuid4()}@example.com"
     password = "test_password123"
-    user_resp = client.users.register(random_email, password)
+    user_resp = client.users.create(random_email, password)
     user = user_resp["results"]
     assert_http_error(
         "id" in user, "User registration failed, no user ID returned"
@@ -370,7 +370,7 @@ def test_superuser_downgrade_permissions():
 
     user_email = f"test_super_{uuid.uuid4()}@test.com"
     user_password = "securepass"
-    new_user = client.users.register(user_email, user_password)["results"]
+    new_user = client.users.create(user_email, user_password)["results"]
     new_user_id = new_user["id"]
 
     # Update them to superuser

--- a/services/clustering/main.py
+++ b/services/clustering/main.py
@@ -1,14 +1,12 @@
 import logging
-from typing import Any, List, Optional
 
 import networkx as nx
-import uvicorn
 from fastapi import FastAPI, HTTPException
 
 # Make sure graspologic and networkx are installed
 # Requires that "graspologic[leiden]" extras are installed if needed.
 from graspologic.partition import hierarchical_leiden
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 app = FastAPI()
 logger = logging.getLogger("graspologic_service")
@@ -32,7 +30,7 @@ class LeidenParams(BaseModel):
     # Add any other parameters as needed.
 
 class ClusterRequest(BaseModel):
-    relationships: List[Relationship]
+    relationships: list[Relationship]
     leiden_params: LeidenParams
 
 class CommunityAssignment(BaseModel):
@@ -41,7 +39,7 @@ class CommunityAssignment(BaseModel):
     level: int
 
 class ClusterResponse(BaseModel):
-    communities: List[CommunityAssignment]
+    communities: list[CommunityAssignment]
 
 
 @app.post("/cluster", response_model=ClusterResponse)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deprecate `register` method for user creation, replace with `create`, and add tests for document chunk access and user interactions.
> 
>   - **Deprecation and Replacement**:
>     - Deprecate `register` method in favor of `create` for user creation in `users.ts`, `auth.py`, `sync_auth.py`, and `users.py`.
>     - Update all relevant test files to use `create` instead of `register`.
>   - **Testing**:
>     - Add tests for listing document chunks and access control in `DocumentsAndCollectionsIntegrationUser.test.ts`.
>     - Add tests for unauthorized access and non-existent chunk retrieval in `runner_chunks.py`.
>     - Add tests for user and document interactions in `runner_user_documents_collections.py`.
>   - **Bug Fixes**:
>     - Fix bug in `documents_router.py` related to document chunk retrieval by correcting collection ID handling.
>     - Correct SQL query in `graph.py` for deleting graphs by collection ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 3a2f108c356631932abed4e0f253f0918a09925d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->