### PR TITLE
NaN Embedding Dimension Support

### DIFF
--- a/py/core/base/providers/embedding.py
+++ b/py/core/base/providers/embedding.py
@@ -23,7 +23,7 @@ logger = logging.getLogger()
 class EmbeddingConfig(ProviderConfig):
     provider: str
     base_model: str
-    base_dimension: int
+    base_dimension: int | float
     rerank_model: Optional[str] = None
     rerank_url: Optional[str] = None
     batch_size: int = 1

--- a/py/core/base/utils/__init__.py
+++ b/py/core/base/utils/__init__.py
@@ -3,6 +3,7 @@ from shared.utils import (
     TextSplitter,
     _decorate_vector_type,
     _get_str_estimation_output,
+    _get_vector_column_str,
     decrement_version,
     deep_update,
     format_search_results_for_llm,
@@ -39,5 +40,6 @@ __all__ = [
     "validate_uuid",
     "deep_update",
     "_decorate_vector_type",
+    "_get_vector_column_str",
     "_get_str_estimation_output",
 ]

--- a/py/core/database/graphs.py
+++ b/py/core/database/graphs.py
@@ -4,6 +4,7 @@ import csv
 import datetime
 import json
 import logging
+import math
 import os
 import tempfile
 import time
@@ -32,6 +33,7 @@ from core.base.providers.database import Handler
 from core.base.utils import (
     _decorate_vector_type,
     _get_str_estimation_output,
+    _get_vector_column_str,
     llm_cost_per_million_tokens,
 )
 
@@ -75,8 +77,8 @@ class PostgresEntitiesHandler(Handler):
 
     async def create_tables(self) -> None:
         """Create separate tables for graph and document entities."""
-        vector_column_str = _decorate_vector_type(
-            f"({self.dimension})", self.quantization_type
+        vector_column_str = _get_vector_column_str(
+            self.dimension, self.quantization_type
         )
 
         for store_type in StoreType:
@@ -527,9 +529,10 @@ class PostgresRelationshipsHandler(Handler):
         for store_type in StoreType:
             table_name = self._get_relationship_table_for_store(store_type)
             parent_constraint = self._get_parent_constraint(store_type)
-            vector_column_str = _decorate_vector_type(
-                f"({self.dimension})", self.quantization_type
+            vector_column_str = _get_vector_column_str(
+                self.dimension, self.quantization_type
             )
+
             QUERY = f"""
                 CREATE TABLE IF NOT EXISTS {self._get_table_name(table_name)} (
                     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -1011,8 +1014,8 @@ class PostgresCommunitiesHandler(Handler):
         self.quantization_type: VectorQuantizationType = kwargs.get("quantization_type")  # type: ignore
 
     async def create_tables(self) -> None:
-        vector_column_str = _decorate_vector_type(
-            f"({self.dimension})", self.quantization_type
+        vector_column_str = _get_vector_column_str(
+            self.dimension, self.quantization_type
         )
 
         query = f"""

--- a/py/core/providers/embeddings/litellm.py
+++ b/py/core/providers/embeddings/litellm.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 from copy import copy
 from typing import Any
@@ -72,6 +73,10 @@ class LiteLLMEmbeddingProvider(EmbeddingProvider):
     async def _execute_task(self, task: dict[str, Any]) -> list[list[float]]:
         texts = task["texts"]
         kwargs = self._get_embedding_kwargs(**task.get("kwargs", {}))
+
+        if "dimensions" in kwargs and math.isnan(kwargs["dimensions"]):
+            kwargs.pop("dimensions")
+            logger.warning("Dropping nan dimensions from kwargs")
 
         try:
             response = await self.litellm_aembedding(

--- a/py/shared/utils/__init__.py
+++ b/py/shared/utils/__init__.py
@@ -1,6 +1,7 @@
 from .base_utils import (
     _decorate_vector_type,
     _get_str_estimation_output,
+    _get_vector_column_str,
     decrement_version,
     deep_update,
     format_search_results_for_llm,
@@ -42,5 +43,6 @@ __all__ = [
     "TextSplitter",
     # Vector utils
     "_decorate_vector_type",
+    "_get_vector_column_str",
     "_get_str_estimation_output",
 ]

--- a/py/shared/utils/base_utils.py
+++ b/py/shared/utils/base_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import math
 from copy import deepcopy
 from datetime import datetime
 from typing import (
@@ -298,6 +299,23 @@ def _decorate_vector_type(
     quantization_type: VectorQuantizationType = VectorQuantizationType.FP32,
 ) -> str:
     return f"{quantization_type.db_type}{input_str}"
+
+
+def _get_vector_column_str(
+    dimension: int | float, quantization_type: VectorQuantizationType
+) -> str:
+    """
+    Returns a string representation of a vector column type.
+
+    Explicitly handles the case where the dimension is not a valid number
+    meant to support embedding models that do not allow for specifying
+    the dimension.
+    """
+    if math.isnan(dimension) or dimension <= 0:
+        vector_dim = ""  # Allows for Postgres to handle any dimension
+    else:
+        vector_dim = f"({dimension})"
+    return _decorate_vector_type(vector_dim, quantization_type)
 
 
 def _get_str_estimation_output(x: tuple[Any, Any]) -> str:


### PR DESCRIPTION
Allows for specifying `nan` dimensions for models that do not support dimension parameters.

```
[embedding]
provider = "litellm"
base_model = "ollama/bge-large"
base_dimension = nan
batch_size = 128
add_title_as_prefix = true
concurrent_request_limit = 2
```