### PR TITLE
Update CLI auth error message, move backoff down to 3 retries

### DIFF
--- a/py/cli/command_group.py
+++ b/py/cli/command_group.py
@@ -1,4 +1,3 @@
-# from .main import load_config
 import json
 import types
 from functools import wraps

--- a/py/cli/commands/config.py
+++ b/py/cli/commands/config.py
@@ -71,9 +71,7 @@ async def reset():
     Config._config = configparser.ConfigParser()  # Reset the config in memory
 
     # Set default values
-    Config.set_credentials(
-        "Base URL", {"base_url": "https://api.cloud.sciphi.ai"}
-    )
+    Config.set_credentials("Base URL", {"base_url": "http://localhost:7272"})
 
     console.print(
         "[green]Successfully reset configuration to defaults[/green]"

--- a/py/compose.full.yaml
+++ b/py/compose.full.yaml
@@ -387,6 +387,8 @@ services:
         condition: service_completed_successfully
       unstructured:
         condition: service_healthy
+      graph_clustering:
+        condition: service_healthy
 
   r2r-dashboard:
     image: emrgntcmplxty/r2r-dashboard:latest

--- a/py/core/base/providers/auth.py
+++ b/py/core/base/providers/auth.py
@@ -133,7 +133,7 @@ class AuthProvider(Provider, ABC):
                 return await self._get_default_admin_user()
             if not auth and not api_key:
                 raise R2RException(
-                    message="No credentials provided",
+                    message="No credentials provided. Create an account at https://app.sciphi.ai and set your API key using `r2r configure key` OR change your base URL to a custom deployment.",
                     status_code=401,
                 )
             if auth and api_key:

--- a/py/core/base/providers/embedding.py
+++ b/py/core/base/providers/embedding.py
@@ -30,7 +30,7 @@ class EmbeddingConfig(ProviderConfig):
     prefixes: Optional[dict[str, str]] = None
     add_title_as_prefix: bool = True
     concurrent_request_limit: int = 256
-    max_retries: int = 8
+    max_retries: int = 3
     initial_backoff: float = 1
     max_backoff: float = 64.0
     quantization_settings: VectorQuantizationSettings = (

--- a/py/core/base/providers/llm.py
+++ b/py/core/base/providers/llm.py
@@ -23,7 +23,7 @@ class CompletionConfig(ProviderConfig):
     provider: Optional[str] = None
     generation_config: GenerationConfig = GenerationConfig()
     concurrent_request_limit: int = 256
-    max_retries: int = 8
+    max_retries: int = 3
     initial_backoff: float = 1.0
     max_backoff: float = 64.0
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "r2r"
 readme = "README.md"
-version = "3.3.19"
+version = "3.3.20"
 
 description = "SciPhi R2R"
 authors = ["Owen Colegrove <owen@sciphi.ai>"]

--- a/py/sdk/async_client.py
+++ b/py/sdk/async_client.py
@@ -29,7 +29,7 @@ class R2RAsyncClient(BaseClient):
     def __init__(
         self,
         base_url: str = "https://api.cloud.sciphi.ai",
-        prefix: str = "/v2",
+        prefix: str = "/v3",
         custom_client=None,
         timeout: float = 300.0,
     ):
@@ -47,7 +47,7 @@ class R2RAsyncClient(BaseClient):
         self.users = UsersSDK(self)
 
     async def _make_request(
-        self, method: str, endpoint: str, version: str = "v2", **kwargs
+        self, method: str, endpoint: str, version: str = "v3", **kwargs
     ):
         url = self._get_full_url(endpoint, version)
         request_args = self._prepare_request_args(endpoint, **kwargs)
@@ -70,7 +70,7 @@ class R2RAsyncClient(BaseClient):
             ) from e
 
     async def _make_streaming_request(
-        self, method: str, endpoint: str, version: str = "v2", **kwargs
+        self, method: str, endpoint: str, version: str = "v3", **kwargs
     ) -> AsyncGenerator[Any, None]:
         url = self._get_full_url(endpoint, version)
         request_args = self._prepare_request_args(endpoint, **kwargs)

--- a/py/sdk/base/base_client.py
+++ b/py/sdk/base/base_client.py
@@ -36,7 +36,7 @@ class BaseClient:
     def __init__(
         self,
         base_url: str = "https://api.cloud.sciphi.ai",
-        prefix: str = "/v2",
+        prefix: str = "/v3",
         timeout: float = 300.0,
     ):
         self.base_url = base_url
@@ -66,7 +66,7 @@ class BaseClient:
                 message="Not authenticated. Please login first.",
             )
 
-    def _get_full_url(self, endpoint: str, version: str = "v2") -> str:
+    def _get_full_url(self, endpoint: str, version: str = "v3") -> str:
         return f"{self.base_url}/{version}/{endpoint}"
 
     def _prepare_request_args(self, endpoint: str, **kwargs) -> dict:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CLI auth error message, reduce retry count, and change default base URL and API version.
> 
>   - **Behavior**:
>     - Update authentication error message in `_auth_wrapper()` in `auth.py` to provide more guidance on setting API key or changing base URL.
>     - Reduce `max_retries` from 8 to 3 in `EmbeddingConfig` in `embedding.py` and `CompletionConfig` in `llm.py`.
>     - Change default `base_url` to `http://localhost:7272` in `reset()` in `config.py`.
>     - Update API version prefix from `/v2` to `/v3` in `async_client.py` and `base_client.py`.
>   - **Configuration**:
>     - Add `graph_clustering` service with health check in `compose.full.yaml`.
>   - **Misc**:
>     - Increment version to `3.3.20` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 96588116716a62f23649f78305a6da332899e916. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->