### PR TITLE
force overwrite of graphrag prompts

### DIFF
--- a/py/core/database/prompts/graphrag_entity_description.yaml
+++ b/py/core/database/prompts/graphrag_entity_description.yaml
@@ -37,3 +37,4 @@ graphrag_entity_description:
     document_summary: str
     entity_info: str
     relationships_txt: str
+  overwrite_on_diff: true

--- a/py/core/database/prompts/graphrag_relationships_extraction_few_shot.yaml
+++ b/py/core/database/prompts/graphrag_relationships_extraction_few_shot.yaml
@@ -98,3 +98,4 @@ graphrag_relationships_extraction_few_shot:
     input: str
     entity_types: list[str]
     relation_types: list[str]
+  overwrite_on_diff: true

--- a/py/core/database/prompts_handler.py
+++ b/py/core/database/prompts_handler.py
@@ -301,8 +301,15 @@ class PostgresPromptsHandler(CacheablePromptHandler):
             logger.error(f"Failed to load prompts from database: {e}")
             raise
 
-    async def _load_prompts_from_yaml_directory(self) -> None:
-        """Load prompts from YAML files in the specified directory."""
+    async def _load_prompts_from_yaml_directory(
+        self, default_overwrite_on_diff: bool = False
+    ) -> None:
+        """
+        Load prompts from YAML files in the specified directory.
+
+        :param default_overwrite_on_diff: If a YAML prompt does not specify
+                                        'overwrite_on_diff', we use this default.
+        """
         if not self.prompt_directory.is_dir():
             logger.warning(
                 f"Prompt directory not found: {self.prompt_directory}"
@@ -313,7 +320,7 @@ class PostgresPromptsHandler(CacheablePromptHandler):
         for yaml_file in self.prompt_directory.glob("*.yaml"):
             logger.debug(f"Processing {yaml_file}")
             try:
-                with open(yaml_file, "r") as file:
+                with open(yaml_file, "r", encoding="utf-8") as file:
                     data = yaml.safe_load(file)
                     if not isinstance(data, dict):
                         raise ValueError(
@@ -321,23 +328,41 @@ class PostgresPromptsHandler(CacheablePromptHandler):
                         )
 
                     for name, prompt_data in data.items():
+                        # Attempt to parse the relevant prompt fields
+                        template = prompt_data.get("template")
+                        input_types = prompt_data.get("input_types", {})
+
+                        # Decide on per-prompt overwrite behavior (or fallback)
+                        overwrite_on_diff = prompt_data.get(
+                            "overwrite_on_diff", default_overwrite_on_diff
+                        )
+
+                        # Some logic to determine if we *should* modify
+                        # For instance, preserve only if it has never been updated
+                        # (i.e., created_at == updated_at).
                         should_modify = True
                         if name in self.prompts:
-                            # Only modify if the prompt hasn't been updated since creation
                             existing = self.prompts[name]
                             should_modify = (
                                 existing["created_at"]
                                 == existing["updated_at"]
                             )
 
-                        if should_modify:
-                            logger.info(f"Loading default prompt: {name}")
-                            await self.add_prompt(
-                                name=name,
-                                template=prompt_data["template"],
-                                input_types=prompt_data.get("input_types", {}),
-                                preserve_existing=(not should_modify),
-                            )
+                        # If should_modify is True, the default logic is
+                        #   preserve_existing = False,
+                        # so we can pass that in. Otherwise, preserve_existing=True
+                        # effectively means we skip the update.
+                        logger.info(
+                            f"Loading default prompt: {name} from {yaml_file}."
+                        )
+
+                        await self.add_prompt(
+                            name=name,
+                            template=template,
+                            input_types=input_types,
+                            preserve_existing=(not should_modify),
+                            overwrite_on_diff=overwrite_on_diff,
+                        )
             except Exception as e:
                 logger.error(f"Error loading {yaml_file}: {e}")
                 continue
@@ -502,12 +527,47 @@ class PostgresPromptsHandler(CacheablePromptHandler):
         template: str,
         input_types: dict[str, str],
         preserve_existing: bool = False,
+        overwrite_on_diff: bool = False,  # <-- new param
     ) -> None:
-        """Add or update a prompt."""
-        if preserve_existing and name in self.prompts:
+        """
+        Add or update a prompt.
+
+        If `preserve_existing` is True and prompt already exists, we skip updating.
+
+        If `overwrite_on_diff` is True and an existing prompt differs from what is provided,
+        we overwrite and log a warning. Otherwise, we skip if the prompt differs.
+        """
+        # Check if prompt is in-memory
+        existing_prompt = self.prompts.get(name)
+
+        # If preserving existing and it already exists, skip entirely
+        if preserve_existing and existing_prompt:
+            logger.debug(
+                f"Preserving existing prompt: {name}, skipping update."
+            )
             return
 
