### PR TITLE
Auto-release staging

### DIFF
--- a/.github/workflows/build-r2r-docker.yml
+++ b/.github/workflows/build-r2r-docker.yml
@@ -3,14 +3,16 @@ name: Build and Publish R2R Docker Image
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch to simulate (e.g., dev, dev-minor, main)'
-        required: false
-        default: 'main'
+      environment:
+        description: 'Environment to deploy to (prod/staging)'
+        required: true
+        type: choice
+        options:
+          - prod
+          - staging
   push:
     branches:
-      - dev
-      - dev-minor
+      - main
 
 env:
   REGISTRY_BASE: ragtoriches
@@ -24,8 +26,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -41,20 +41,16 @@ jobs:
           VERSION=$(python -c "import toml; print(toml.load('py/pyproject.toml')['tool']['poetry']['version'])")
           RELEASE_VERSION=$VERSION
 
-          # Use input branch if this is a workflow dispatch
+          # Set registry based on trigger type
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            BRANCH="${{ github.event.inputs.branch }}"
+            if [ "${{ github.event.inputs.environment }}" == "prod" ]; then
+              REGISTRY_IMAGE="${{ env.REGISTRY_BASE }}/prod"
+            else
+              REGISTRY_IMAGE="${{ env.REGISTRY_BASE }}/staging"
+            fi
           else
-            BRANCH="${{ github.ref }}"
-          fi
-
-          # Determine the registry based on the branch
-          if [ "$BRANCH" == "refs/heads/dev" ] || [ "$BRANCH" == "dev" ]; then
-            REGISTRY_IMAGE="${{ env.REGISTRY_BASE }}/dev"
-          elif [ "$BRANCH" == "refs/heads/dev-minor" ] || [ "$BRANCH" == "dev-minor" ]; then
-            REGISTRY_IMAGE="${{ env.REGISTRY_BASE }}/dev-minor"
-          else
-            REGISTRY_IMAGE="${{ env.REGISTRY_BASE }}/prod"
+            # Push to main always goes to staging
+            REGISTRY_IMAGE="${{ env.REGISTRY_BASE }}/staging"
           fi
 
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
@@ -74,8 +70,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.BRANCH }}
 
       - name: Echo Commit Hash
         run: |
@@ -129,3 +123,18 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ needs.prepare.outputs.REGISTRY_IMAGE }}:${{ needs.prepare.outputs.release_version }}
           docker buildx imagetools inspect ${{ needs.prepare.outputs.REGISTRY_IMAGE }}:latest
+
+  deploy-staging:
+    needs: [create-manifest, prepare]
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Staging
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USERNAME }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          script: |
+            docker service update --image ${{ needs.prepare.outputs.REGISTRY_IMAGE }}:${{ needs.prepare.outputs.RELEASE_VERSION }} r2r-blue_r2r


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions workflow to deploy Docker images based on environment input and add staging deployment job.
> 
>   - **Behavior**:
>     - Modify `build-r2r-docker.yml` to deploy based on environment (`prod`/`staging`) instead of branch.
>     - Add `deploy-staging` job to deploy to staging on `push` or `workflow_dispatch` with `staging`.
>   - **Inputs**:
>     - Change input from `branch` to `environment` with options `prod` and `staging`.
>   - **Registry Logic**:
>     - Set `REGISTRY_IMAGE` based on `environment` input or `main` branch push.
>     - Remove branch-specific logic for `dev` and `dev-minor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 634802e5006c41f22ebeee966ade109b38c71d84. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->