### PR TITLE
Retain order for hi-res ingestion, fix AttributeError

### DIFF
--- a/py/core/parsers/media/pdf_parser.py
+++ b/py/core/parsers/media/pdf_parser.py
@@ -140,7 +140,7 @@ class VLMPDFParser(AsyncParser[str | bytes]):
             raise
 
     async def ingest(
-        self, data: str | bytes, maintain_order: bool = False, **kwargs
+        self, data: str | bytes, maintain_order: bool = True, **kwargs
     ) -> AsyncGenerator[dict[str, str], None]:
         """
         Ingest PDF data and yield descriptions for each page using vision model.

--- a/py/shared/utils/base_utils.py
+++ b/py/shared/utils/base_utils.py
@@ -120,9 +120,9 @@ def format_search_results_for_llm(results: AggregateSearchResult) -> str:
                 formatted_results.append(f"Summary: {summary}")
 
             # Then each chunk inside:
-            for i, ch in enumerate(chunks, start=1):
-                chunk_text = ch.get("text", "")
-                formatted_results.append(f"Chunk {i}: {chunk_text}")
+            formatted_results.extend(
+                f"Chunk {i}: {ch}" for i, ch in enumerate(chunks, start=1)
+            )
 
             source_counter += 1
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `maintain_order` to `True` in `ingest()` in `pdf_parser.py` and optimize `format_search_results_for_llm()` in `base_utils.py`.
> 
>   - **Behavior**:
>     - Change default `maintain_order` to `True` in `ingest()` in `pdf_parser.py` to ensure results are yielded in page order by default.
>   - **Optimization**:
>     - Use `extend` with a generator expression in `format_search_results_for_llm()` in `base_utils.py` to improve performance when formatting chunks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 99c3697ec1d24fed2c9793013048b94b1947dff3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->