### PR TITLE
Add 'processing' status to document extraction

### DIFF
--- a/py/core/main/orchestration/hatchet/kg_workflow.py
+++ b/py/core/main/orchestration/hatchet/kg_workflow.py
@@ -267,6 +267,12 @@ def hatchet_kg_factory(
             document_id = input_data.get("document_id", None)
             collection_id = input_data.get("collection_id", None)
 
+            await self.kg_service.providers.database.documents_handler.set_workflow_status(
+                id=uuid.UUID(document_id),
+                status_type="extraction_status",
+                status=KGExtractionStatus.PROCESSING,
+            )
+
             if collection_id and not document_id:
                 document_ids = (
                     await self.kg_service.get_document_ids_for_create_graph(

--- a/py/core/main/orchestration/hatchet/kg_workflow.py
+++ b/py/core/main/orchestration/hatchet/kg_workflow.py
@@ -268,7 +268,7 @@ def hatchet_kg_factory(
             collection_id = input_data.get("collection_id", None)
 
             await self.kg_service.providers.database.documents_handler.set_workflow_status(
-                id=uuid.UUID(document_id),
+                id=document_id,
                 status_type="extraction_status",
                 status=KGExtractionStatus.PROCESSING,
             )

--- a/py/core/main/orchestration/simple/kg_workflow.py
+++ b/py/core/main/orchestration/simple/kg_workflow.py
@@ -4,7 +4,7 @@ import math
 import uuid
 
 from core import GenerationConfig, R2RException
-from core.base.abstractions import KGEnrichmentStatus
+from core.base.abstractions import KGEnrichmentStatus, KGExtractionStatus
 
 from ...services import GraphService
 
@@ -79,6 +79,13 @@ def simple_kg_factory(service: GraphService):
         )
 
         for _, document_id in enumerate(document_ids):
+
+            await service.providers.database.documents_handler.set_workflow_status(
+                id=document_id,
+                status_type="extraction_status",
+                status=KGExtractionStatus.PROCESSING,
+            )
+
             # Extract relationships from the document
             try:
                 extractions = []

--- a/py/core/main/services/graph_service.py
+++ b/py/core/main/services/graph_service.py
@@ -403,17 +403,12 @@ class GraphService(Service):
     async def get_document_ids_for_create_graph(
         self,
         collection_id: UUID,
-        force_kg_creation: bool = False,
         **kwargs,
     ):
         document_status_filter = [
             KGExtractionStatus.PENDING,
             KGExtractionStatus.FAILED,
         ]
-        if force_kg_creation:
-            document_status_filter += [
-                KGExtractionStatus.PROCESSING,
-            ]
 
         return await self.providers.database.documents_handler.get_document_ids_by_status(
             status_type="extraction_status",


### PR DESCRIPTION
Fixes #1810 

![Screenshot 2025-01-14 at 10 20 55 AM](https://github.com/user-attachments/assets/148a582a-0e5f-4576-82d1-9d403a94b444)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add 'processing' status to document extraction workflows and update status handling in `kg_workflow.py` and `graph_service.py`.
> 
>   - **Behavior**:
>     - Set document status to `KGExtractionStatus.PROCESSING` at the start of `kg_extraction()` in `kg_workflow.py` (both `hatchet` and `simple` versions).
>     - Removed `KGExtractionStatus.PROCESSING` from `document_status_filter` in `get_document_ids_for_create_graph()` in `graph_service.py`.
>   - **Imports**:
>     - Import `KGExtractionStatus` in `simple/kg_workflow.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 6103180c0165a39cfe91ae3d7a033ac14c72b2e5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->