-        id = generate_default_prompt_id(name)
+        # If an existing prompt is found, check for diffs
+        if existing_prompt:
+            existing_template = existing_prompt["template"]
+            existing_input_types = existing_prompt["input_types"]
+
+            # If there's a difference in template or input_types, decide to overwrite or skip
+            if (
+                existing_template != template
+                or existing_input_types != input_types
+            ):
+                if overwrite_on_diff:
+                    logger.warning(
+                        f"Overwriting existing prompt '{name}' due to detected diff."
+                    )
+                else:
+                    logger.info(
+                        f"Prompt '{name}' differs from existing but overwrite_on_diff=False. Skipping update."
+                    )
+                    return
+
+        prompt_id = generate_default_prompt_id(name)
 
         # Ensure input_types is properly serialized
         input_types_json = (
@@ -516,6 +576,7 @@ class PostgresPromptsHandler(CacheablePromptHandler):
             else input_types
         )
 
+        # Upsert logic
         query = f"""
         INSERT INTO {self._get_table_name("prompts")} (id, name, template, input_types)
         VALUES ($1, $2, $3, $4)
@@ -527,7 +588,7 @@ class PostgresPromptsHandler(CacheablePromptHandler):
         """
 
         result = await self.connection_manager.fetchrow_query(
-            query, [id, name, template, input_types_json]
+            query, [prompt_id, name, template, input_types_json]
         )
 
         self.prompts[name] = {
@@ -542,10 +603,10 @@ class PostgresPromptsHandler(CacheablePromptHandler):
         self._template_cache.set(
             name,
             {
-                "id": id,
+                "id": prompt_id,
                 "template": template,
                 "input_types": input_types,
-            },  # Store as dict in cache
+            },
         )
 
         # Invalidate any cached formatted prompts

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "r2r"
 readme = "README.md"
-version = "3.3.27"
+version = "3.3.28"
 
 description = "SciPhi R2R"
 authors = ["Owen Colegrove <owen@sciphi.ai>"]

--- a/py/tests/unit/conftest.py
+++ b/py/tests/unit/conftest.py
@@ -14,6 +14,7 @@ from core.database.postgres import (
     PostgresDocumentsHandler,
     PostgresGraphsHandler,
     PostgresLimitsHandler,
+    PostgresPromptsHandler,
 )
 from core.database.users import (  # Make sure this import is correct
     PostgresUserHandler,
@@ -176,6 +177,27 @@ async def users_handler(db_provider, crypto_provider):
         f"TRUNCATE {handler._get_table_name('users_api_keys')} CASCADE;"
     )
 
+    return handler
+
+
+@pytest.fixture
+async def prompt_handler(db_provider):
+    """
+    Returns an instance of PostgresPromptsHandler, creating the necessary tables first.
+    """
+    # from core.database.postgres_prompts import PostgresPromptsHandler
+
+    project_name = db_provider.project_name
+    connection_manager = db_provider.connection_manager
+
+    handler = PostgresPromptsHandler(
+        project_name=project_name,
+        connection_manager=connection_manager,
+        # You can specify a local prompt directory if desired
+        prompt_directory=None,
+    )
+    # Create necessary tables and do initial prompt load
+    await handler.create_tables()
     return handler
 
 

