### PR TITLE
Only log POST and DELETE requests in the request_log table

### DIFF
--- a/py/core/main/api/v3/base_router.py
+++ b/py/core/main/api/v3/base_router.py
@@ -152,10 +152,11 @@ class BaseRouterV3:
             try:
                 yield
             finally:
-                # 4) Log the request afterwards
-                await self.providers.database.limits_handler.log_request(
-                    user_id, route
-                )
+                # 4) Log only POST and DELETE requests
+                if request.method in ["POST", "DELETE"]:
+                    await self.providers.database.limits_handler.log_request(
+                        user_id, route
+                    )
 
         async def websocket_rate_limit_dependency(websocket: WebSocket):
             # Example: if you want to rate-limit websockets similarly


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `rate_limit_dependency` in `base_router.py` to log only `POST` and `DELETE` requests, skipping others.
> 
>   - **Behavior**:
>     - Modify `rate_limit_dependency` in `base_router.py` to log only `POST` and `DELETE` requests.
>     - Skips logging for other HTTP methods, optimizing database operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 28ef06b42d5b167480e2e4ed8cd0508cfb64c974. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->