### PR TITLE
Allow setting dashboard image in Compose

### DIFF
--- a/py/r2r/compose.full.swarm.yaml
+++ b/py/r2r/compose.full.swarm.yaml
@@ -398,10 +398,8 @@ services:
         parallelism: 1
         delay: 30s
 
-
-
   r2r-dashboard:
-    image: dashboard/test
+    image: ${R2R_DASHBOARD_IMAGE:-emrgntcmplxty/r2r-dashboard:latest}
     environment:
       - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
       - NEXT_PUBLIC_HATCHET_DASHBOARD_URL=${HATCHET_DASHBOARD_URL:-http://localhost:${R2R_HATCHET_DASHBOARD_PORT:-7274}}

--- a/py/r2r/compose.full.yaml
+++ b/py/r2r/compose.full.yaml
@@ -407,7 +407,7 @@ services:
         condition: service_healthy
 
   r2r-dashboard:
-    image: emrgntcmplxty/r2r-dashboard:latest
+    image: ${R2R_DASHBOARD_IMAGE:-emrgntcmplxty/r2r-dashboard:latest}
     environment:
       - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
       - NEXT_PUBLIC_HATCHET_DASHBOARD_URL=${HATCHET_DASHBOARD_URL:-http://localhost:${R2R_HATCHET_DASHBOARD_PORT:-7274}}

--- a/py/r2r/compose.yaml
+++ b/py/r2r/compose.yaml
@@ -145,7 +145,7 @@ services:
       - host.docker.internal:host-gateway
 
   r2r-dashboard:
-    image: emrgntcmplxty/r2r-dashboard:latest
+    image: ${R2R_DASHBOARD_IMAGE:-emrgntcmplxty/r2r-dashboard:latest}
     environment:
       - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
     networks:


### PR DESCRIPTION
See #1885
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allows setting `r2r-dashboard` image via `R2R_DASHBOARD_IMAGE` environment variable in Docker Compose files, defaulting to `emrgntcmplxty/r2r-dashboard:latest`.
> 
>   - **Behavior**:
>     - Allows setting `r2r-dashboard` image via `R2R_DASHBOARD_IMAGE` environment variable in `compose.full.swarm.yaml`, `compose.full.yaml`, and `compose.yaml`.
>     - Defaults to `emrgntcmplxty/r2r-dashboard:latest` if `R2R_DASHBOARD_IMAGE` is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 44e5689f027af73696add8f077773cdc1e073f08. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->