### PR TITLE
Add support for directly starting R2R server

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -213,7 +213,7 @@ module = "yaml"
 ignore_missing_imports = true
 
 [tool.poetry.scripts]
-r2r = "cli.main:main"
+r2r-serve = "r2r.serve:run_server"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -214,6 +214,7 @@ ignore_missing_imports = true
 
 [tool.poetry.scripts]
 r2r-serve = "r2r.serve:run_server"
+r2r = "cli.main:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/py/r2r/__init__.py
+++ b/py/r2r/__init__.py
@@ -1,11 +1,8 @@
-import logging
 from importlib import metadata
 
 from sdk.async_client import R2RAsyncClient
 from sdk.models import R2RException
 from sdk.sync_client import R2RClient
-
-logger = logging.getLogger()
 
 __version__ = metadata.version("r2r")
 
@@ -16,17 +13,6 @@ __all__ = [
     "R2RException",
 ]
 
-try:
-    import core
-    from core import *
 
-    __all__ += core.__all__
-except ImportError as e:
-    logger.warning(
-        f"Warning: encountered ImportError: `{e}`, likely due to core dependencies not being installed. This will not affect your use of SDK, but use of `r2r serve` may not be available."
-    )
-
-
-# Add a function to get the version
 def get_version():
     return __version__

--- a/py/r2r/serve.py
+++ b/py/r2r/serve.py
@@ -1,0 +1,50 @@
+import asyncio
+import os
+from typing import Optional
+
+from core import R2RApp, R2RBuilder, R2RConfig
+from core.utils.logging_config import configure_logging
+
+
+async def create_app(
+    config_name: Optional[str] = None,
+    config_path: Optional[str] = None,
+    full: bool = False,
+) -> "R2RApp":
+    config_name = config_name or os.getenv("R2R_CONFIG_NAME")
+    config_path = config_path or os.getenv("R2R_CONFIG_PATH")
+
+    if config_path and config_name:
+        raise ValueError("Cannot specify both config_path and config_name")
+    if not config_path and not config_name:
+        config_name = "full" if full else "default"
+
+    r2r_instance = await R2RBuilder(
+        config=R2RConfig.load(config_name, config_path)
+    ).build()
+
+    await r2r_instance.orchestration_provider.start_worker()
+    return r2r_instance
+
+
+def run_server(
+    host: str = "0.0.0.0",
+    port: int = 7272,
+    config_name: Optional[str] = None,
+    config_path: Optional[str] = None,
+    full: bool = False,
+):
+    configure_logging()
+
+    port = int(os.getenv("R2R_PORT", port))
+    host = os.getenv("R2R_HOST", host)
+
+    async def start():
+        app = await create_app(config_name, config_path, full)
+        await app.serve(host, port)
+
+    asyncio.run(start())
+
+
+if __name__ == "__main__":
+    run_server()

--- a/py/sdk/asnyc_methods/chunks.py
+++ b/py/sdk/asnyc_methods/chunks.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedChunkResponse,
     WrappedChunksResponse,

--- a/py/sdk/asnyc_methods/collections.py
+++ b/py/sdk/asnyc_methods/collections.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedCollectionResponse,
     WrappedCollectionsResponse,

--- a/py/sdk/asnyc_methods/conversations.py
+++ b/py/sdk/asnyc_methods/conversations.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import aiofiles
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedConversationMessagesResponse,
     WrappedConversationResponse,

--- a/py/sdk/asnyc_methods/documents.py
+++ b/py/sdk/asnyc_methods/documents.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 import aiofiles
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedChunksResponse,
     WrappedCollectionsResponse,

--- a/py/sdk/asnyc_methods/graphs.py
+++ b/py/sdk/asnyc_methods/graphs.py
@@ -2,7 +2,7 @@ from builtins import list as _list
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedCommunitiesResponse,
     WrappedCommunityResponse,

--- a/py/sdk/asnyc_methods/indices.py
+++ b/py/sdk/asnyc_methods/indices.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedGenericMessageResponse,
     WrappedVectorIndexResponse,
     WrappedVectorIndicesResponse,

--- a/py/sdk/asnyc_methods/prompts.py
+++ b/py/sdk/asnyc_methods/prompts.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedGenericMessageResponse,
     WrappedPromptResponse,

--- a/py/sdk/asnyc_methods/retrieval.py
+++ b/py/sdk/asnyc_methods/retrieval.py
@@ -1,6 +1,6 @@
 from typing import Any, AsyncGenerator, Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedAgentResponse,
     WrappedRAGResponse,
     WrappedSearchResponse,

--- a/py/sdk/asnyc_methods/system.py
+++ b/py/sdk/asnyc_methods/system.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedGenericMessageResponse,
     WrappedLogsResponse,
     WrappedServerStatsResponse,

--- a/py/sdk/asnyc_methods/users.py
+++ b/py/sdk/asnyc_methods/users.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedAPIKeyResponse,
     WrappedAPIKeysResponse,
     WrappedBooleanResponse,

--- a/py/sdk/sync_methods/chunks.py
+++ b/py/sdk/sync_methods/chunks.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedChunkResponse,
     WrappedChunksResponse,

--- a/py/sdk/sync_methods/collections.py
+++ b/py/sdk/sync_methods/collections.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedCollectionResponse,
     WrappedCollectionsResponse,

--- a/py/sdk/sync_methods/conversations.py
+++ b/py/sdk/sync_methods/conversations.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedConversationMessagesResponse,
     WrappedConversationResponse,

--- a/py/sdk/sync_methods/documents.py
+++ b/py/sdk/sync_methods/documents.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedChunksResponse,
     WrappedCollectionsResponse,

