### PR TITLE
Fix compose commands

### DIFF
--- a/compose.full.yaml
+++ b/compose.full.yaml
@@ -291,7 +291,7 @@ services:
 
       # R2R
       - R2R_LOG_LEVEL=${R2R_LOG_LEVEL:-INFO}
-      - R2R_CONFIG_NAME=${R2R_CONFIG_NAME:-full}
+      - R2R_CONFIG_NAME=${R2R_CONFIG_NAME:-}
       - R2R_CONFIG_PATH=${R2R_CONFIG_PATH:-}
       - R2R_PROJECT_NAME=${R2R_PROJECT_NAME:-r2r_default}
       - R2R_SECRET_KEY=${R2R_SECRET_KEY:-}

--- a/py/README.md
+++ b/py/README.md
@@ -64,7 +64,11 @@ python -m r2r.serve
 
 # Alternatively, run R2R in `full` mode
 # git clone git@github.com:SciPhi-AI/R2R.git . && cd R2R
-# COMPOSE_PROFILES=postgres docker compose -f compose.full.yaml down
+# export OPENAI_API_KEY=sk-...
+# export R2R_CONFIG_NAME=full
+
+# docker compose -f compose.full.yaml --profile postgres up -d
+# `--profile postgres` can be omitted when using external Postgres
 
 # Refer to docs for local LLM setup - https://r2r-docs.sciphi.ai/self-hosting/local-rag
 ```

--- a/py/sdk/async_client.py
+++ b/py/sdk/async_client.py
@@ -112,7 +112,6 @@ class R2RAsyncClient(BaseClient):
                 message = response.text
             except Exception as e:
                 message = str(e)
-                print(e)
 
             raise R2RException(
                 status_code=response.status_code, message=message

--- a/py/sdk/sync_client.py
+++ b/py/sdk/sync_client.py
@@ -109,7 +109,6 @@ class R2RClient(BaseClient):
                 message = response.text
             except Exception as e:
                 message = str(e)
-                print(e)
 
             raise R2RException(
                 status_code=response.status_code, message=message


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix compose commands by removing default `R2R_CONFIG_NAME` and clean up code in client files.
> 
>   - **Compose Configuration**:
>     - Remove default value for `R2R_CONFIG_NAME` in `compose.full.yaml`.
>   - **Documentation**:
>     - Update `py/README.md` to include instructions for setting `OPENAI_API_KEY` and `R2R_CONFIG_NAME` before running Docker compose.
>   - **Code Cleanup**:
>     - Remove `print(e)` from exception handling in `_handle_response` in `async_client.py` and `sync_client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for e6bd7e1c535a031a3472457e509baf07cf1982a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->