### PR TITLE
Move from user_id to owner_id for contextual enrichment

### DIFF
--- a/py/core/main/orchestration/hatchet/ingestion_workflow.py
+++ b/py/core/main/orchestration/hatchet/ingestion_workflow.py
@@ -225,7 +225,7 @@ def hatchet_ingestion_factory(
                         await self.ingestion_service.providers.database.documents_handler.get_documents_overview(  # FIXME: This was using the pagination defaults from before... We need to review if this is as intended.
                             offset=0,
                             limit=100,
-                            filter_user_ids=[document_info.user_id],
+                            filter_user_ids=[document_info.owner_id],
                             filter_document_ids=[document_info.id],
                         )
                     )["results"][0]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `filter_user_ids` to `filter_user_ids` in `parse()` method of `HatchetIngestFilesWorkflow` to use `owner_id` instead of `user_id`.
> 
>   - **Behavior**:
>     - In `ingestion_workflow.py`, change `filter_user_ids` from `document_info.user_id` to `document_info.owner_id` in `parse()` method of `HatchetIngestFilesWorkflow` class.
>     - Affects document overview retrieval, aligning with owner-based filtering instead of user-based.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for b0930144a3bd80c075f224e67533d79bfff51529. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->