### PR TITLE
Reset password and verification email to public routes

### DIFF
--- a/js/sdk/src/v3/clients/users.ts
+++ b/js/sdk/src/v3/clients/users.ts
@@ -81,7 +81,10 @@ export class UsersClient {
     email: string;
   }): Promise<WrappedGenericMessageResponse> {
     return this.client.makeRequest("POST", "users/send-verification-email", {
-      data: options,
+      data: `email=${encodeURIComponent(options.email)}`,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
     });
   }
 

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -337,9 +337,8 @@ class UsersRouter(BaseRouterV3):
                             from r2r import R2RClient
 
                             client = R2RClient()
-                            tokens = client.users.verify_email(
+                            tokens = client.users.send_verification_email(
                                 email="jane.doe@example.com",
-                                verification_code="1lklwal!awdclm"
                             )"""
                         ),
                     },
@@ -352,9 +351,8 @@ class UsersRouter(BaseRouterV3):
                             const client = new r2rClient();
 
                             function main() {
-                                const response = await client.users.verifyEmail({
+                                const response = await client.users.sendVerificationEmail({
                                     email: jane.doe@example.com",
-                                    verificationCode: "1lklwal!awdclm"
                                 });
                             }
 
@@ -366,9 +364,9 @@ class UsersRouter(BaseRouterV3):
                         "lang": "cURL",
                         "source": textwrap.dedent(
                             """
-                            curl -X POST "https://api.example.com/v3/users/login" \\
+                            curl -X POST "https://api.example.com/v3/users/send-verification-email" \\
                                 -H "Content-Type: application/x-www-form-urlencoded" \\
-                                -d "email=jane.doe@example.com&verification_code=1lklwal!awdclm"
+                                -d "email=jane.doe@example.com"
                             """
                         ),
                     },
@@ -391,9 +389,7 @@ class UsersRouter(BaseRouterV3):
                     message="This email is already verified. Please log in.",
                 )
 
-            result = await self.services.auth.send_verification_email(
-                email=email
-            )
+            await self.services.auth.send_verification_email(email=email)
             return GenericMessageResponse(message="A verification email has been sent.")  # type: ignore
 
         @self.router.post(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make password reset and verification email functionalities public by updating API routes, backend logic, client SDK, and tests.
> 
>   - **API Changes**:
>     - Made `/users/send-verification-email` and `/users/reset-password` public in `users_router.py`.
>     - Updated `/users/verify-email` to return `WrappedGenericMessageResponse`.
>   - **Backend Logic**:
>     - Added `send_verification_email` method in `auth.py` and `r2r_auth.py`.
>     - Modified `register` method in `r2r_auth.py` to use `send_verification_email`.
>   - **Client SDK**:
>     - Added `sendVerificationEmail` method in `users.ts` and `users.py`.
>     - Updated `package.json` version to `0.4.10`.
>   - **Testing**:
>     - Added test `Request verification email` in `UsersIntegrationSuperUser.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 529287246d1c3ab8eeae4bac61f6d57d047718db. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->