### PR TITLE
Revert commit 924d2a3

### DIFF
--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -431,6 +431,8 @@ class DocumentsRouter(BaseRouterV3):
                     ),
                 }
 
+                # TODO - Modify create_chunks so that we can add chunks to existing document
+
                 if run_with_orchestration:
                     # Run ingestion with orchestration
                     raw_message = (
@@ -535,21 +537,6 @@ class DocumentsRouter(BaseRouterV3):
             )
 
             if run_with_orchestration:
-                # TODO - Modify create_chunks so that we can add chunks to existing document
-                document_info = (
-                    self.services.ingestion._create_document_info_from_file(
-                        document_id,
-                        auth_user,
-                        file_name,
-                        workflow_input["metadata"],
-                        "v0",
-                        workflow_input["size_in_bytes"],
-                    )
-                )
-                await self.providers.database.documents_handler.upsert_documents_overview(
-                    document_info
-                )
-
                 raw_message: dict[str, str | None] = await self.providers.orchestration.run_workflow(  # type: ignore
                     "ingest-files",
                     {"request": workflow_input},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts commit 924d2a3 in `documents_router.py`, removing document info creation and overview update with orchestration in `create_document`.
> 
>   - **Revert Changes**:
>     - Reverts commit 924d2a3 in `documents_router.py`.
>     - Removes code block in `create_document` that created document info and updated document overview with orchestration.
>   - **Comments**:
>     - Adds a TODO comment about modifying `create_chunks` to add chunks to existing documents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 62f6f6f587c1114da4f7f0f04496e507be17e296. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->