### PR TITLE
Add useExtendedPrompt agent param to JS SDK

### DIFF
--- a/js/sdk/package-lock.json
+++ b/js/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/js/sdk/src/v3/clients/retrieval.ts
+++ b/js/sdk/src/v3/clients/retrieval.ts
@@ -148,36 +148,39 @@ export class RetrievalClient {
    * find and synthesize information, providing detailed, factual responses
    * with proper attribution to source documents.
    * @param message Current message to process
-   * @param searchSettings Settings for the search
    * @param ragGenerationConfig Configuration for RAG generation
+   * @param searchMode Search mode to use, either "basic", "advanced", or "custom"
+   * @param searchSettings Settings for the search
    * @param taskPromptOverride Optional custom prompt to override default
    * @param includeTitleIfAvailable Include document titles in responses when available
    * @param conversationId ID of the conversation
-   * @param maxToolContextLength Maximum context length for tool replies
    * @param tools List of tool configurations
+   * @param maxToolContextLength Maximum context length for tool replies
+   * @param useExtendedPrompt Use extended prompt for generation
    * @returns
    */
   async agent(options: {
     message: Message;
-    searchMode?: "advanced" | "basic" | "custom";
-    searchSettings?: SearchSettings | Record<string, any>;
     ragGenerationConfig?: GenerationConfig | Record<string, any>;
+    searchMode?: "basic" | "advanced" | "custom";
+    searchSettings?: SearchSettings | Record<string, any>;
     taskPromptOverride?: string;
     includeTitleIfAvailable?: boolean;
     conversationId?: string;
-    maxToolContextLength?: number;
     tools?: Array<Record<string, any>>;
+    maxToolContextLength?: number;
+    useExtendedPrompt?: boolean;
   }): Promise<any | AsyncGenerator<string, void, unknown>> {
     const data: Record<string, any> = {
       message: options.message,
       ...(options.searchMode && {
         search_mode: options.searchMode,
       }),
-      ...(options.searchSettings && {
-        search_settings: ensureSnakeCase(options.searchSettings),
-      }),
       ...(options.ragGenerationConfig && {
         rag_generation_config: ensureSnakeCase(options.ragGenerationConfig),
+      }),
+      ...(options.searchSettings && {
+        search_settings: ensureSnakeCase(options.searchSettings),
       }),
       ...(options.taskPromptOverride && {
         task_prompt_override: options.taskPromptOverride,
@@ -188,11 +191,14 @@ export class RetrievalClient {
       ...(options.conversationId && {
         conversation_id: options.conversationId,
       }),
+      ...(options.tools && {
+        tools: options.tools,
+      }),
       ...(options.maxToolContextLength && {
         max_tool_context_length: options.maxToolContextLength,
       }),
-      ...(options.tools && {
-        tools: options.tools,
+      ...(options.useExtendedPrompt && {
+        use_extended_prompt: options.useExtendedPrompt,
       }),
     };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `useExtendedPrompt` parameter to `agent()` in `retrieval.ts` and updates version to `0.4.20`.
> 
>   - **Behavior**:
>     - Adds `useExtendedPrompt` parameter to `agent()` in `retrieval.ts` for extended prompt usage.
>   - **Versioning**:
>     - Updates version in `package.json` from `0.4.19` to `0.4.20`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for bc18d4c734a9aa6fdbbf4e10e9ef965edf2e5b35. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->