### PR TITLE
Test cloud rate limit

### DIFF
--- a/.github/workflows/rate-limit-test.yml
+++ b/.github/workflows/rate-limit-test.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v3
-      
+
     - name: Run rate limit test
       run: |
-        chmod +x ./py/tests/rate-limit-test.sh
-        ./py/tests/rate-limit-test.sh
+        chmod +x ./py/tests/rateLimit.bash
+        ./py/tests/rateLimit.bash

--- a/.github/workflows/rate-limit-test.yml
+++ b/.github/workflows/rate-limit-test.yml
@@ -1,0 +1,20 @@
+name: Rate Limit Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+      
+    - name: Run rate limit test
+      run: |
+        chmod +x ./py/tests/rate-limit-test.sh
+        ./py/tests/rate-limit-test.sh

--- a/py/tests/rateLimit.bash
+++ b/py/tests/rateLimit.bash
@@ -30,7 +30,7 @@ echo "Target: At least $REQUIRED_429_COUNT rate limits (HTTP 429)"
 for ((i=1; i<=TOTAL_REQUESTS; i++)); do
     RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
     count_total=$((count_total + 1))
-    
+
     # Color coding for different responses
     if [ "$RESPONSE" = "429" ]; then
         count_429=$((count_429 + 1))
@@ -40,7 +40,7 @@ for ((i=1; i<=TOTAL_REQUESTS; i++)); do
     else
         echo -e "\033[31mRequest $i: HTTP $RESPONSE (Error)\033[0m"
     fi
-    
+
     sleep $SLEEP_INTERVAL
 done
 

--- a/py/tests/rateLimit.bash
+++ b/py/tests/rateLimit.bash
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Configuration
+URL="https://api.cloud.sciphi.ai/v3/health"
+TOTAL_REQUESTS=60
+SLEEP_INTERVAL=0.05
+REQUIRED_429_COUNT=20
+
+# Initialize counters
+count_429=0
+count_total=0
+
+# Function to handle exit codes
+check_exit_status() {
+    if [ $count_429 -ge $REQUIRED_429_COUNT ]; then
+        echo "✅ Test passed: Got $count_429 rate limits (429s), which meets the minimum requirement of $REQUIRED_429_COUNT"
+        exit 0
+    else
+        echo "❌ Test failed: Only got $count_429 rate limits (429s), which is less than the required $REQUIRED_429_COUNT"
+        exit 1
+    fi
+}
+
+# Trap Ctrl+C and call check_exit_status
+trap check_exit_status INT
+
+echo "Starting rate limit test for $URL"
+echo "Target: At least $REQUIRED_429_COUNT rate limits (HTTP 429)"
+
+for ((i=1; i<=TOTAL_REQUESTS; i++)); do
+    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+    count_total=$((count_total + 1))
+    
+    # Color coding for different responses
+    if [ "$RESPONSE" = "429" ]; then
+        count_429=$((count_429 + 1))
+        echo -e "\033[33mRequest $i: HTTP $RESPONSE (Rate limit) - Total 429s: $count_429\033[0m"
+    elif [ "$RESPONSE" = "200" ]; then
+        echo -e "\033[32mRequest $i: HTTP $RESPONSE (Success)\033[0m"
+    else
+        echo -e "\033[31mRequest $i: HTTP $RESPONSE (Error)\033[0m"
+    fi
+    
+    sleep $SLEEP_INTERVAL
+done
+
+# Check final results
+check_exit_status


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a GitHub Actions workflow and bash script to test API rate limits by sending requests and checking for HTTP 429 responses.
> 
>   - **Workflow**:
>     - Adds `rate-limit-test.yml` to `.github/workflows` to test API rate limits.
>     - Triggers on push and pull request events to the `main` branch.
>   - **Script**:
>     - Adds `rateLimit.bash` to `py/tests` to send 60 requests to `https://api.cloud.sciphi.ai/v3/health`.
>     - Expects at least 20 HTTP 429 responses to pass the test.
>     - Uses `curl` to check response codes and logs results with color coding.
>     - Handles Ctrl+C to check exit status before termination.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for b7345d82eb62a94dbcf0fd82a6b3dd09e7227279. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->