### PR TITLE
Allow superuser to delete any document

### DIFF
--- a/js/sdk/__tests__/ConversationsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/ConversationsIntegrationSuperUser.test.ts
@@ -21,10 +21,25 @@ describe("r2rClient V3 Collections Integration Tests", () => {
     expect(response.results).toBeDefined();
   });
 
+  test("Create a conversation with a name", async () => {
+    const response = await client.conversations.create({
+      name: "Test Conversation",
+    });
+    conversationId = response.results.id;
+    expect(response.results).toBeDefined();
+    expect(response.results.name).toBe("Test Conversation");
+  });
+
+  test("Delete a conversation", async () => {
+    const response = await client.conversations.delete({ id: conversationId });
+    expect(response.results).toBeDefined();
+  });
+
   test("Create a conversation", async () => {
     const response = await client.conversations.create();
     conversationId = response.results.id;
     expect(response.results).toBeDefined();
+    expect(response.results.name).toBeNull();
   });
 
   test("Add a message to a conversation", async () => {

--- a/js/sdk/__tests__/ConversationsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/ConversationsIntegrationSuperUser.test.ts
@@ -30,6 +30,15 @@ describe("r2rClient V3 Collections Integration Tests", () => {
     expect(response.results.name).toBe("Test Conversation");
   });
 
+  test("Update a conversation name", async () => {
+    const response = await client.conversations.update({
+      id: conversationId,
+      name: "Updated Name",
+    });
+    expect(response.results).toBeDefined();
+    expect(response.results.name).toBe("Updated Name");
+  });
+
   test("Delete a conversation", async () => {
     const response = await client.conversations.delete({ id: conversationId });
     expect(response.results).toBeDefined();

--- a/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
+++ b/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
@@ -213,7 +213,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
   test("User 1 should not be able to list user 2's document chunks", async () => {
     await expect(
       user1Client.documents.listChunks({ id: user2DocumentId }),
-    ).rejects.toThrow(/Status 404/);
+    ).rejects.toThrow(/Status 403/);
   });
 
   test("User 1 should not be able to delete user 2's document", async () => {
@@ -225,7 +225,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
   test("User 2 should not be able to delete user 1's document", async () => {
     await expect(
       user2Client.documents.delete({ id: user1Document2Id }),
-    ).rejects.toThrow(/Status 403/);
+    ).rejects.toThrow(/Status 404/);
   });
 
   test("A superuser should be able to delete any document", async () => {

--- a/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
+++ b/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
@@ -17,6 +17,8 @@ describe("r2rClient V3 System Integration Tests User", () => {
   let user2Id: string;
   let user1DocumentId: string;
   let user2DocumentId: string;
+  let user1Document2Id: string;
+  let user2Document2Id: string;
   let user1CollectionId: string;
   let user2CollectionId: string;
 
@@ -146,6 +148,30 @@ describe("r2rClient V3 System Integration Tests User", () => {
     expect(response.results.id).toBe(user2DocumentId);
   });
 
+  test("Create document as user 1 from raw text", async () => {
+    const response = await user1Client.documents.create({
+      raw_text: "Hello, world!",
+      metadata: { title: "hello.txt" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    expect(response.results.document_id).toBeDefined();
+    user1Document2Id = response.results.document_id;
+  }, 15000);
+
+  test("Create document as user 2 from raw text", async () => {
+    const response = await user2Client.documents.create({
+      raw_text: "Hello, world!",
+      metadata: { title: "hello.txt" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    expect(response.results.document_id).toBeDefined();
+    user2Document2Id = response.results.document_id;
+  }, 15000);
+
   test("List documents with no parameters as user 1", async () => {
     const response = await user1Client.documents.list();
 
@@ -187,7 +213,27 @@ describe("r2rClient V3 System Integration Tests User", () => {
   test("User 1 should not be able to list user 2's document chunks", async () => {
     await expect(
       user1Client.documents.listChunks({ id: user2DocumentId }),
+    ).rejects.toThrow(/Status 404/);
+  });
+
+  test("User 1 should not be able to delete user 2's document", async () => {
+    await expect(
+      user1Client.documents.delete({ id: user2Document2Id }),
+    ).rejects.toThrow(/Status 404/);
+  });
+
+  test("User 2 should not be able to delete user 1's document", async () => {
+    await expect(
+      user2Client.documents.delete({ id: user1Document2Id }),
     ).rejects.toThrow(/Status 403/);
+  });
+
+  test("A superuser should be able to delete any document", async () => {
+    const response = await client.documents.delete({ id: user1Document2Id });
+    expect(response.results).toBeDefined();
+
+    const response2 = await client.documents.delete({ id: user2Document2Id });
+    expect(response2.results).toBeDefined();
   });
 
   test("Delete document as user 1", async () => {

--- a/js/sdk/__tests__/GraphsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/GraphsIntegrationSuperUser.test.ts
@@ -151,7 +151,7 @@ describe("r2rClient V3 Graphs Integration Tests", () => {
     await new Promise((resolve) => setTimeout(resolve, 15000));
 
     expect(response.results).toBeDefined();
-  }, 45000);
+  }, 60000);
 
   test("Check that there are communities in the graph", async () => {
     const response = await client.graphs.listCommunities({

--- a/js/sdk/src/v3/clients/conversations.ts
+++ b/js/sdk/src/v3/clients/conversations.ts
@@ -69,6 +69,26 @@ export class ConversationsClient {
   }
 
   /**
+   * Update an existing conversation.
+   * @param id The ID of the conversation to update
+   * @param name The new name of the conversation
+   * @returns The updated conversation
+   */
+  @feature("conversations.update")
+  async update(options: {
+    id: string;
+    name: string;
+  }): Promise<WrappedConversationResponse> {
+    const data: Record<string, any> = {
+      name: options.name,
+    };
+
+    return this.client.makeRequest("POST", `conversations/${options.id}`, {
+      data,
+    });
+  }
+
+  /**
    * Delete a conversation.
    * @param id The ID of the conversation to delete
    * @returns Whether the conversation was successfully deleted

--- a/js/sdk/src/v3/clients/conversations.ts
+++ b/js/sdk/src/v3/clients/conversations.ts
@@ -13,11 +13,20 @@ export class ConversationsClient {
 
   /**
    * Create a new conversation.
-   * @returns
+   * @param name The name of the conversation
+   * @returns The created conversation
    */
   @feature("conversations.create")
-  async create(): Promise<WrappedConversationResponse> {
-    return this.client.makeRequest("POST", "conversations");
+  async create(options?: {
+    name?: string;
+  }): Promise<WrappedConversationResponse> {
+    const data: Record<string, any> = {
+      ...(options?.name && { name: options?.name }),
+    };
+
+    return this.client.makeRequest("POST", "conversations", {
+      data,
+    });
   }
 
   /**
@@ -25,7 +34,7 @@ export class ConversationsClient {
    * @param ids List of conversation IDs to retrieve
    * @param offset Specifies the number of objects to skip. Defaults to 0.
    * @param limit Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.
-   * @returns
+   * @returns A list of conversations
    */
   @feature("conversations.list")
   async list(options?: {
@@ -50,7 +59,7 @@ export class ConversationsClient {
   /**
    * Get detailed information about a specific conversation.
    * @param id The ID of the conversation to retrieve
-   * @returns
+   * @returns The conversation
    */
   @feature("conversations.retrieve")
   async retrieve(options: {
@@ -62,7 +71,7 @@ export class ConversationsClient {
   /**
    * Delete a conversation.
    * @param id The ID of the conversation to delete
-   * @returns
+   * @returns Whether the conversation was successfully deleted
    */
   @feature("conversations.delete")
   async delete(options: { id: string }): Promise<WrappedBooleanResponse> {
@@ -76,7 +85,7 @@ export class ConversationsClient {
    * @param role The role of the message (e.g., "user" or "assistant")
    * @param parentID The ID of the parent message
    * @param metadata Additional metadata to attach to the message
-   * @returns
+   * @returns The created message
    */
   @feature("conversations.addMessage")
   async addMessage(options: {
@@ -108,7 +117,7 @@ export class ConversationsClient {
    * @param messageID The ID of the message to update
    * @param content The new content of the message
    * @param metadata Additional metadata to attach to the message
-   * @returns
+   * @returns The updated message
    */
   @feature("conversations.updateMessage")
   async updateMessage(options: {

--- a/py/core/database/conversations.py
+++ b/py/core/database/conversations.py
@@ -1,4 +1,5 @@
 import json
+from fastapi import HTTPException
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
@@ -19,10 +20,6 @@ class PostgresConversationsHandler(Handler):
         self.connection_manager = connection_manager
 
     async def create_tables(self):
-        # Ensure the uuid_generate_v4() extension is available
-        # Depending on your environment, you may need a separate call:
-        # await self.connection_manager.execute_query("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";")
-
         create_conversations_query = f"""
         CREATE TABLE IF NOT EXISTS {self._get_table_name("conversations")} (
             id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -48,26 +45,31 @@ class PostgresConversationsHandler(Handler):
         await self.connection_manager.execute_query(create_messages_query)
 
     async def create_conversation(
-        self, user_id: Optional[UUID] = None, name: Optional[str] = None
+        self,
+        user_id: Optional[UUID] = None,
+        name: Optional[str] = None,
     ) -> ConversationResponse:
         query = f"""
             INSERT INTO {self._get_table_name("conversations")} (user_id, name)
             VALUES ($1, $2)
             RETURNING id, extract(epoch from created_at) as created_at_epoch
         """
-        result = await self.connection_manager.fetchrow_query(
-            query, [user_id, name]
-        )
-
-        if not result:
-            raise R2RException(
-                status_code=500, message="Failed to create conversation."
+        try:
+            result = await self.connection_manager.fetchrow_query(
+                query, [user_id, name]
             )
 
-        return ConversationResponse(
-            id=str(result["id"]),
-            created_at=result["created_at_epoch"],
-        )
+            return ConversationResponse(
+                id=str(result["id"]),
+                created_at=result["created_at_epoch"],
+                user_id=str(user_id) if user_id else None,
+                name=name or None,
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to create conversation: {str(e)}",
+            ) from e
 
     async def verify_conversation_access(
         self, conversation_id: UUID, user_id: UUID
@@ -117,9 +119,9 @@ class PostgresConversationsHandler(Handler):
             params.extend(conversation_ids)
             param_index += len(conversation_ids)
 
-        where_clause = ""
-        if conditions:
-            where_clause = "WHERE " + " AND ".join(conditions)
+        where_clause = (
+            "WHERE " + " AND ".join(conditions) if conditions else ""
+        )
 
         limit_clause = ""
         if limit != -1:

--- a/py/core/main/api/v3/conversations_router.py
+++ b/py/core/main/api/v3/conversations_router.py
@@ -87,6 +87,9 @@ class ConversationsRouter(BaseRouterV3):
         )
         @self.base_endpoint
         async def create_conversation(
+            name: Optional[str] = Body(
+                None, description="The name of the conversation", embed=True
+            ),
             auth_user=Depends(self.providers.auth.auth_wrapper),
         ) -> WrappedConversationResponse:
             """
@@ -94,7 +97,12 @@ class ConversationsRouter(BaseRouterV3):
 
             This endpoint initializes a new conversation for the authenticated user.
             """
-            return await self.services.management.create_conversation()
+            user_id = auth_user.id
+
+            return await self.services.management.create_conversation(
+                user_id=user_id,
+                name=name,
+            )
 
         @self.router.get(
             "/conversations",

--- a/py/core/main/api/v3/conversations_router.py
+++ b/py/core/main/api/v3/conversations_router.py
@@ -327,8 +327,10 @@ class ConversationsRouter(BaseRouterV3):
                         "lang": "cURL",
                         "source": textwrap.dedent(
                             """
-                            curl -X PUT "https://api.example.com/v3/conversations/123e4567-e89b-12d3-a456-426614174000" \\
-                                -H "Authorization: B
+                            curl -X POST "https://api.example.com/v3/conversations/123e4567-e89b-12d3-a456-426614174000" \
+                                -H "Authorization: Bearer YOUR_API_KEY" \
+                                -H "Content-Type: application/json" \
+                                -d '{"name": "new_name"}'
                             """
                         ),
                     },

--- a/py/core/main/api/v3/conversations_router.py
+++ b/py/core/main/api/v3/conversations_router.py
@@ -279,7 +279,7 @@ class ConversationsRouter(BaseRouterV3):
 
         @self.router.post(
             "/conversations/{id}",
-            summary="Delete conversation",
+            summary="Update conversation",
             dependencies=[Depends(self.rate_limit_dependency)],
             openapi_extra={
                 "x-codeSamples": [

--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -1162,12 +1162,13 @@ class DocumentsRouter(BaseRouterV3):
 
             NOTE - Deletions do not yet impact the knowledge graph or other derived data. This feature is planned for a future release.
             """
-            filters = {
-                "$and": [
-                    {"owner_id": {"$eq": str(auth_user.id)}},
-                    {"document_id": {"$eq": str(id)}},
-                ]
-            }
+
+            filters = {"document_id": {"$eq": str(id)}}
+            if not auth_user.is_superuser:
+                filters = {
+                    "$and": [{"owner_id": {"$eq": str(auth_user.id)}}, filters]
+                }
+
             await self.services.management.delete_documents_and_chunks_by_filter(
                 filters=filters
             )

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -820,10 +820,13 @@ class ManagementService(Service):
 
     @telemetry_event("CreateConversation")
     async def create_conversation(
-        self, user_id: Optional[UUID] = None, auth_user=None
+        self,
+        user_id: Optional[UUID] = None,
+        name: Optional[str] = None,
     ) -> dict:
-        return await self.providers.database.conversations_handler.create_conversation(  # type: ignore
-            user_id=user_id
+        return await self.providers.database.conversations_handler.create_conversation(
+            user_id=user_id,
+            name=name,
         )
 
     @telemetry_event("ConversationsOverview")

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -16,6 +16,7 @@ from core.base import (
     R2RException,
     RunManager,
     User,
+    ConversationResponse,
 )
 from core.telemetry.telemetry_decorator import telemetry_event
 
@@ -804,18 +805,19 @@ class ManagementService(Service):
     @telemetry_event("GetConversation")
     async def get_conversation(
         self,
-        conversation_id: str,
+        conversation_id: UUID,
         auth_user=None,
     ) -> Tuple[str, list[Message], list[dict]]:
         return await self.providers.database.conversations_handler.get_conversation(  # type: ignore
-            conversation_id
+            conversation_id=conversation_id
         )
 
     async def verify_conversation_access(
-        self, conversation_id: str, user_id: UUID
+        self, conversation_id: UUID, user_id: UUID
     ) -> bool:
         return await self.providers.database.conversations_handler.verify_conversation_access(
-            conversation_id, user_id
+            conversation_id=conversation_id,
+            user_id=user_id,
         )
 
     @telemetry_event("CreateConversation")
@@ -823,7 +825,7 @@ class ManagementService(Service):
         self,
         user_id: Optional[UUID] = None,
         name: Optional[str] = None,
-    ) -> dict:
+    ) -> ConversationResponse:
         return await self.providers.database.conversations_handler.create_conversation(
             user_id=user_id,
             name=name,
@@ -848,14 +850,17 @@ class ManagementService(Service):
     @telemetry_event("AddMessage")
     async def add_message(
         self,
-        conversation_id: str,
+        conversation_id: UUID,
         content: Message,
-        parent_id: Optional[str] = None,
+        parent_id: Optional[UUID] = None,
         metadata: Optional[dict] = None,
         auth_user=None,
     ) -> str:
         return await self.providers.database.conversations_handler.add_message(
-            conversation_id, content, parent_id, metadata
+            conversation_id=conversation_id,
+            content=content,
+            parent_id=parent_id,
+            metadata=metadata,
         )
 
     @telemetry_event("EditMessage")
@@ -874,10 +879,18 @@ class ManagementService(Service):
             )
         )
 
+    @telemetry_event("UpdateConversation")
+    async def update_conversation(
+        self, conversation_id: UUID, name: str
+    ) -> ConversationResponse:
+        return await self.providers.database.conversations_handler.update_conversation(
+            conversation_id=conversation_id, name=name
+        )
+
     @telemetry_event("DeleteConversation")
-    async def delete_conversation(self, conversation_id: str, auth_user=None):
+    async def delete_conversation(self, conversation_id: UUID) -> None:
         await self.providers.database.conversations_handler.delete_conversation(
-            conversation_id
+            conversation_id=conversation_id
         )
 
     async def get_user_max_documents(self, user_id: UUID) -> int:

--- a/py/core/providers/crypto/bcrypt.py
+++ b/py/core/providers/crypto/bcrypt.py
@@ -2,7 +2,7 @@ import base64
 import os
 from abc import ABC
 from datetime import datetime, timezone
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import bcrypt
 import jwt
@@ -127,7 +127,7 @@ class BCryptCryptoProvider(CryptoProvider, ABC):
         stored_hash = base64.b64decode(hashed_key.encode("utf-8"))
         return bcrypt.checkpw(raw_api_key.encode("utf-8"), stored_hash)
 
-    def generate_secure_token(self, data: Dict, expiry: datetime) -> str:
+    def generate_secure_token(self, data: dict, expiry: datetime) -> str:
         now = datetime.now(timezone.utc)
         to_encode = {
             **data,
@@ -139,7 +139,7 @@ class BCryptCryptoProvider(CryptoProvider, ABC):
         }
         return jwt.encode(to_encode, self.secret_key, algorithm="HS256")
 
-    def verify_secure_token(self, token: str) -> Optional[Dict]:
+    def verify_secure_token(self, token: str) -> Optional[dict]:
         try:
             payload = jwt.decode(token, self.secret_key, algorithms=["HS256"])
             exp = payload.get("exp")

--- a/py/sdk/async_client.py
+++ b/py/sdk/async_client.py
@@ -65,7 +65,6 @@ class R2RAsyncClient(
     async def _make_request(
         self, method: str, endpoint: str, version: str = "v2", **kwargs
     ):
-        print("in async client......")
         url = self._get_full_url(endpoint, version)
         request_args = self._prepare_request_args(endpoint, **kwargs)
 
@@ -135,9 +134,7 @@ class R2RAsyncClient(
     def set_api_key(self, api_key: str) -> None:
         if self.access_token:
             raise ValueError("Cannot have both access token and api key.")
-        print("calling set api key, api_key = ", api_key)
         self.api_key = api_key
 
     def unset_api_key(self) -> None:
-        print("calling unset api key")
         self.api_key = None

--- a/py/sdk/base/base_client.py
+++ b/py/sdk/base/base_client.py
@@ -46,8 +46,6 @@ class BaseClient:
         self.api_key: Optional[str] = None
 
     def _get_auth_header(self) -> dict[str, str]:
-        print("self.access_token = ", self.access_token)
-        print("self.api_key = ", self.api_key)
         if self.access_token and self.api_key:
             raise R2RException(
                 status_code=400,

--- a/py/sdk/v3/conversations.py
+++ b/py/sdk/v3/conversations.py
@@ -14,16 +14,22 @@ class ConversationsSDK:
     def __init__(self, client):
         self.client = client
 
-    async def create(self) -> WrappedConversationResponse:
+    async def create(
+        self,
+        name: Optional[str] = None,
+    ) -> WrappedConversationResponse:
         """
         Create a new conversation.
 
         Returns:
             dict: Created conversation information
         """
+        data = {"name": name} if name else None
+
         return await self.client._make_request(
             "POST",
             "conversations",
+            data=data,
             version="v3",
         )
 

--- a/py/sdk/v3/conversations.py
+++ b/py/sdk/v3/conversations.py
@@ -83,6 +83,32 @@ class ConversationsSDK:
             version="v3",
         )
 
+    async def update(
+        self,
+        id: str | UUID,
+        name: str,
+    ) -> WrappedConversationResponse:
+        """
+        Update an existing conversation.
+
+        Args:
+            id (Union[str, UUID]): The ID of the conversation to update
+            name (str): The new name of the conversation
+
+        Returns:
+            dict: The updated conversation
+        """
+        data: dict[str, Any] = {
+            "name": name,
+        }
+
+        return await self.client._make_request(
+            "POST",
+            f"conversations/{str(id)}",
+            json=data,
+            version="v3",
+        )
+
     async def delete(
         self,
         id: str | UUID,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable superusers to delete any document, update related tests, and refine API and database handling for document management.
> 
>   - **Behavior**:
>     - Superusers can delete any document, verified by tests in `DocumentsAndCollectionsIntegrationUser.test.ts`.
>     - Regular users cannot delete documents they do not own, enforced by status checks (403/404).
>   - **API Changes**:
>     - Updated `delete_document_by_id` in `documents_router.py` to allow superuser deletions without owner checks.
>     - Added tests for conversation creation, update, and deletion in `ConversationsIntegrationSuperUser.test.ts`.
>   - **Database**:
>     - `delete_documents_and_chunks_by_filter` in `management_service.py` now supports superuser deletions.
>     - `create_conversation` and `update_conversation` in `conversations.py` handle exceptions more robustly.
>   - **Misc**:
>     - Increased timeout for `GraphsIntegrationSuperUser.test.ts` to 60000ms.
>     - Removed debug prints from `async_client.py` and `base_client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 9e4702a39e377a3536476a6edd2d6c2c75be1a50. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->