--- a/py/tests/unit/test_prompts.py
+++ b/py/tests/unit/test_prompts.py
@@ -1,0 +1,195 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+# from core.database.postgres_prompts import PostgresPromptsHandler
+
+
+@pytest.mark.asyncio
+async def test_add_prompt_basic(prompt_handler):
+    """
+    Test basic addition of a new prompt.
+    """
+    prompt_name = f"test_prompt_{uuid.uuid4()}"
+    template = "Hello, {name}!"
+    input_types = {"name": "str"}
+
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=template,
+        input_types=input_types,
+    )
+
+    # Verify in-memory
+    assert prompt_name in prompt_handler.prompts
+    # Verify DB read is consistent
+    prompt_info = prompt_handler.prompts[prompt_name]
+    assert prompt_info["template"] == template
+    assert prompt_info["input_types"] == input_types
+
+    # Attempt retrieval using the get_prompt method (should exist)
+    db_data = await prompt_handler.get_prompt(prompt_name)
+    assert db_data["template"] == template
+    assert db_data["input_types"] == input_types
+
+
+@pytest.mark.asyncio
+async def test_add_prompt_preserve_existing(prompt_handler):
+    """
+    If preserve_existing is True, we skip overwriting even if we supply new data.
+    """
+    prompt_name = f"test_preserve_{uuid.uuid4()}"
+    template_original = "Original template"
+    input_types_original = {"param": "str"}
+
+    # Create original
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=template_original,
+        input_types=input_types_original,
+    )
+
+    # Attempt second add with new data but preserve_existing = True
+    template_new = "New template"
+    input_types_new = {"param": "int"}
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=template_new,
+        input_types=input_types_new,
+        preserve_existing=True,
+    )
+
+    # Expect no changes to the original prompt
+    existing = prompt_handler.prompts[prompt_name]
+    assert existing["template"] == template_original
+    assert existing["input_types"] == input_types_original
+
+
+@pytest.mark.asyncio
+async def test_add_prompt_overwrite_on_diff_false(prompt_handler, caplog):
+    """
+    If overwrite_on_diff=False but there is a diff, skip updating
+    and log an info message.
+    """
+    prompt_name = f"test_diff_false_{uuid.uuid4()}"
+    template_original = "Original template: {key}"
+    input_types_original = {"key": "str"}
+
+    # Create original
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=template_original,
+        input_types=input_types_original,
+    )
+
+    # Attempt second add with new data but overwrite_on_diff=False
+    new_template = "New template: {key}"
+    new_input_types = {"key": "int"}
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=new_template,
+        input_types=new_input_types,
+        overwrite_on_diff=False,
+    )
+
+    # Should be no changes
+    existing = prompt_handler.prompts[prompt_name]
+    assert existing["template"] == template_original
+    assert existing["input_types"] == input_types_original
+
+    # Check logs for the skipping message
+    assert any(
+        "Skipping update" in record.message for record in caplog.records
+    ), "Expected a skip update log message."
+
+
+@pytest.mark.asyncio
+async def test_add_prompt_overwrite_on_diff_true(prompt_handler, caplog):
+    """
+    If overwrite_on_diff=True and there's a diff, we overwrite existing prompt
+    and log a warning.
+    """
+    prompt_name = f"test_diff_true_{uuid.uuid4()}"
+    template_original = "Original template: {key}"
+    input_types_original = {"key": "str"}
+
+    # Create original
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=template_original,
+        input_types=input_types_original,
+    )
+
+    # Attempt second add with new data but overwrite_on_diff=True
+    new_template = "New template: {new_key}"
+    new_input_types = {"new_key": "int"}
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=new_template,
+        input_types=new_input_types,
+        overwrite_on_diff=True,
+    )
+
+    # Expect changes
+    existing = prompt_handler.prompts[prompt_name]
+    assert existing["template"] == new_template
+    assert existing["input_types"] == new_input_types
+
+    # Check logs for the overwriting warning
+    assert any(
+        "Overwriting existing prompt" in record.message
+        for record in caplog.records
+    ), "Expected an overwrite warning message."
+
+
+@pytest.mark.asyncio
+async def test_get_cached_prompt(prompt_handler):
+    """
+    Test that get_cached_prompt uses caching properly.
+    """
+    prompt_name = f"test_cached_{uuid.uuid4()}"
+    template = "Cached template: {key}"
+    input_types = {"key": "str"}
+
+    await prompt_handler.add_prompt(
+        name=prompt_name,
+        template=template,
+        input_types=input_types,
+    )
+
+    # First retrieval should set the cache
+    content_1 = await prompt_handler.get_cached_prompt(
+        prompt_name, {"key": "Bob"}
+    )
+    assert "Bob" in content_1
+
+    # Modify in DB behind the scenes (simulate a change not going through add_prompt)
+    # We'll do a direct DB update to illustrate caching effect
+    new_template = "Updated in DB: {key}"
+    query = f"""
+        UPDATE {prompt_handler._get_table_name("prompts")}
+        SET template=$1
+        WHERE name=$2
+    """
+    await prompt_handler.connection_manager.execute_query(
+        query, [new_template, prompt_name]
+    )
+
+    # Second retrieval should still reflect the old template if the cache is not bypassed
+    content_2 = await prompt_handler.get_cached_prompt(
+        prompt_name, {"key": "Alice"}
+    )
+    assert "Bob" not in content_2  # Just to ensure we see the difference
+    assert (
+        "Updated in DB" not in content_2
+    ), "Should not see updated text if cache is used."
+    assert "Cached template" in content_2
+
+    # Bypass cache
+    content_3 = await prompt_handler.get_cached_prompt(
+        prompt_name, {"key": "Alice"}, bypass_cache=True
+    )
+    assert (
+        "Updated in DB" in content_3
+    ), "Now we should see the new DB changes after bypassing cache."


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR adds functionality to overwrite prompts on differences, updates caching logic, and includes tests for these changes, with a version increment in `pyproject.toml`.
> 
>   - **Behavior**:
>     - Added `overwrite_on_diff: true` to `graphrag_entity_description.yaml` and `graphrag_relationships_extraction_few_shot.yaml` to force prompt overwriting on differences.
>     - Updated `get_cached_prompt()` in `prompts_handler.py` to include `bypass_template_cache` parameter for improved cache handling.
>     - Modified `add_prompt()` in `prompts_handler.py` to support `overwrite_on_diff` logic, allowing overwriting of prompts if differences are detected.
>   - **Caching**:
>     - Enhanced caching logic in `prompts_handler.py` to handle template cache with `bypass_template_cache`.
>     - Improved cache invalidation in `update_prompt()` and `add_prompt()`.
>   - **Testing**:
>     - Added unit tests in `test_prompts.py` to verify `add_prompt()` behavior with `preserve_existing` and `overwrite_on_diff` flags.
>     - Tested caching behavior in `get_cached_prompt()` to ensure proper cache usage and invalidation.
>   - **Misc**:
>     - Incremented version in `pyproject.toml` from `3.3.27` to `3.3.28`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 7104691c96f034daf8abc91c70ba4036fec352f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->