### PR TITLE
Allow for setting public routes

### DIFF
--- a/py/core/main/api/v3/base_router.py
+++ b/py/core/main/api/v3/base_router.py
@@ -182,7 +182,7 @@ class BaseRouterV3:
 
         async def rate_limit_dependency(
             request: Request,
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ):
             user_id = auth_user.id
             route = request.scope["path"]

--- a/py/core/main/api/v3/chunks_router.py
+++ b/py/core/main/api/v3/chunks_router.py
@@ -74,7 +74,7 @@ class ChunksRouter(BaseRouterV3):
             search_settings: SearchSettings = Body(
                 default_factory=SearchSettings,
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedVectorSearchResponse:  # type: ignore
             # TODO - Deduplicate this code by sharing the code on the retrieval router
             """
@@ -141,7 +141,7 @@ class ChunksRouter(BaseRouterV3):
         @self.base_endpoint
         async def retrieve_chunk(
             id: UUID = Path(...),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedChunkResponse:
             """
             Get a specific chunk by its ID.
@@ -222,7 +222,7 @@ class ChunksRouter(BaseRouterV3):
             id: UUID = Path(...),
             chunk_update: UpdateChunk = Body(...),
             # TODO: Run with orchestration?
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedChunkResponse:
             """
             Update an existing chunk's content and/or metadata.
@@ -307,7 +307,7 @@ class ChunksRouter(BaseRouterV3):
         @self.base_endpoint
         async def delete_chunk(
             id: UUID = Path(...),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete a specific chunk by ID.
@@ -400,7 +400,7 @@ class ChunksRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedChunksResponse:
             """
             List chunks with pagination support.

--- a/py/core/main/api/v3/collections_router.py
+++ b/py/core/main/api/v3/collections_router.py
@@ -158,7 +158,7 @@ class CollectionsRouter(BaseRouterV3):
             description: Optional[str] = Body(
                 None, description="An optional description of the collection"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCollectionResponse:
             """
             Create a new collection and automatically add the creating user to it.
@@ -252,7 +252,7 @@ class CollectionsRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCollectionsResponse:
             """
             Returns a paginated list of collections the authenticated user has access to.
@@ -346,7 +346,7 @@ class CollectionsRouter(BaseRouterV3):
             id: UUID = Path(
                 ..., description="The unique identifier of the collection"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCollectionResponse:
             """
             Get details of a specific collection.
@@ -448,7 +448,7 @@ class CollectionsRouter(BaseRouterV3):
                 False,
                 description="Whether to generate a new synthetic description for the collection",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCollectionResponse:
             """
             Update an existing collection's configuration.
@@ -534,7 +534,7 @@ class CollectionsRouter(BaseRouterV3):
                 ...,
                 description="The unique identifier of the collection to delete",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete an existing collection.
@@ -607,7 +607,7 @@ class CollectionsRouter(BaseRouterV3):
         async def add_document_to_collection(
             id: UUID = Path(...),
             document_id: UUID = Path(...),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGenericMessageResponse:
             """
             Add a document to a collection.
@@ -697,7 +697,7 @@ class CollectionsRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedDocumentsResponse:
             """
             Get all documents in a collection with pagination and sorting options.
@@ -783,7 +783,7 @@ class CollectionsRouter(BaseRouterV3):
                 ...,
                 description="The unique identifier of the document to remove",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Remove a document from a collection.
@@ -876,7 +876,7 @@ class CollectionsRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedUsersResponse:
             """
             Get all users in a collection with pagination and sorting options.
@@ -961,7 +961,7 @@ class CollectionsRouter(BaseRouterV3):
             user_id: UUID = Path(
                 ..., description="The unique identifier of the user to add"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Add a user to a collection.
@@ -1039,7 +1039,7 @@ class CollectionsRouter(BaseRouterV3):
             user_id: UUID = Path(
                 ..., description="The unique identifier of the user to remove"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Remove a user from a collection.
@@ -1100,7 +1100,7 @@ class CollectionsRouter(BaseRouterV3):
                 default=True,
                 description="Whether to run the entities and relationships extraction process with orchestration.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ):
             """
             Extracts entities and relationships from a document.

--- a/py/core/main/api/v3/conversations_router.py
+++ b/py/core/main/api/v3/conversations_router.py
@@ -90,7 +90,7 @@ class ConversationsRouter(BaseRouterV3):
             name: Optional[str] = Body(
                 None, description="The name of the conversation", embed=True
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedConversationResponse:
             """
             Create a new conversation.
@@ -179,7 +179,7 @@ class ConversationsRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedConversationsResponse:
             """
             List conversations with pagination and sorting options.
@@ -270,7 +270,7 @@ class ConversationsRouter(BaseRouterV3):
             id: UUID = Path(
                 ..., description="The unique identifier of the conversation"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedConversationMessagesResponse:
             """
             Get details of a specific conversation.
@@ -358,7 +358,7 @@ class ConversationsRouter(BaseRouterV3):
                 description="The updated name for the conversation",
                 embed=True,
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedConversationResponse:
             """
             Update an existing conversation.
@@ -433,7 +433,7 @@ class ConversationsRouter(BaseRouterV3):
                 ...,
                 description="The unique identifier of the conversation to delete",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete an existing conversation.
@@ -527,7 +527,7 @@ class ConversationsRouter(BaseRouterV3):
             metadata: Optional[dict[str, str]] = Body(
                 None, description="Additional metadata for the message"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedMessageResponse:
             """
             Add a new message to a conversation.
@@ -617,7 +617,7 @@ class ConversationsRouter(BaseRouterV3):
             metadata: Optional[dict[str, str]] = Body(
                 None, description="Additional metadata for the message"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedMessageResponse:
             """
             Update an existing message in a conversation.

--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -297,7 +297,7 @@ class DocumentsRouter(BaseRouterV3):
                 True,
                 description="Whether or not ingestion runs with orchestration, default is `True`. When set to `False`, the ingestion process will run synchronous and directly return the result.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedIngestionResponse:
             """
             Creates a new Document object from an input file, text content, or chunks. The chosen `ingestion_mode` determines
@@ -628,7 +628,7 @@ class DocumentsRouter(BaseRouterV3):
                 False,
                 description="Specifies whether or not to include embeddings of each document summary.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedDocumentsResponse:
             """
             Returns a paginated list of documents the authenticated user has access to.
@@ -733,7 +733,7 @@ class DocumentsRouter(BaseRouterV3):
                 ...,
                 description="The ID of the document to retrieve.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedDocumentResponse:
             """
             Retrieves detailed information about a specific document by its ID.
@@ -844,7 +844,7 @@ class DocumentsRouter(BaseRouterV3):
                 False,
                 description="Whether to include vector embeddings in the response.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedChunksResponse:
             """
             Retrieves the text chunks that were generated from a document during ingestion.
@@ -952,7 +952,7 @@ class DocumentsRouter(BaseRouterV3):
         @self.base_endpoint
         async def get_document_file(
             id: str = Path(..., description="Document ID"),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> StreamingResponse:
             """
             Downloads the original file content of a document.
@@ -1078,7 +1078,7 @@ class DocumentsRouter(BaseRouterV3):
             filters: Json[dict] = Body(
                 ..., description="JSON-encoded filters"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete documents based on provided filters. Allowed operators include `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `in`, and `nin`. Deletion requests are limited to a user's own documents.
@@ -1155,7 +1155,7 @@ class DocumentsRouter(BaseRouterV3):
         @self.base_endpoint
         async def delete_document_by_id(
             id: UUID = Path(..., description="Document ID"),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete a specific document. All chunks corresponding to the document are deleted, and all other references to the document are removed.
@@ -1247,7 +1247,7 @@ class DocumentsRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCollectionsResponse:
             """
             Retrieves all collections that contain the specified document. This endpoint is restricted
@@ -1321,7 +1321,7 @@ class DocumentsRouter(BaseRouterV3):
                 default=True,
                 description="Whether to run the entities and relationships extraction process with orchestration.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGenericMessageResponse:
             """
             Extracts entities and relationships from a document.
@@ -1436,7 +1436,7 @@ class DocumentsRouter(BaseRouterV3):
                 False,
                 description="Whether to include vector embeddings in the response.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedEntitiesResponse:
             """
             Retrieves the entities that were extracted from a document. These represent
@@ -1577,7 +1577,7 @@ class DocumentsRouter(BaseRouterV3):
                 None,
                 description="Filter relationships by specific relationship types.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedRelationshipsResponse:
             """
             Retrieves the relationships between entities that were extracted from a document. These represent
@@ -1658,7 +1658,7 @@ class DocumentsRouter(BaseRouterV3):
                 default_factory=SearchSettings,
                 description="Settings for document search",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ):  # -> WrappedDocumentSearchResponse:  # type: ignore
             """
             Perform a search query on the automatically generated document summaries in the system.

--- a/py/core/main/api/v3/graph_router.py
+++ b/py/core/main/api/v3/graph_router.py
@@ -207,7 +207,7 @@ class GraphRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGraphsResponse:
             """
             Returns a paginated list of graphs the authenticated user has access to.
@@ -287,7 +287,7 @@ class GraphRouter(BaseRouterV3):
         @self.base_endpoint
         async def get_graph(
             collection_id: UUID = Path(...),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGraphResponse:
             """
             Retrieves detailed information about a specific graph by ID.
@@ -328,7 +328,7 @@ class GraphRouter(BaseRouterV3):
                 description="Settings for the graph enrichment process.",
             ),
             run_with_orchestration: Optional[bool] = Body(True),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ):
             """
             Creates communities in the graph by analyzing entity relationships and similarities.
@@ -453,7 +453,7 @@ class GraphRouter(BaseRouterV3):
         @self.base_endpoint
         async def reset(
             collection_id: UUID = Path(...),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Deletes a graph and all its associated data.
@@ -540,7 +540,7 @@ class GraphRouter(BaseRouterV3):
             description: Optional[str] = Body(
                 None, description="An optional description of the graph"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ):
             """
             Update an existing graphs's configuration.
@@ -624,7 +624,7 @@ class GraphRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedEntitiesResponse:
             """Lists all entities in the graph with pagination support."""
             if (
@@ -669,7 +669,7 @@ class GraphRouter(BaseRouterV3):
             metadata: Optional[dict] = Body(
                 None, description="The metadata of the entity to create."
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedEntityResponse:
             """Creates a new entity in the graph."""
             if (
@@ -727,7 +727,7 @@ class GraphRouter(BaseRouterV3):
             metadata: Optional[dict] = Body(
                 None, description="The metadata of the relationship to create."
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedRelationshipResponse:
             """Creates a new relationship in the graph."""
             if not auth_user.is_superuser:
@@ -808,7 +808,7 @@ class GraphRouter(BaseRouterV3):
             entity_id: UUID = Path(
                 ..., description="The ID of the entity to retrieve."
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedEntityResponse:
             """Retrieves a specific entity by its ID."""
             if (
@@ -857,7 +857,7 @@ class GraphRouter(BaseRouterV3):
             metadata: Optional[dict] = Body(
                 None, description="The updated metadata of the entity."
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedEntityResponse:
             """Updates an existing entity in the graph."""
             if not auth_user.is_superuser:
@@ -936,7 +936,7 @@ class GraphRouter(BaseRouterV3):
                 ...,
                 description="The ID of the entity to remove from the graph.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """Removes an entity from the graph."""
             if not auth_user.is_superuser:
@@ -1018,7 +1018,7 @@ class GraphRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedRelationshipsResponse:
             """
             Lists all relationships in the graph with pagination support.
@@ -1096,7 +1096,7 @@ class GraphRouter(BaseRouterV3):
             relationship_id: UUID = Path(
                 ..., description="The ID of the relationship to retrieve."
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedRelationshipResponse:
             """Retrieves a specific relationship by its ID."""
             if (
@@ -1160,7 +1160,7 @@ class GraphRouter(BaseRouterV3):
             metadata: Optional[dict] = Body(
                 None, description="The updated metadata of the relationship."
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedRelationshipResponse:
             """Updates an existing relationship in the graph."""
             if not auth_user.is_superuser:
@@ -1244,7 +1244,7 @@ class GraphRouter(BaseRouterV3):
                 ...,
                 description="The ID of the relationship to remove from the graph.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """Removes a relationship from the graph."""
             if not auth_user.is_superuser:
@@ -1337,7 +1337,7 @@ class GraphRouter(BaseRouterV3):
             rating_explanation: Optional[str] = Body(
                 default="", description="Explanation for the rating"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCommunityResponse:
             """
             Creates a new community in the graph.
@@ -1434,7 +1434,7 @@ class GraphRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCommunitiesResponse:
             """
             Lists all communities in the graph with pagination support.
@@ -1509,7 +1509,7 @@ class GraphRouter(BaseRouterV3):
                 ...,
                 description="The ID of the community to get.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCommunityResponse:
             """
             Retrieves a specific community by its ID.
@@ -1591,7 +1591,7 @@ class GraphRouter(BaseRouterV3):
                 ...,
                 description="The ID of the community to delete.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ):
             if (
                 not auth_user.is_superuser
@@ -1680,7 +1680,7 @@ class GraphRouter(BaseRouterV3):
             findings: Optional[list[str]] = Body(None),
             rating: Optional[float] = Body(default=None, ge=1, le=10),
             rating_explanation: Optional[str] = Body(None),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCommunityResponse:
             """
             Updates an existing community in the graph.
@@ -1765,7 +1765,7 @@ class GraphRouter(BaseRouterV3):
             # document_ids: list[UUID] = Body(
             #     ..., description="List of document IDs to add to the graph."
             # ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Adds documents to a graph by copying their entities and relationships.

--- a/py/core/main/api/v3/indices_router.py
+++ b/py/core/main/api/v3/indices_router.py
@@ -172,7 +172,7 @@ class IndicesRouter(BaseRouterV3):
                 True,
                 description="Whether to run index creation as an orchestrated task (recommended for large indices)",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGenericMessageResponse:
             """
             Create a new vector similarity search index in over the target table. Allowed tables include 'vectors', 'entity', 'document_collections'.
@@ -315,7 +315,7 @@ class IndicesRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedListVectorIndicesResponse:
             """
             List existing vector similarity search indices with pagination support.
@@ -407,7 +407,7 @@ class IndicesRouter(BaseRouterV3):
             index_name: str = Path(
                 ..., description="The name of the index to delete"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> dict:  #  -> WrappedGetIndexResponse:
             """
             Get detailed information about a specific vector index.
@@ -494,7 +494,7 @@ class IndicesRouter(BaseRouterV3):
         #             id: UUID = Path(...),
         #             config: IndexConfig = Body(...),
         #             run_with_orchestration: Optional[bool] = Body(True),
-        #             auth_user=Depends(self.providers.auth.auth_wrapper),
+        #             auth_user=Depends(self.providers.auth.auth_wrapper()),
         #         ):  # -> WrappedUpdateIndexResponse:
         #             """
         #             Update an existing index's configuration.
@@ -581,7 +581,7 @@ class IndicesRouter(BaseRouterV3):
             #     description="Whether to delete the index concurrently (recommended for large indices)",
             # ),
             # run_with_orchestration: Optional[bool] = Body(True),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGenericMessageResponse:
             """
             Delete an existing vector similarity search index.

--- a/py/core/main/api/v3/prompts_router.py
+++ b/py/core/main/api/v3/prompts_router.py
@@ -93,7 +93,7 @@ class PromptsRouter(BaseRouterV3):
                 default={},
                 description="A dictionary mapping input names to their types",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGenericMessageResponse:
             """
             Create a new prompt with the given configuration.
@@ -167,7 +167,7 @@ class PromptsRouter(BaseRouterV3):
         )
         @self.base_endpoint
         async def get_prompts(
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedPromptsResponse:
             """
             List all available prompts.
@@ -262,7 +262,7 @@ class PromptsRouter(BaseRouterV3):
             prompt_override: Optional[str] = Query(
                 None, description="Prompt override"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedPromptResponse:
             """
             Get a specific prompt by name, optionally with inputs and override.
@@ -347,7 +347,7 @@ class PromptsRouter(BaseRouterV3):
                 default={},
                 description="A dictionary mapping input names to their types",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGenericMessageResponse:
             """
             Update an existing prompt's template and/or input types.
@@ -424,7 +424,7 @@ class PromptsRouter(BaseRouterV3):
         @self.base_endpoint
         async def delete_prompt(
             name: str = Path(..., description="Prompt name"),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete a prompt by name.

--- a/py/core/main/api/v3/retrieval_router.py
+++ b/py/core/main/api/v3/retrieval_router.py
@@ -219,7 +219,7 @@ class RetrievalRouterV3(BaseRouterV3):
                     "Common overrides include `filters` to narrow results and `limit` to control how many results are returned."
                 ),
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedSearchResponse:
             """
             Perform a search query against vector and/or graph-based databases.
@@ -412,7 +412,7 @@ class RetrievalRouterV3(BaseRouterV3):
                 default=False,
                 description="Include document titles in responses when available",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedRAGResponse:
             """
             Execute a RAG (Retrieval-Augmented Generation) query.
@@ -612,7 +612,7 @@ class RetrievalRouterV3(BaseRouterV3):
                 default=None,
                 description="ID of the conversation",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedAgentResponse:
             """
             Engage with an intelligent RAG-powered conversational agent for complex information retrieval and analysis.
@@ -800,7 +800,7 @@ class RetrievalRouterV3(BaseRouterV3):
                     "stream": False,
                 },
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
             response_model=WrappedCompletionResponse,
         ):
             """
@@ -879,7 +879,7 @@ class RetrievalRouterV3(BaseRouterV3):
                 ...,
                 description="Text to generate embeddings for",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ):
             """
             Generate embeddings for the provided text using the specified model.

--- a/py/core/main/api/v3/system_router.py
+++ b/py/core/main/api/v3/system_router.py
@@ -144,7 +144,7 @@ class SystemRouter(BaseRouterV3):
         )
         @self.base_endpoint
         async def app_settings(
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedSettingsResponse:
             if not auth_user.is_superuser:
                 raise R2RException(
@@ -210,7 +210,7 @@ class SystemRouter(BaseRouterV3):
         )
         @self.base_endpoint
         async def server_stats(
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedServerStatsResponse:
             if not auth_user.is_superuser:
                 raise R2RException(

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -110,6 +110,7 @@ class UsersRouter(BaseRouterV3):
         ) -> WrappedUserResponse:
             """Register a new user with the given email and password."""
 
+            # TODO: Do we really want this validation? The default password for the superuser would not pass...
             def validate_password(password: str) -> bool:
                 if len(password) < 10:
                     return False
@@ -524,7 +525,9 @@ class UsersRouter(BaseRouterV3):
 
         @self.router.post(
             "/users/request-password-reset",
-            dependencies=[Depends(self.rate_limit_dependency)],
+            dependencies=[
+                Depends(self.providers.auth.auth_wrapper(public=True))
+            ],
             response_model=WrappedGenericMessageResponse,
             openapi_extra={
                 "x-codeSamples": [
@@ -574,7 +577,7 @@ class UsersRouter(BaseRouterV3):
         )
         @self.base_endpoint
         async def request_password_reset(
-            email: EmailStr = Body(..., description="User's email address")
+            email: EmailStr = Body(..., description="User's email address"),
         ) -> WrappedGenericMessageResponse:
             """Request a password reset for a user."""
             result = await self.services.auth.request_password_reset(email)

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -106,7 +106,7 @@ class UsersRouter(BaseRouterV3):
             profile_picture: str | None = Body(
                 None, description="Updated user profile picture"
             ),
-            # auth_user=Depends(self.providers.auth.auth_wrapper),
+            # auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedUserResponse:
             """Register a new user with the given email and password."""
 
@@ -391,7 +391,7 @@ class UsersRouter(BaseRouterV3):
         @self.base_endpoint
         async def logout(
             token: str = Depends(oauth2_scheme),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedGenericMessageResponse:
             """Log out the current user."""
             result = await self.services.auth.logout(token)
@@ -515,7 +515,7 @@ class UsersRouter(BaseRouterV3):
         async def change_password(
             current_password: str = Body(..., description="Current password"),
             new_password: str = Body(..., description="New password"),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> GenericMessageResponse:
             """Change the authenticated user's password."""
             result = await self.services.auth.change_password(
@@ -715,7 +715,7 @@ class UsersRouter(BaseRouterV3):
             #     email: Optional[str] = Query(None, example="john@example.com"),
             #     is_active: Optional[bool] = Query(None, example=True),
             #     is_superuser: Optional[bool] = Query(None, example=False),
-            #     auth_user=Depends(self.providers.auth.auth_wrapper),
+            #     auth_user=Depends(self.providers.auth.auth_wrapper()),
             ids: list[str] = Query(
                 [], description="List of user IDs to filter by"
             ),
@@ -730,7 +730,7 @@ class UsersRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedUsersResponse:
             """
             List all users with pagination and filtering options.
@@ -812,7 +812,7 @@ class UsersRouter(BaseRouterV3):
         )
         @self.base_endpoint
         async def get_current_user(
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedUserResponse:
             """
             Get detailed information about the currently authenticated user.
@@ -884,7 +884,7 @@ class UsersRouter(BaseRouterV3):
             id: UUID = Path(
                 ..., example="550e8400-e29b-41d4-a716-446655440000"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedUserResponse:
             """
             Get detailed information about a specific user.
@@ -960,7 +960,7 @@ class UsersRouter(BaseRouterV3):
                 False,
                 description="Whether to delete the user's vector data",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete a specific user.
@@ -1060,7 +1060,7 @@ class UsersRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCollectionsResponse:
             """
             Get all collections associated with a specific user.
@@ -1153,7 +1153,7 @@ class UsersRouter(BaseRouterV3):
             collection_id: UUID = Path(
                 ..., example="750e8400-e29b-41d4-a716-446655440000"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             if auth_user.id != id and not auth_user.is_superuser:
                 raise R2RException(
@@ -1237,7 +1237,7 @@ class UsersRouter(BaseRouterV3):
             collection_id: UUID = Path(
                 ..., example="750e8400-e29b-41d4-a716-446655440000"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Remove a user from a collection.
@@ -1329,7 +1329,7 @@ class UsersRouter(BaseRouterV3):
             profile_picture: str | None = Body(
                 None, description="Updated profile picture URL"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedUserResponse:
             """
             Update user information.
@@ -1397,7 +1397,7 @@ class UsersRouter(BaseRouterV3):
             id: UUID = Path(
                 ..., description="ID of the user for whom to create an API key"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedAPIKeyResponse:
             """
             Create a new API key for the specified user.
@@ -1450,7 +1450,7 @@ class UsersRouter(BaseRouterV3):
             id: UUID = Path(
                 ..., description="ID of the user whose API keys to list"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedAPIKeysResponse:
             """
             List all API keys for the specified user.
@@ -1510,7 +1510,7 @@ class UsersRouter(BaseRouterV3):
             key_id: UUID = Path(
                 ..., description="ID of the API key to delete"
             ),
-            auth_user=Depends(self.providers.auth.auth_wrapper),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedBooleanResponse:
             """
             Delete a specific API key for the specified user.


### PR DESCRIPTION
Dependency on and checks within the auth provider were too rigid and didn't make sense for endpoints that must be publicly available. This allows for marking routes as public.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for public routes in `auth_wrapper` and mark `request-password-reset` as public in `users_router.py`.
> 
>   - **Behavior**:
>     - Add `public` parameter to `auth_wrapper` in `auth.py` to allow public routes.
>     - Update `request-password-reset` endpoint in `users_router.py` to be public.
>   - **Functions**:
>     - Modify `auth_wrapper` in `auth.py` to handle `public` routes.
>   - **Endpoints**:
>     - Mark `/users/request-password-reset` in `users_router.py` as public.
>   - **Misc**:
>     - Update `auth_wrapper` usage in `base_router.py`, `chunks_router.py`, and `collections_router.py` to accommodate `public` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 3a5174ea1d14eaedb1b6c2818a507489f882f36f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->