### PR TITLE
User Registration with Profile Fields

### DIFF
--- a/py/core/database/users.py
+++ b/py/core/database/users.py
@@ -251,6 +251,9 @@ class PostgresUserHandler(Handler):
         google_id: Optional[str] = None,
         github_id: Optional[str] = None,
         is_superuser: bool = False,
+        name: Optional[str] = None,
+        bio: Optional[str] = None,
+        profile_picture: Optional[str] = None
     ) -> User:
         """Create a new user."""
         # 1) Check if a user with this email already exists
@@ -308,6 +311,9 @@ class PostgresUserHandler(Handler):
                     "google_id": google_id,
                     "github_id": github_id,
                     "is_verified": account_type != "password",
+                    "name": name,
+                    "bio": bio,
+                    "profile_picture": profile_picture,
                 }
             )
             .returning(
@@ -322,6 +328,9 @@ class PostgresUserHandler(Handler):
                     "collection_ids",
                     "limits_overrides",
                     "metadata",
+                    "name",
+                    "bio",
+                    "profile_picture",
                 ]
             )
             .build()
@@ -345,9 +354,9 @@ class PostgresUserHandler(Handler):
             collection_ids=result["collection_ids"] or [],
             limits_overrides=json.loads(result["limits_overrides"] or "{}"),
             metadata=json.loads(result["metadata"] or "{}"),
-            name=None,
-            bio=None,
-            profile_picture=None,
+            name=result["name"],
+            bio=result["bio"],
+            profile_picture=result["profile_picture"],
             account_type=account_type,
             hashed_password=hashed_password,
             google_id=google_id,

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -147,15 +147,12 @@ class UsersRouter(BaseRouterV3):
             #     )
 
             registration_response = await self.services.auth.register(
-                email, password
+                email=email,
+                password=password,
+                name=name,
+                bio=bio,
+                profile_picture=profile_picture
             )
-            if name or bio or profile_picture:
-                return await self.services.auth.update_user(
-                    user_id=registration_response.id,
-                    name=name,
-                    bio=bio,
-                    profile_picture=profile_picture,
-                )
 
             return registration_response
 

--- a/py/core/main/services/auth_service.py
+++ b/py/core/main/services/auth_service.py
@@ -35,8 +35,21 @@ class AuthService(Service):
         )
 
     @telemetry_event("RegisterUser")
-    async def register(self, email: str, password: str) -> User:
-        return await self.providers.auth.register(email, password)
+    async def register(
+        self,
+        email: str,
+        password: str,
+        name: Optional[str] = None,
+        bio: Optional[str] = None,
+        profile_picture: Optional[str] = None,
+    ) -> User:
+        return await self.providers.auth.register(
+            email=email,
+            password=password,
+            name=name,
+            bio=bio,
+            profile_picture=profile_picture
+        )
 
     @telemetry_event("SendVerificationEmail")
     async def send_verification_email(

--- a/py/core/providers/auth/r2r_auth.py
+++ b/py/core/providers/auth/r2r_auth.py
@@ -203,6 +203,9 @@ class R2RAuthProvider(AuthProvider):
         account_type: str = "password",
         github_id: Optional[str] = None,
         google_id: Optional[str] = None,
+        name: Optional[str] = None,
+        bio: Optional[str] = None,
+        profile_picture: Optional[str] = None
     ) -> User:
         if account_type == "password":
             if not password:
@@ -228,6 +231,9 @@ class R2RAuthProvider(AuthProvider):
             account_type=account_type,
             github_id=github_id,
             google_id=google_id,
+            name=name,
+            bio=bio,
+            profile_picture=profile_picture
         )
         default_collection: CollectionResponse = (
             await self.database_provider.collections_handler.create_collection(

--- a/py/core/providers/auth/supabase.py
+++ b/py/core/providers/auth/supabase.py
@@ -72,7 +72,14 @@ class SupabaseAuthProvider(AuthProvider):
             "decode_token is not used with Supabase authentication"
         )
 
-    async def register(self, email: str, password: str) -> User:  # type: ignore
+    async def register(
+        self,
+        email: str, 
+        password: str,
+        name: Optional[str] = None,
+        bio: Optional[str] = None,
+        profile_picture: Optional[str] = None
+        ) -> User:  # type: ignore
         # Use Supabase client to create a new user
 
         if user := self.supabase.auth.sign_up(email=email, password=password):


### PR DESCRIPTION
🎯 Problem
Previously, setting user profile fields (name, bio, profile_picture) required two API calls:

Register user with email/password
Update user to add profile fields
This caused verification emails to use email prefix instead of actual name since the name was set after registration.

💡 Solution
Combined registration and profile update into a single API call by:

Adding profile fields to initial user registration
Removing the separate update call after registration
Ensuring verification emails use actual name immediately
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Combine user registration and profile update into a single API call, adding `name`, `bio`, and `profile_picture` fields to the registration process.
> 
>   - **Behavior**:
>     - Combine user registration and profile update into a single API call in `users_router.py`.
>     - Add `name`, `bio`, and `profile_picture` fields to `register()` in `auth_service.py` and `r2r_auth.py`.
>     - Remove separate update call after registration in `users_router.py`.
>     - Ensure verification emails use actual name immediately.
>   - **Database**:
>     - Update `create_user()` in `users.py` to include `name`, `bio`, and `profile_picture` fields.
>     - Modify `register()` in `supabase.py` to accept new fields.
>   - **Misc**:
>     - Update `register()` in `auth_service.py` to pass new fields to `providers.auth.register()`.
>     - Adjust `register()` in `r2r_auth.py` to handle new fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for d39fac26ececfa90cbf5d7d4a4d643ea2a457e45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->