### PR TITLE
Move Never from typing to typing_extensions

### DIFF
--- a/py/cli/command_group.py
+++ b/py/cli/command_group.py
@@ -3,7 +3,7 @@ import os
 import types
 from functools import wraps
 from pathlib import Path
-from typing import Any, Never
+from typing import Any
 
 import asyncclick as click
 from asyncclick import pass_context
@@ -11,6 +11,7 @@ from asyncclick.exceptions import Exit
 from rich import box
 from rich.console import Console
 from rich.table import Table
+from typing_extensions import Never
 
 from sdk import R2RAsyncClient
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `Never` import from `typing` to `typing_extensions` in `command_group.py`.
> 
>   - **Imports**:
>     - Move `Never` from `typing` to `typing_extensions` in `command_group.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for ee432dd43ef2b6f5b961b4cd916e942a8e734cba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->