--- a/py/sdk/sync_methods/graphs.py
+++ b/py/sdk/sync_methods/graphs.py
@@ -2,7 +2,7 @@ from builtins import list as _list
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedCommunitiesResponse,
     WrappedCommunityResponse,

--- a/py/sdk/sync_methods/indices.py
+++ b/py/sdk/sync_methods/indices.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedGenericMessageResponse,
     WrappedVectorIndexResponse,
     WrappedVectorIndicesResponse,

--- a/py/sdk/sync_methods/prompts.py
+++ b/py/sdk/sync_methods/prompts.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedBooleanResponse,
     WrappedGenericMessageResponse,
     WrappedPromptResponse,

--- a/py/sdk/sync_methods/retrieval.py
+++ b/py/sdk/sync_methods/retrieval.py
@@ -1,6 +1,6 @@
 from typing import Any, AsyncGenerator, Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedAgentResponse,
     WrappedRAGResponse,
     WrappedSearchResponse,

--- a/py/sdk/sync_methods/system.py
+++ b/py/sdk/sync_methods/system.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedGenericMessageResponse,
     WrappedLogsResponse,
     WrappedServerStatsResponse,

--- a/py/sdk/sync_methods/users.py
+++ b/py/sdk/sync_methods/users.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 from uuid import UUID
 
-from core.base.api.models import (
+from shared.api.models import (
     WrappedAPIKeyResponse,
     WrappedAPIKeysResponse,
     WrappedBooleanResponse,

--- a/py/shared/api/models/__init__.py
+++ b/py/shared/api/models/__init__.py
@@ -12,14 +12,22 @@ from shared.api.models.base import (
 )
 from shared.api.models.graph.responses import (
     GraphResponse,
+    WrappedCommunitiesResponse,
+    WrappedCommunityResponse,
+    WrappedEntitiesResponse,
+    WrappedEntityResponse,
     WrappedGraphResponse,
     WrappedGraphsResponse,
+    WrappedRelationshipResponse,
+    WrappedRelationshipsResponse,
 )
 from shared.api.models.ingestion.responses import (
     IngestionResponse,
     WrappedIngestionResponse,
     WrappedMetadataUpdateResponse,
     WrappedUpdateResponse,
+    WrappedVectorIndexResponse,
+    WrappedVectorIndicesResponse,
 )
 from shared.api.models.management.responses import (
     AnalyticsResponse,
@@ -45,6 +53,7 @@ from shared.api.models.management.responses import (
     WrappedLimitsResponse,
     WrappedLoginResponse,
     WrappedLogsResponse,
+    WrappedMessageResponse,
     WrappedPromptResponse,
     WrappedPromptsResponse,
     WrappedServerStatsResponse,
@@ -73,11 +82,18 @@ __all__ = [
     "IngestionResponse",
     "WrappedIngestionResponse",
     "WrappedUpdateResponse",
+    "WrappedVectorIndexResponse",
+    "WrappedVectorIndicesResponse",
     "WrappedMetadataUpdateResponse",
-    # TODO: Need to review anything above this
     "GraphResponse",
     "WrappedGraphResponse",
     "WrappedGraphsResponse",
+    "WrappedEntityResponse",
+    "WrappedEntitiesResponse",
+    "WrappedRelationshipResponse",
+    "WrappedRelationshipsResponse",
+    "WrappedCommunityResponse",
+    "WrappedCommunitiesResponse",
     # Management Responses
     "PromptResponse",
     "ServerStats",
@@ -114,6 +130,7 @@ __all__ = [
     "WrappedAPIKeysResponse",
     "WrappedLoginResponse",
     "WrappedUsersResponse",
+    "WrappedMessageResponse",
     # Base Responses
     "PaginatedR2RResult",
     "R2RResults",

--- a/py/tests/integration/conftest.py
+++ b/py/tests/integration/conftest.py
@@ -1,7 +1,5 @@
-# tests/conftest.py
-import asyncio
 import uuid
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator
 
 import pytest
 
@@ -61,7 +59,7 @@ import uuid
 
 import pytest
 
-from r2r import Message, R2RClient, R2RException, SearchMode
+from r2r import R2RClient, R2RException
 
 
 @pytest.fixture(scope="session")

--- a/py/tests/integration/test_retrieval.py
+++ b/py/tests/integration/test_retrieval.py
@@ -2,7 +2,8 @@ import uuid
 
 import pytest
 
-from r2r import Message, R2RClient, R2RException, SearchMode
+from core.base import Message, SearchMode
+from r2r import R2RClient, R2RException
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Part of effort to deprecate CLI. Now, users should run either:
`python -m r2r.serve`
or 
`r2r-serve`

Also cleans up an annoying import warning that was thrown anytime the SDK was called and core dependencies were not installed. Now, such an error is caught when trying to serve only.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for starting R2R server directly and improve import error handling.
> 
>   - **Behavior**:
>     - Introduces `r2r-serve` script in `pyproject.toml` to start the R2R server directly.
>     - Users can now start the server using `python -m r2r.serve` or `r2r-serve`.
>     - Import error for core dependencies is now caught in `r2r/serve.py` when trying to serve, instead of during SDK usage.
>   - **Code Structure**:
>     - Removes import and logging of `core` in `r2r/__init__.py`.
>     - Adds `serve.py` with `run_server()` function to handle server startup.
>   - **Imports**:
>     - Changes import paths from `core.base.api.models` to `shared.api.models` in multiple `sdk/asnyc_methods` and `sdk/sync_methods` files.
>   - **Testing**:
>     - Updates `conftest.py` and `test_retrieval.py` to align with new server start method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for bb9e15823e94ba87a9eb1857f57cbc1ca1d64520. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->