### PR TITLE
Admin only for logs websocket

### DIFF
--- a/py/core/configs/r2r_azure.toml
+++ b/py/core/configs/r2r_azure.toml
@@ -21,7 +21,7 @@ batch_size = 256
 
 [embedding]
 provider = "litellm"
-base_model = "openai/text-embedding-3-small"
+base_model = "azure/text-embedding-3-small"
 base_dimension = 512
 
 [file]

--- a/py/core/main/api/v3/logs_router.py
+++ b/py/core/main/api/v3/logs_router.py
@@ -68,7 +68,14 @@ class LogsRouter(BaseRouterV3):
             "/logs/stream",
             dependencies=[Depends(self.websocket_rate_limit_dependency)],
         )
-        async def stream_logs(websocket: WebSocket):
+        async def stream_logs(
+            websocket: WebSocket,
+            auth_user=Depends(
+                self.providers.auth.websocket_auth_wrapper(superuser_only=True)
+            ),
+        ):
+            if not auth_user:
+                return
             await websocket.accept()
             try:
                 # Send the entire file content upon initial connection

--- a/py/r2r/compose.full.yaml
+++ b/py/r2r/compose.full.yaml
@@ -281,8 +281,7 @@ services:
       retries: 5
 
   r2r:
-    # image: ${R2R_IMAGE:-ragtoriches/prod:latest}
-    image: r2r/test
+    image: ${R2R_IMAGE:-ragtoriches/prod:latest}
     build:
       context: .
       args:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added WebSocket authentication for superusers in `auth.py` and updated `r2r` service image in Docker Compose.
> 
>   - **WebSocket Authentication**:
>     - Added `websocket_auth_wrapper` in `auth.py` to restrict WebSocket access to superusers.
>     - Applied `websocket_auth_wrapper` to `stream_logs` in `logs_router.py`.
>   - **Configuration Changes**:
>     - Updated `base_model` in `r2r_azure.toml` from `openai/text-embedding-3-small` to `azure/text-embedding-3-small`.
>   - **Docker Compose**:
>     - Changed `r2r` service image in `compose.full.yaml` from `r2r/test` to `${R2R_IMAGE:-ragtoriches/prod:latest}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 4d3ed76ead2927aba2bed10019ab43181e5b2737. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->