### PR TITLE
Adding auto-gen email fallback for github oauth

### DIFF
--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -1831,6 +1831,7 @@ class UsersRouter(BaseRouterV3):
             # id_info will contain "sub", "email", etc.
             google_id = id_info["sub"]
             email = id_info.get("email")
+            email = email or f"{google_id}@google_oauth.fake"
 
             # 3. Now call our R2RAuthProvider method that handles "oauth-based" user creation or login
             token_response = await self.providers.auth.oauth_callback_handler(
@@ -1895,12 +1896,13 @@ class UsersRouter(BaseRouterV3):
                 "https://api.github.com/user",
                 headers={"Authorization": f"Bearer {access_token}"},
             ).json()
+
             github_id = str(
                 user_info_resp["id"]
             )  # GitHub user ID is typically an integer
             # fetch email (sometimes you need to call /user/emails endpoint if user sets email private)
             email = user_info_resp.get("email")
-
+            email = email or f"{github_id}@github_oauth.fake"
             # 3. Pass to your auth provider
             token_response = await self.providers.auth.oauth_callback_handler(
                 provider="github",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds fallback email generation for GitHub and Google OAuth in `users_router.py` when email is not provided.
> 
>   - **Behavior**:
>     - Adds fallback email generation in `google_callback()` and `github_callback()` in `users_router.py`.
>     - Uses format `{oauth_id}@google_oauth.fake` and `{github_id}@github_oauth.fake` if email is not provided by the OAuth provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for bd861d273cfe71d36753dde9429aa30b93e63da8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->