### PR TITLE
Move JS SDK to camel case

### DIFF
--- a/js/sdk/__tests__/ChunksIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/ChunksIntegrationSuperUser.test.ts
@@ -5,7 +5,7 @@ const baseUrl = "http://localhost:7272";
 
 describe("r2rClient V3 Collections Integration Tests", () => {
   let client: r2rClient;
-  let document_id: string;
+  let documentId: string;
   let chunkId: string;
 
   beforeAll(async () => {
@@ -22,18 +22,18 @@ describe("r2rClient V3 Collections Integration Tests", () => {
       runWithOrchestration: false,
     });
 
-    document_id = response.results.document_id;
+    documentId = response.results.documentId;
 
     expect(response.results).toEqual({
-      document_id: expect.any(String),
+      documentId: expect.any(String),
       message: "Document created and ingested successfully.",
-      task_id: null,
+      taskId: null,
     });
   });
 
   test("Retrieve document's chunks", async () => {
     const response = await client.documents.listChunks({
-      id: document_id,
+      id: documentId,
     });
 
     chunkId = response.results[0]?.id;
@@ -41,9 +41,9 @@ describe("r2rClient V3 Collections Integration Tests", () => {
     expect(chunkId).toBeDefined();
     expect(response.results[0]).toMatchObject({
       id: expect.any(String),
-      document_id: expect.any(String),
+      documentId: expect.any(String),
       text: expect.any(String),
-      collection_ids: expect.any(Array),
+      collectionIds: expect.any(Array),
       metadata: expect.any(Object),
     });
   });
@@ -55,9 +55,9 @@ describe("r2rClient V3 Collections Integration Tests", () => {
 
     expect(response.results).toMatchObject({
       id: expect.any(String),
-      document_id: expect.any(String),
+      documentId: expect.any(String),
       text: expect.any(String),
-      collection_ids: expect.any(Array),
+      collectionIds: expect.any(Array),
       metadata: expect.any(Object),
     });
   });
@@ -70,9 +70,9 @@ describe("r2rClient V3 Collections Integration Tests", () => {
 
     expect(response.results).toMatchObject({
       id: expect.any(String),
-      document_id: expect.any(String),
+      documentId: expect.any(String),
       text: "Hello, world! How are you?",
-      collection_ids: expect.any(Array),
+      collectionIds: expect.any(Array),
       metadata: expect.any(Object),
     });
   });

--- a/js/sdk/__tests__/CollectionsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/CollectionsIntegrationSuperUser.test.ts
@@ -63,8 +63,8 @@ describe("r2rClient V3 Collections Integration Tests", () => {
       metadata: { title: "zametov.txt" },
     });
 
-    expect(ingestResponse.results.document_id).toBeDefined();
-    documentId = ingestResponse.results.document_id;
+    expect(ingestResponse.results.documentId).toBeDefined();
+    documentId = ingestResponse.results.documentId;
 
     const response = await client.collections.addDocument({
       id: collectionId,

--- a/js/sdk/__tests__/ConversationsIntegrationUser.test.ts
+++ b/js/sdk/__tests__/ConversationsIntegrationUser.test.ts
@@ -32,7 +32,7 @@ describe("r2rClient V3 Collections Integration Tests", () => {
 
     user1Id = response.results.id;
     expect(response.results).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
+    expect(response.results.isSuperuser).toBe(false);
     expect(response.results.name).toBe(null);
   });
 
@@ -52,7 +52,7 @@ describe("r2rClient V3 Collections Integration Tests", () => {
 
     user2Id = response.results.id;
     expect(response.results).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
+    expect(response.results.isSuperuser).toBe(false);
     expect(response.results.name).toBe(null);
   });
 
@@ -84,7 +84,7 @@ describe("r2rClient V3 Collections Integration Tests", () => {
 
     expect(response.results).toBeDefined();
     expect(response.results).toEqual([]);
-    expect(response.total_entries).toBe(0);
+    expect(response.totalEntries).toBe(0);
   });
 
   test("List all conversations as user 1", async () => {
@@ -92,7 +92,7 @@ describe("r2rClient V3 Collections Integration Tests", () => {
 
     expect(response.results).toBeDefined();
     expect(response.results).toEqual([]);
-    expect(response.total_entries).toBe(0);
+    expect(response.totalEntries).toBe(0);
   });
 
   test("List all conversations as user 2", async () => {
@@ -100,7 +100,7 @@ describe("r2rClient V3 Collections Integration Tests", () => {
 
     expect(response.results).toBeDefined();
     expect(response.results).toEqual([]);
-    expect(response.total_entries).toBe(0);
+    expect(response.totalEntries).toBe(0);
   });
 
   test("Create a conversation with a name", async () => {

--- a/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
+++ b/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
@@ -41,7 +41,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     user1Id = response.results.id;
     expect(response.results).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
+    expect(response.results.isSuperuser).toBe(false);
     expect(response.results.name).toBe(null);
   });
 
@@ -61,7 +61,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     user2Id = response.results.id;
     expect(response.results).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
+    expect(response.results.isSuperuser).toBe(false);
     expect(response.results.name).toBe(null);
   });
 
@@ -93,7 +93,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     expect(response.results).toBeDefined();
     expect(response.results.length).toBe(1);
-    expect(response.total_entries).toBe(1);
+    expect(response.totalEntries).toBe(1);
     user1CollectionId = response.results[0].id;
   });
 
@@ -102,7 +102,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     expect(response.results).toBeDefined();
     expect(response.results.length).toBe(1);
-    expect(response.total_entries).toBe(1);
+    expect(response.totalEntries).toBe(1);
     user2CollectionId = response.results[0].id;
   });
 
@@ -114,8 +114,8 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
-    expect(response.results.document_id).toBeDefined();
-    user1DocumentId = response.results.document_id;
+    expect(response.results.documentId).toBeDefined();
+    user1DocumentId = response.results.documentId;
   }, 15000);
 
   test("Create document as user 2 with file path", async () => {
@@ -126,8 +126,8 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
-    expect(response.results.document_id).toBeDefined();
-    user2DocumentId = response.results.document_id;
+    expect(response.results.documentId).toBeDefined();
+    user2DocumentId = response.results.documentId;
   }, 15000);
 
   test("Retrieve document as user 1", async () => {
@@ -156,8 +156,8 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
-    expect(response.results.document_id).toBeDefined();
-    user1Document2Id = response.results.document_id;
+    expect(response.results.documentId).toBeDefined();
+    user1Document2Id = response.results.documentId;
   }, 15000);
 
   test("Create document as user 2 from raw text", async () => {
@@ -168,8 +168,8 @@ describe("r2rClient V3 System Integration Tests User", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
-    expect(response.results.document_id).toBeDefined();
-    user2Document2Id = response.results.document_id;
+    expect(response.results.documentId).toBeDefined();
+    user2Document2Id = response.results.documentId;
   }, 15000);
 
   test("List documents with no parameters as user 1", async () => {

--- a/js/sdk/__tests__/DocumentsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/DocumentsIntegrationSuperUser.test.ts
@@ -25,8 +25,8 @@ describe("r2rClient V3 Documents Integration Tests", () => {
       metadata: { title: "marmeladov.txt" },
     });
 
-    expect(response.results.document_id).toBeDefined();
-    documentId = response.results.document_id;
+    expect(response.results.documentId).toBeDefined();
+    documentId = response.results.documentId;
   }, 10000);
 
   test("Create document with content", async () => {
@@ -35,7 +35,7 @@ describe("r2rClient V3 Documents Integration Tests", () => {
       metadata: { title: "Test Document" },
     });
 
-    expect(response.results.document_id).toBeDefined();
+    expect(response.results.documentId).toBeDefined();
   }, 30000);
 
   test("Retrieve document", async () => {
@@ -45,15 +45,15 @@ describe("r2rClient V3 Documents Integration Tests", () => {
 
     expect(response.results).toBeDefined();
     expect(response.results.id).toBe(documentId);
-    expect(response.results.collection_ids).toContain(
+    expect(response.results.collectionIds).toContain(
       "122fdf6a-e116-546b-a8f6-e4cb2e2c0a09",
     );
     expect(response.results.metadata.title).toBe("marmeladov.txt");
-    expect(response.results.size_in_bytes).toBeDefined();
-    expect(response.results.ingestion_status).toBe("success");
-    expect(response.results.extraction_status).toBe("pending");
-    expect(response.results.created_at).toBeDefined();
-    expect(response.results.updated_at).toBeDefined();
+    expect(response.results.sizeInBytes).toBeDefined();
+    expect(response.results.ingestionStatus).toBe("success");
+    expect(response.results.extractionStatus).toBe("pending");
+    expect(response.results.createdAt).toBeDefined();
+    expect(response.results.updatedAt).toBeDefined();
     expect(response.results.summary).toBeDefined();
   });
 

--- a/js/sdk/__tests__/GraphsIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/GraphsIntegrationSuperUser.test.ts
@@ -29,8 +29,8 @@ describe("r2rClient V3 Graphs Integration Tests", () => {
       metadata: { title: "raskolnikov_2.txt" },
     });
 
-    expect(response.results.document_id).toBeDefined();
-    documentId = response.results.document_id;
+    expect(response.results.documentId).toBeDefined();
+    documentId = response.results.documentId;
   }, 10000);
 
   test("Create new collection", async () => {
@@ -66,7 +66,7 @@ describe("r2rClient V3 Graphs Integration Tests", () => {
 
     expect(response.results).toBeDefined();
     expect(response.results.name).toBe("Raskolnikov Graph");
-    expect(response.results.updated_at).not.toBe(response.results.created_at);
+    expect(response.results.updatedAt).not.toBe(response.results.createdAt);
   });
 
   test("List graphs", async () => {
@@ -123,7 +123,7 @@ describe("r2rClient V3 Graphs Integration Tests", () => {
       collectionId: collectionId,
     });
     expect(response.results).toBeDefined();
-    expect(response.total_entries).toBeGreaterThanOrEqual(1);
+    expect(response.totalEntries).toBeGreaterThanOrEqual(1);
   }, 60000);
 
   test("Check that there are relationships in the graph", async () => {
@@ -131,7 +131,7 @@ describe("r2rClient V3 Graphs Integration Tests", () => {
       collectionId: collectionId,
     });
     expect(response.results).toBeDefined();
-    expect(response.total_entries).toBeGreaterThanOrEqual(1);
+    expect(response.totalEntries).toBeGreaterThanOrEqual(1);
   });
 
   test("Check that there are no communities in the graph prior to building", async () => {
@@ -159,7 +159,7 @@ describe("r2rClient V3 Graphs Integration Tests", () => {
     });
 
     expect(response.results).toBeDefined();
-    expect(response.total_entries).toBeGreaterThanOrEqual(1);
+    expect(response.totalEntries).toBeGreaterThanOrEqual(1);
   });
 
   test("Create a new entity", async () => {

--- a/js/sdk/__tests__/RetrievalIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/RetrievalIntegrationSuperUser.test.ts
@@ -46,8 +46,8 @@ describe("r2rClient V3 Documents Integration Tests", () => {
       metadata: { title: "sonia.txt" },
     });
 
-    expect(response.results.document_id).toBeDefined();
-    documentId = response.results.document_id;
+    expect(response.results.documentId).toBeDefined();
+    documentId = response.results.documentId;
   }, 10000);
 
   test("Search documents with no parameters", async () => {

--- a/js/sdk/__tests__/SystemIntegrationUser.test.ts
+++ b/js/sdk/__tests__/SystemIntegrationUser.test.ts
@@ -23,7 +23,7 @@ describe("r2rClient V3 System Integration Tests User", () => {
     userId = response.results.id;
     name = response.results.name;
     expect(response.results).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
+    expect(response.results.isSuperuser).toBe(false);
     expect(response.results.name).toBe("Test User");
     expect(response.results.bio).toBe("This is the bio of the test user.");
   });

--- a/js/sdk/__tests__/UsersIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/UsersIntegrationSuperUser.test.ts
@@ -24,17 +24,17 @@ describe("r2rClient V3 Users Integration Tests", () => {
     expect(response.results).toBeDefined();
     expect(response.results.id).toBeDefined();
     expect(response.results.email).toBe("new_user@example.com");
-    expect(response.results.is_active).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
-    expect(response.results.created_at).toBeDefined();
-    expect(response.results.updated_at).toBeDefined();
+    expect(response.results.isActive).toBeDefined();
+    expect(response.results.isSuperuser).toBe(false);
+    expect(response.results.createdAt).toBeDefined();
+    expect(response.results.updatedAt).toBeDefined();
     // expect(response.results.is_verified).toBe(false);
-    expect(response.results.collection_ids).toBeDefined();
+    expect(response.results.collectionIds).toBeDefined();
     // expect(response.results.hashed_password).toBeUndefined();
     // expect(response.results.verification_code_expiry).toBeUndefined();
     expect(response.results.name).toBe(null);
     expect(response.results.bio).toBe(null);
-    expect(response.results.profile_picture).toBe(null);
+    expect(response.results.profilePicture).toBe(null);
   });
 
   test("Login as a user", async () => {
@@ -95,17 +95,17 @@ describe("r2rClient V3 Users Integration Tests", () => {
     expect(response.results).toBeDefined();
     expect(response.results.id).toBeDefined();
     expect(response.results.email).toBe("new_user@example.com");
-    expect(response.results.is_active).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
-    expect(response.results.created_at).toBeDefined();
-    expect(response.results.updated_at).toBeDefined();
+    expect(response.results.isActive).toBeDefined();
+    expect(response.results.isSuperuser).toBe(false);
+    expect(response.results.createdAt).toBeDefined();
+    expect(response.results.updatedAt).toBeDefined();
     // expect(response.results.is_verified).toBe(false);
-    expect(response.results.collection_ids).toBeDefined();
+    expect(response.results.collectionIds).toBeDefined();
     // expect(response.results.hashed_password).toBeUndefined();
     // expect(response.results.verification_code_expiry).toBeUndefined();
     expect(response.results.name).toBe("New Name");
     expect(response.results.bio).toBe("New Bio");
-    expect(response.results.profile_picture).toBe(null);
+    expect(response.results.profilePicture).toBe(null);
   });
 
   test("Retrieve a user after update", async () => {
@@ -114,17 +114,17 @@ describe("r2rClient V3 Users Integration Tests", () => {
     expect(response.results).toBeDefined();
     expect(response.results.id).toBeDefined();
     expect(response.results.email).toBe("new_user@example.com");
-    expect(response.results.is_active).toBeDefined();
-    expect(response.results.is_superuser).toBe(false);
-    expect(response.results.created_at).toBeDefined();
-    expect(response.results.updated_at).toBeDefined();
+    expect(response.results.isActive).toBeDefined();
+    expect(response.results.isSuperuser).toBe(false);
+    expect(response.results.createdAt).toBeDefined();
+    expect(response.results.updatedAt).toBeDefined();
     // expect(response.results.is_verified).toBe(false);
-    expect(response.results.collection_ids).toBeDefined();
+    expect(response.results.collectionIds).toBeDefined();
     // expect(response.results.hashed_password).toBeUndefined();
     // expect(response.results.verification_code_expiry).toBeUndefined();
     expect(response.results.name).toBe("New Name");
     expect(response.results.bio).toBe("New Bio");
-    expect(response.results.profile_picture).toBe(null);
+    expect(response.results.profilePicture).toBe(null);
   });
 
   test("List user's collections", async () => {

--- a/js/sdk/__tests__/util/typeTransformer.test.ts
+++ b/js/sdk/__tests__/util/typeTransformer.test.ts
@@ -1,0 +1,233 @@
+import {
+  ensureCamelCase,
+  ensureSnakeCase,
+} from "../../src/utils/typeTransformer";
+import { describe, it, expect } from "@jest/globals";
+
+describe("Type Transformers", () => {
+  describe("ensureCamelCase", () => {
+    it("handles basic transformations", () => {
+      expect(ensureCamelCase({ user_name: "test" })).toEqual({
+        userName: "test",
+      });
+    });
+
+    it("handles nested objects", () => {
+      const input = {
+        user_details: {
+          first_name: "John",
+          last_name: "Doe",
+          contact_info: {
+            phone_number: "123",
+            email_address: "test@test.com",
+          },
+        },
+      };
+      expect(ensureCamelCase(input)).toEqual({
+        userDetails: {
+          firstName: "John",
+          lastName: "Doe",
+          contactInfo: {
+            phoneNumber: "123",
+            emailAddress: "test@test.com",
+          },
+        },
+      });
+    });
+
+    it("preserves Symbols as keys", () => {
+      const testSymbol = Symbol("test");
+      const nestedSymbol = Symbol("nested");
+      const input = {
+        [testSymbol]: "value",
+        nested_object: {
+          [nestedSymbol]: "nested value",
+        },
+      };
+
+      const result = ensureCamelCase(input);
+      expect(result[testSymbol]).toBe("value");
+      expect(result.nestedObject[nestedSymbol]).toBe("nested value");
+    });
+
+    it("handles special JavaScript types", () => {
+      const date = new Date("2024-01-01");
+      const map = new Map([["key", "value"]]);
+      const set = new Set(["value"]);
+
+      const input = {
+        date_field: date,
+        map_field: map,
+        set_field: set,
+        nested_special: {
+          inner_date: date,
+        },
+      };
+
+      expect(ensureCamelCase(input)).toEqual({
+        dateField: date,
+        mapField: map,
+        setField: set,
+        nestedSpecial: {
+          innerDate: date,
+        },
+      });
+    });
+
+    it("handles arrays with nested special types", () => {
+      const map = new Map([["key", "value"]]);
+      const input = {
+        complex_array: [
+          { nested_map: map },
+          { nested_date: new Date("2024-01-01") },
+        ],
+      };
+
+      const result = ensureCamelCase(input);
+      expect(result.complexArray[0].nestedMap).toEqual(map);
+      expect(result.complexArray[1].nestedDate instanceof Date).toBeTruthy();
+    });
+
+    it("properly handles acronyms and consecutive uppercase letters", () => {
+      const input = {
+        xml_parser: "value",
+        html_content: "value",
+        api_key: "value",
+        db_connection: "value",
+      };
+
+      expect(ensureCamelCase(input)).toEqual({
+        xmlParser: "value",
+        htmlContent: "value",
+        apiKey: "value",
+        dbConnection: "value",
+      });
+    });
+
+    it("preserves leading underscores", () => {
+      const input = {
+        _private_field: "value",
+        __proto_field: "value",
+        nested_object: {
+          _internal_value: "test",
+        },
+      };
+
+      expect(ensureCamelCase(input)).toEqual({
+        _privateField: "value",
+        __protoField: "value",
+        nestedObject: {
+          _internalValue: "test",
+        },
+      });
+    });
+
+    it("handles null and undefined values", () => {
+      expect(ensureCamelCase(null)).toBeNull();
+      expect(ensureCamelCase(undefined)).toBeUndefined();
+      expect(
+        ensureCamelCase({ null_value: null, undefined_value: undefined }),
+      ).toEqual({ nullValue: null, undefinedValue: undefined });
+    });
+  });
+
+  describe("ensureSnakeCase", () => {
+    it("handles basic transformations", () => {
+      expect(ensureSnakeCase({ userName: "test" })).toEqual({
+        user_name: "test",
+      });
+    });
+
+    it("handles nested objects", () => {
+      const input = {
+        userDetails: {
+          firstName: "John",
+          lastName: "Doe",
+          contactInfo: {
+            phoneNumber: "123",
+            emailAddress: "test@test.com",
+          },
+        },
+      };
+      expect(ensureSnakeCase(input)).toEqual({
+        user_details: {
+          first_name: "John",
+          last_name: "Doe",
+          contact_info: {
+            phone_number: "123",
+            email_address: "test@test.com",
+          },
+        },
+      });
+    });
+
+    it("properly converts acronyms to snake case", () => {
+      const input = {
+        XMLParser: "value",
+        HTMLContent: "value",
+        APIKey: "value",
+        DBConnection: "value",
+      };
+
+      expect(ensureSnakeCase(input)).toEqual({
+        xml_parser: "value",
+        html_content: "value",
+        api_key: "value",
+        db_connection: "value",
+      });
+    });
+
+    it("preserves special types in nested structures", () => {
+      const date = new Date("2024-01-01");
+      const map = new Map([["key", "value"]]);
+
+      const input = {
+        complexData: {
+          dateField: date,
+          mapField: map,
+          nestedArray: [{ innerDate: date }],
+        },
+      };
+
+      const result = ensureSnakeCase(input);
+      expect(result.complex_data.date_field).toBe(date);
+      expect(result.complex_data.map_field).toBe(map);
+      expect(result.complex_data.nested_array[0].inner_date).toBe(date);
+    });
+
+    it("handles edge cases and special characters", () => {
+      const input = {
+        $specialKey: "test",
+        _privateKey: "test",
+        constructor: "test",
+        key123Key: "test",
+      };
+
+      expect(ensureSnakeCase(input)).toEqual({
+        $special_key: "test",
+        _private_key: "test",
+        constructor: "test",
+        key123_key: "test",
+      });
+    });
+  });
+
+  describe("Error handling", () => {
+    it("handles circular references", () => {
+      const circular: any = { key: "value" };
+      circular.self = circular;
+
+      expect(() => ensureCamelCase(circular)).toThrow();
+      expect(() => ensureSnakeCase(circular)).toThrow();
+    });
+
+    it("handles invalid inputs gracefully", () => {
+      const inputs = [function () {}, /regex/, new Error("test")];
+
+      inputs.forEach((input) => {
+        expect(ensureCamelCase(input)).toBe(input);
+        expect(ensureSnakeCase(input)).toBe(input);
+      });
+    });
+  });
+});

--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -1,7 +1,7 @@
 export interface UnprocessedChunk {
   id: string;
-  document_id?: string;
-  collection_ids: string[];
+  documentId?: string;
+  collectionIds: string[];
   metadata: Record<string, any>;
   text: string;
 }
@@ -12,7 +12,7 @@ export interface ResultsWrapper<T> {
 }
 
 export interface PaginatedResultsWrapper<T> extends ResultsWrapper<T> {
-  total_entries: number;
+  totalEntries: number;
 }
 
 // Generic response types
@@ -27,9 +27,9 @@ export interface GenericMessageResponse {
 // Chunk types
 export interface ChunkResponse {
   id: string;
-  document_id: string;
-  user_id: string;
-  collection_ids: string[];
+  documentId: string;
+  userId: string;
+  collectionIds: string[];
   text: string;
   metadata: Record<string, any>;
   vector?: any;
@@ -38,15 +38,15 @@ export interface ChunkResponse {
 // Collection types
 export interface CollectionResponse {
   id: string;
-  owner_id?: string;
+  ownerId?: string;
   name: string;
   description?: string;
-  graph_cluster_status: string;
-  graph_sync_status: string;
-  created_at: string;
-  updated_at: string;
-  user_count: number;
-  document_count: number;
+  graphClusterStatus: string;
+  graphSyncStatus: string;
+  createdAt: string;
+  updatedAt: string;
+  userCount: number;
+  documentCount: number;
 }
 
 // Community types
@@ -66,8 +66,8 @@ export interface CommunityResponse {
 // Conversation types
 export interface ConversationResponse {
   id: string;
-  created_at: string;
-  user_id?: string;
+  createdAt: string;
+  userId?: string;
   name?: string;
 }
 
@@ -79,20 +79,20 @@ export interface MessageResponse {
 // Document types
 export interface DocumentResponse {
   id: string;
-  collection_ids: string[];
-  owner_id: string;
-  document_type: string;
+  collectionIds: string[];
+  ownerId: string;
+  documentType: string;
   metadata: Record<string, any>;
   title?: string;
   version: string;
-  size_in_bytes?: number;
-  ingestion_status: string;
-  extraction_status: string;
-  created_at: string;
-  updated_at: string;
-  ingestion_attempt_number?: number;
+  sizeInBytes?: number;
+  ingestionStatus: string;
+  extractionStatus: string;
+  createdAt: string;
+  updatedAt: string;
+  ingestionAttemptNumber?: number;
   summary?: string;
-  summary_embedding?: string;
+  summaryEmbedding?: string;
 }
 
 // Entity types
@@ -102,20 +102,20 @@ export interface EntityResponse {
   description?: string;
   category?: string;
   metadata: Record<string, any>;
-  parent_id?: string;
-  chunk_ids?: string[];
-  description_embedding?: string;
+  parentId?: string;
+  chunkIds?: string[];
+  descriptionEmbedding?: string;
 }
 
 // Graph types
 export interface GraphResponse {
   id: string;
-  user_id: string;
+  userId: string;
   name: string;
   description: string;
   status: string;
-  created_at: string;
-  updated_at: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 // Index types
@@ -128,24 +128,24 @@ export enum IndexMeasure {
 // Ingestion types
 export interface IngestionResponse {
   message: string;
-  task_id?: string;
-  document_id: string;
+  taskId?: string;
+  documentId: string;
 }
 
 export interface UpdateResponse {
   message: string;
-  task_id?: string;
-  document_id: string;
+  taskId?: string;
+  documentId: string;
 }
 
 export interface IndexConfig {
   name?: string;
-  table_name?: string;
-  index_method?: string;
-  index_measure?: string;
-  index_arguments?: string;
-  index_name?: string;
-  index_column?: string;
+  tableName?: string;
+  indexMethod?: string;
+  indexMeasure?: string;
+  indexArguments?: string;
+  indexName?: string;
+  indexColumn?: string;
   concurrently?: boolean;
 }
 
@@ -154,9 +154,9 @@ export interface PromptResponse {
   id: string;
   name: string;
   template: string;
-  created_at: string;
-  updated_at: string;
-  input_types: string[];
+  createdAt: string;
+  updatedAt: string;
+  inputTypes: string[];
 }
 
 // Relationship types
@@ -166,71 +166,72 @@ export interface RelationshipResponse {
   predicate: string;
   object: string;
   description?: string;
-  subject_id: string;
-  object_id: string;
+  subjectId: string;
+  objectId: string;
   weight: number;
-  chunk_ids: string[];
-  parent_id: string;
+  chunkIds: string[];
+  parentId: string;
   metadata: Record<string, any>;
 }
 
 // Retrieval types
 export interface ChunkSearchSettings {
-  index_measure?: IndexMeasure;
+  indexMeasure?: IndexMeasure;
   probes?: number;
-  ef_search?: number;
+  efSearch?: number;
   enabled?: boolean;
 }
 
 export interface GenerationConfig {
   model?: string;
   temperature?: number;
-  top_p?: number;
-  max_tokens_to_sample?: number;
+  topP?: number;
+  maxTokensToSample?: number;
   stream?: boolean;
   functions?: Array<Record<string, any>>;
   tools?: Array<Record<string, any>>;
-  add_generation_kwargs?: Record<string, any>;
-  api_base?: string;
-  response_format?: string;
+  addGenerationKwargs?: Record<string, any>;
+  apiBase?: string;
+  responseFormat?: string;
 }
 
 export interface HybridSearchSettings {
-  full_text_weight?: number;
-  semantic_weight?: number;
-  full_text_limit?: number;
-  rrf_k?: number;
+  fullTextWeight?: number;
+  semanticWeight?: number;
+  fullTextLimit?: number;
+  rrfK?: number;
 }
 
 export interface GraphSearchSettings {
-  generation_config?: GenerationConfig;
-  graphrag_map_system?: string;
-  graphrag_reduce_system?: string;
-  max_community_description_length?: number;
-  max_llm_queries_for_global_search?: number;
+  generationConfig?: GenerationConfig;
+  graphragMapSystem?: string;
+  graphragReduceSystem?: string;
+  maxCommunityDescriptionLength?: number;
+  maxLlmQueriesForGlobalSearch?: number;
   limits?: Record<string, any>;
   enabled?: boolean;
 }
 
 export interface SearchSettings {
-  use_hybrid_search?: boolean;
-  use_semantic_search?: boolean;
-  use_full_text_search?: boolean;
+  useHybridSearch?: boolean;
+  useSemanticSearch?: boolean;
+  useFullTextSearch?: boolean;
   filters?: Record<string, any>;
   limit?: number;
   offset?: number;
-  include_metadata?: boolean;
-  include_scores?: boolean;
-  search_strategy?: string;
-  hybrid_settings?: HybridSearchSettings;
-  chunk_settings?: ChunkSearchSettings;
-  graph_settings?: GraphSearchSettings;
+  includeMetadata?: boolean;
+  includeScores?: boolean;
+  searchStrategy?: string;
+  hybridSettings?: HybridSearchSettings;
+  chunkSettings?: ChunkSearchSettings;
+  graphSettings?: GraphSearchSettings;
 }
+
 export interface VectorSearchResult {
-  chunk_id: string;
-  document_id: string;
-  user_id: string;
-  collection_ids: string[];
+  chunkId: string;
+  documentId: string;
+  userId: string;
+  collectionIds: string[];
   score: number;
   text: string;
   metadata?: Record<string, any>;
@@ -244,53 +245,53 @@ export type KGSearchResultType =
 
 export interface GraphSearchResult {
   content: any;
-  result_type?: KGSearchResultType;
-  chunk_ids?: string[];
+  resultType?: KGSearchResultType;
+  chunkIds?: string[];
   metadata: Record<string, any>;
   score?: number;
 }
 
 export interface CombinedSearchResponse {
-  chunk_search_results: VectorSearchResult[];
-  graph_search_results?: GraphSearchResult[];
+  chunkSearchResults: VectorSearchResult[];
+  graphSearchResults?: GraphSearchResult[];
 }
 
 // System types
 
 export interface ServerStats {
-  start_time: string;
-  uptime_seconds: number;
-  cpu_usage: number;
-  memory_usage: number;
+  startTime: string;
+  uptimeSeconds: number;
+  cpuUsage: number;
+  memoryUsage: number;
 }
 
 export interface SettingsResponse {
   config: Record<string, any>;
   prompts: Record<string, any>;
-  r2r_project_name: string;
+  r2rProjectName: string;
 }
 
 // User types
 
 export interface TokenResponse {
-  access_token: string;
-  refresh_token: string;
+  accessToken: string;
+  refreshToken: string;
 }
 
 export interface User {
   id: string;
   email: string;
-  is_active: boolean;
-  is_superuser: boolean;
-  created_at: string;
-  updated_at: string;
-  is_verified: boolean;
-  collection_ids: string[];
-  hashed_password?: string;
-  verification_code_expiry?: string;
+  isActive: boolean;
+  isSuperuser: boolean;
+  createdAt: string;
+  updatedAt: string;
+  isVerified: boolean;
+  collectionIds: string[];
+  hashedPassword?: string;
+  verificationCodeExpiry?: string;
   name?: string;
   bio?: string;
-  profile_picture?: string;
+  profilePicture?: string;
 }
 
 // Generic Responses

--- a/js/sdk/src/utils/index.ts
+++ b/js/sdk/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./typeTransformer";

--- a/js/sdk/src/utils/typeTransformer.ts
+++ b/js/sdk/src/utils/typeTransformer.ts
@@ -1,0 +1,224 @@
+/**
+ * Utility type to convert string to camelCase
+ */
+type CamelCase<S extends string> = S extends `${infer P}_${infer Q}`
+  ? `${P}${Capitalize<CamelCase<Q>>}`
+  : S;
+
+/**
+ * Recursively transforms object keys to camelCase
+ */
+type CamelCaseKeys<T> = {
+  [K in keyof T as K extends string ? CamelCase<K> : K]: T[K] extends Record<
+    string,
+    any
+  >
+    ? CamelCaseKeys<T[K]>
+    : T[K] extends Array<any>
+      ? Array<CamelCaseKeys<T[K][number]>>
+      : T[K];
+};
+
+/**
+ * Utility type to convert string to snake_case
+ */
+type SnakeCase<S extends string> = S extends `${infer T}${infer U}`
+  ? T extends Uppercase<T>
+    ? `${T extends Lowercase<T> ? "" : "_"}${Lowercase<T>}${SnakeCase<U>}`
+    : `${T}${SnakeCase<U>}`
+  : S;
+
+/**
+ * Recursively transforms object keys to snake_case
+ */
+type SnakeCaseKeys<T> = {
+  [K in keyof T as K extends string ? SnakeCase<K> : K]: T[K] extends Record<
+    string,
+    any
+  >
+    ? SnakeCaseKeys<T[K]>
+    : T[K] extends Array<any>
+      ? Array<SnakeCaseKeys<T[K][number]>>
+      : T[K];
+};
+
+const isObject = (value: unknown): value is Record<string | symbol, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  !(value instanceof Date) &&
+  !(value instanceof Map) &&
+  !(value instanceof Set) &&
+  !(value instanceof Error) &&
+  !(value instanceof RegExp);
+
+const isValidInput = (value: unknown): boolean =>
+  value !== null && value !== undefined;
+
+const convertToCamelCase = (str: string): string => {
+  // Preserve leading underscores
+  const matches = str.match(/^(_+)/);
+  const leadingUnderscores = matches ? matches[1] : "";
+  const withoutLeadingUnderscores = str.slice(leadingUnderscores.length);
+
+  if (!withoutLeadingUnderscores) {
+    return str;
+  }
+
+  // Split by underscore and capitalize
+  const converted = withoutLeadingUnderscores
+    .split("_")
+    .map((word, index) => {
+      if (index === 0) {
+        return word.toLowerCase();
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join("");
+
+  return leadingUnderscores + converted;
+};
+
+const convertToSnakeCase = (str: string): string => {
+  // Preserve leading underscores
+  const matches = str.match(/^(_+)/);
+  const leadingUnderscores = matches ? matches[1] : "";
+  const withoutLeadingUnderscores = str.slice(leadingUnderscores.length);
+
+  if (!withoutLeadingUnderscores) {
+    return str;
+  }
+
+  // Handle acronyms and regular camelCase
+  const withAcronyms = withoutLeadingUnderscores
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z\d])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+
+  return leadingUnderscores + withAcronyms;
+};
+
+export function ensureCamelCase<T>(input: T): CamelCaseKeys<T> {
+  if (!isValidInput(input)) {
+    return input as CamelCaseKeys<T>;
+  }
+
+  if (Array.isArray(input)) {
+    return input.map((item) => ensureCamelCase(item)) as CamelCaseKeys<T>;
+  }
+
+  if (!isObject(input)) {
+    return input as CamelCaseKeys<T>;
+  }
+
+  try {
+    const result = {} as Record<string | symbol, unknown>;
+
+    // Handle all properties including symbols
+    const allKeys = [
+      ...Object.getOwnPropertyNames(input),
+      ...Object.getOwnPropertySymbols(input),
+    ];
+
+    for (const key of allKeys) {
+      const descriptor = Object.getOwnPropertyDescriptor(input, key)!;
+
+      if (typeof key === "symbol") {
+        Object.defineProperty(result, key, descriptor);
+      } else {
+        const newKey = convertToCamelCase(key.toString());
+        const value = (input as any)[key];
+
+        if (isObject(value)) {
+          // Transform nested object and preserve its symbol properties
+          const transformed = ensureCamelCase(value);
+          result[newKey] = transformed;
+
+          // Copy all symbol properties from the original nested object
+          Object.getOwnPropertySymbols(value).forEach((symKey) => {
+            const symDesc = Object.getOwnPropertyDescriptor(value, symKey)!;
+            Object.defineProperty(transformed, symKey, symDesc);
+          });
+        } else if (Array.isArray(value)) {
+          result[newKey] = value.map((item) => ensureCamelCase(item));
+        } else {
+          result[newKey] = value;
+        }
+      }
+    }
+
+    return result as CamelCaseKeys<T>;
+  } catch (error) {
+    throw new Error(
+      `Failed to transform to camelCase: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}
+
+export function ensureSnakeCase<T>(input: T): SnakeCaseKeys<T> {
+  if (!isValidInput(input)) {
+    return input as SnakeCaseKeys<T>;
+  }
+
+  if (Array.isArray(input)) {
+    return input.map((item) => ensureSnakeCase(item)) as SnakeCaseKeys<T>;
+  }
+
+  if (!isObject(input)) {
+    return input as SnakeCaseKeys<T>;
+  }
+
+  try {
+    const result = {} as Record<string | symbol, unknown>;
+    const descriptors = Object.getOwnPropertyDescriptors(input);
+
+    for (const key of [
+      ...Object.getOwnPropertyNames(input),
+      ...Object.getOwnPropertySymbols(input),
+    ]) {
+      const desc = descriptors[key as any];
+      const { value } = desc;
+
+      if (typeof key === "symbol") {
+        if (isObject(value)) {
+          const transformed = ensureSnakeCase(value);
+          Object.defineProperty(result, key, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: transformed,
+          });
+        } else {
+          result[key] = value;
+        }
+      } else {
+        const newKey = convertToSnakeCase(key.toString());
+        if (isObject(value)) {
+          const transformed = ensureSnakeCase(value) as Record<
+            string | symbol,
+            unknown
+          >;
+          result[newKey] = transformed;
+
+          // Copy symbol properties
+          Object.getOwnPropertySymbols(value).forEach((symKey) => {
+            Object.defineProperty(transformed, symKey, {
+              ...Object.getOwnPropertyDescriptor(value, symKey)!,
+              value: value[symKey],
+            });
+          });
+        } else if (Array.isArray(value)) {
+          result[newKey] = value.map((item) => ensureSnakeCase(item));
+        } else {
+          result[newKey] = value;
+        }
+      }
+    }
+
+    return result as SnakeCaseKeys<T>;
+  } catch (error) {
+    throw new Error(
+      `Failed to transform to snake_case: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}

--- a/js/sdk/src/v3/clients/chunks.ts
+++ b/js/sdk/src/v3/clients/chunks.ts
@@ -6,6 +6,7 @@ import {
   WrappedChunkResponse,
   WrappedChunksResponse,
 } from "../../types";
+import { ensureSnakeCase } from "../../utils";
 
 export class ChunksClient {
   constructor(private client: r2rClient) {}
@@ -28,7 +29,7 @@ export class ChunksClient {
   }): Promise<any> {
     return this.client.makeRequest("POST", "chunks", {
       data: {
-        raw_chunks: options.chunks,
+        raw_chunks: ensureSnakeCase(options.chunks),
         runWithOrchestration: options.runWithOrchestration,
       },
     });

--- a/js/sdk/src/v3/clients/retrieval.ts
+++ b/js/sdk/src/v3/clients/retrieval.ts
@@ -7,6 +7,7 @@ import {
   WrappedSearchResponse,
   GenerationConfig,
 } from "../../types";
+import { ensureSnakeCase } from "../../utils";
 
 export class RetrievalClient {
   constructor(private client: r2rClient) {}
@@ -34,7 +35,7 @@ export class RetrievalClient {
     const data = {
       query: options.query,
       ...(options.searchSettings && {
-        search_settings: options.searchSettings,
+        search_settings: ensureSnakeCase(options.searchSettings),
       }),
       ...(options.searchMode && {
         search_mode: options.searchMode,
@@ -76,10 +77,10 @@ export class RetrievalClient {
         search_mode: options.searchMode,
       }),
       ...(options.searchSettings && {
-        search_settings: options.searchSettings,
+        search_settings: ensureSnakeCase(options.searchSettings),
       }),
       ...(options.ragGenerationConfig && {
-        rag_generation_config: options.ragGenerationConfig,
+        rag_generation_config: ensureSnakeCase(options.ragGenerationConfig),
       }),
       ...(options.taskPromptOverride && {
         task_prompt_override: options.taskPromptOverride,
@@ -174,10 +175,10 @@ export class RetrievalClient {
         search_mode: options.searchMode,
       }),
       ...(options.searchSettings && {
-        search_settings: options.searchSettings,
+        search_settings: ensureSnakeCase(options.searchSettings),
       }),
       ...(options.ragGenerationConfig && {
-        rag_generation_config: options.ragGenerationConfig,
+        rag_generation_config: ensureSnakeCase(options.ragGenerationConfig),
       }),
       ...(options.taskPromptOverride && {
         task_prompt_override: options.taskPromptOverride,

--- a/js/sdk/src/v3/clients/users.ts
+++ b/js/sdk/src/v3/clients/users.ts
@@ -115,8 +115,8 @@ export class UsersClient {
 
     if (response?.results) {
       this.client.setTokens(
-        response.results.access_token.token,
-        response.results.refresh_token.token,
+        response.results.accessToken.token,
+        response.results.refreshToken.token,
       );
     }
 
@@ -184,8 +184,8 @@ export class UsersClient {
 
     if (response?.results) {
       this.client.setTokens(
-        response.results.access_token.token,
-        response.results.refresh_token.token,
+        response.results.accessToken.token,
+        response.results.refreshToken.token,
       );
     } else {
       throw new Error("Invalid response structure");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert JavaScript SDK to camelCase naming conventions and add utility functions for key conversion.
> 
>   - **Behavior**:
>     - Convert all object keys and variable names from snake_case to camelCase in `js/sdk/src/types.ts`.
>     - Update `baseClient.ts` to use `ensureCamelCase` for response data.
>     - Modify `ChunksClient`, `RetrievalClient`, and `UsersClient` to use `ensureSnakeCase` for request data.
>   - **Utilities**:
>     - Add `ensureCamelCase` and `ensureSnakeCase` functions in `typeTransformer.ts` for key conversion.
>     - Export utility functions in `index.ts`.
>   - **Tests**:
>     - Add tests for `ensureCamelCase` and `ensureSnakeCase` in `typeTransformer.test.ts`.
>     - Update integration tests in `__tests__` to reflect camelCase changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for f80653b40660e4cb2886aab6bb0b981b93b15bda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->