### PR TITLE
Fix messages passing in conversations

### DIFF
--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -9,13 +9,10 @@ from fastapi import HTTPException
 from core import R2RStreamingRAGAgent
 from core.base import (
     DocumentResponse,
-    EmbeddingPurpose,
     GenerationConfig,
-    GraphSearchSettings,
     Message,
     R2RException,
     RunManager,
-    SearchMode,
     SearchSettings,
     manage_run,
     to_async_generator,
@@ -306,17 +303,15 @@ class RetrievalService(Service):
 
                 if conversation_id:  # Fetch the existing conversation
                     try:
-                        conversation = await self.providers.database.conversations_handler.get_conversations_overview(
-                            offset=0,
-                            limit=1,
-                            conversation_ids=[conversation_id],
+                        conversation_messages = await self.providers.database.conversations_handler.get_conversation(
+                            conversation_id=conversation_id,
                         )
                     except Exception as e:
                         logger.error(f"Error fetching conversation: {str(e)}")
 
-                    if conversation is not None:
+                    if conversation_messages is not None:
                         messages_from_conversation: list[Message] = []
-                        for message_response in conversation:
+                        for message_response in conversation_messages:
                             if isinstance(message_response, MessageResponse):
                                 messages_from_conversation.append(
                                     message_response.message


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `retrieval_service.py`, `agent()` now fetches conversation messages using `get_conversation()` and removes unused imports.
> 
>   - **Behavior**:
>     - In `retrieval_service.py`, `agent()` now uses `get_conversation()` instead of `get_conversations_overview()` to fetch conversation messages.
>     - Processes `conversation_messages` directly, appending them to `messages`.
>   - **Imports**:
>     - Removed unused imports: `EmbeddingPurpose`, `GraphSearchSettings`, and `SearchMode` from `retrieval_service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for ab61ad59dfe6a44e55e580c9aa9ecf9c090faa0c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->