### PR TITLE
CI/CD success regardless of staging deploy

### DIFF
--- a/.github/workflows/build-r2r-docker.yml
+++ b/.github/workflows/build-r2r-docker.yml
@@ -139,3 +139,11 @@ jobs:
           script: |
             docker pull ${{ needs.prepare.outputs.REGISTRY_IMAGE }}:${{ needs.prepare.outputs.RELEASE_VERSION }}
             docker service update --image ${{ needs.prepare.outputs.REGISTRY_IMAGE }}:${{ needs.prepare.outputs.RELEASE_VERSION }} r2r-blue_r2r
+
+  success-check:
+    needs: [create-manifest]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Always succeed
+        run: exit 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `success-check` job in CI/CD workflow to ensure pipeline success regardless of staging deployment outcome.
> 
>   - **CI/CD Workflow**:
>     - Adds `success-check` job in `build-r2r-docker.yml` to ensure pipeline success regardless of staging deployment.
>     - `success-check` job depends on `create-manifest` and always exits with success (`exit 0`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for f6c4dd516af3f70667fead3560f889aa3243bf22. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->