### PR TITLE
add citation parsers

### DIFF
--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/js/sdk/src/v3/clients/retrieval.ts
+++ b/js/sdk/src/v3/clients/retrieval.ts
@@ -299,7 +299,7 @@ export class RetrievalClient {
    * @param options.tools List of tool configurations
    * @returns
    */
-  async reasoning_agent(options: {
+  async reasoningAgent(options: {
     message?: Message;
     ragGenerationConfig?: GenerationConfig | Record<string, any>;
     conversationId?: string;

--- a/py/core/base/__init__.py
+++ b/py/core/base/__init__.py
@@ -120,4 +120,7 @@ __all__ = [
     "generate_default_user_collection_id",
     "generate_user_id",
     "increment_version",
+    "my_map_citations_to_sources",
+    "my_extract_citations",
+    "reassign_citations_in_order",
 ]

--- a/py/core/base/api/models/__init__.py
+++ b/py/core/base/api/models/__init__.py
@@ -72,6 +72,7 @@ from shared.api.models.management.responses import (  # Document Responses; Prom
 )
 from shared.api.models.retrieval.responses import (
     AgentResponse,
+    Citation,
     RAGResponse,
     WrappedAgentResponse,
     WrappedCompletionResponse,
@@ -158,6 +159,7 @@ __all__ = [
     "WrappedGenericMessageResponse",
     # TODO: This needs to be cleaned up
     "RAGResponse",
+    "Citation",
     "AgentResponse",
     "WrappedDocumentSearchResponse",
     "WrappedSearchResponse",

--- a/py/core/base/providers/llm.py
+++ b/py/core/base/providers/llm.py
@@ -149,8 +149,6 @@ class CompletionProvider(Provider):
             "generation_config": generation_config,
             "kwargs": kwargs,
         }
-        if modalities := kwargs.get("modalities"):
-            task["modalities"] = modalities
         response = await self._execute_with_backoff_async(task)
         return LLMChatCompletion(**response.dict())
 

--- a/py/core/base/utils/__init__.py
+++ b/py/core/base/utils/__init__.py
@@ -15,6 +15,9 @@ from shared.utils import (
     generate_id,
     generate_user_id,
     increment_version,
+    my_extract_citations,
+    my_map_citations_to_sources,
+    reassign_citations_in_order,
     to_async_generator,
     validate_uuid,
 )
@@ -36,6 +39,9 @@ __all__ = [
     "TextSplitter",
     "validate_uuid",
     "deep_update",
+    "my_map_citations_to_sources",
+    "my_extract_citations",
+    "reassign_citations_in_order",
     "_decorate_vector_type",
     "_get_vector_column_str",
 ]

--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -546,21 +546,6 @@ class RetrievalService(Service):
             )
             return rag_response
 
-            # llm_text_response = response.choices[0].message.content # Add in completion metadata here
-
-            # # # 6) Optionally do citation extraction here if you want
-            # citations = my_extract_citations(llm_text_response)
-            # mapped_citations = my_map_citations_to_sources(citations, aggregated_results)
-
-            # # 7) Build final RAGResponse
-            # rag_response = RAGResponse(
-            #     generated_answer=llm_text_response,
-            #     search_results=aggregated_results,
-            #     citations=mapped_citations,
-            #     metadata={} # response.remainder
-            # )
-            # return rag_response
-
         except Exception as e:
             logger.error(f"Error in RAG: {e}")
             if "NoneType" in str(e):

--- a/py/shared/api/models/__init__.py
+++ b/py/shared/api/models/__init__.py
@@ -64,6 +64,7 @@ from shared.api.models.management.responses import (
 from shared.api.models.retrieval.responses import (
     AgentResponse,
     AggregateSearchResult,
+    Citation,
     RAGResponse,
     WrappedAgentResponse,
     WrappedDocumentSearchResponse,
@@ -141,6 +142,7 @@ __all__ = [
     # TODO: Clean up the following responses
     # Retrieval Responses
     "RAGResponse",
+    "Citation",
     "WrappedRAGResponse",
     "AgentResponse",
     "AggregateSearchResult",

--- a/py/shared/api/models/retrieval/responses.py
+++ b/py/shared/api/models/retrieval/responses.py
@@ -1,13 +1,11 @@
-from typing import Any, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
 from shared.abstractions import (
     AggregateSearchResult,
     ChunkSearchResult,
-    GraphSearchResult,
     Message,
-    WebSearchResult,
 )
 from shared.abstractions.llm import LLMChatCompletion
 from shared.api.models.base import R2RResults
@@ -15,13 +13,19 @@ from shared.api.models.management.responses import DocumentResponse
 
 
 class RAGResponse(BaseModel):
-    completion: Any = Field(
-        ...,
-        description="The generated completion from the RAG process",
+    generated_answer: str = Field(
+        ..., description="The generated completion from the RAG process"
     )
     search_results: AggregateSearchResult = Field(
-        ...,
-        description="The search results used for the RAG process",
+        ..., description="The search results used for the RAG process"
+    )
+    citations: Optional[list[dict]] = Field(
+        None,
+        description="Structured citation metadata, if you do citation extraction.",
+    )
+    metadata: dict = Field(
+        default_factory=dict,
+        description="Additional data returned by the LLM provider",
     )
 
     class Config:
@@ -33,7 +37,6 @@ class RAGResponse(BaseModel):
                         {
                             "finish_reason": "stop",
                             "index": 0,
-                            "logprobs": None,
                             "message": {
                                 "content": "Paris is the capital of France.",
                                 "role": "assistant",
@@ -42,16 +45,23 @@ class RAGResponse(BaseModel):
                     ],
                 },
                 "search_results": {
-                    "chunk_search_results": [
-                        ChunkSearchResult.Config.json_schema_extra,
-                    ],
-                    "graph_search_results": [
-                        GraphSearchResult.Config.json_schema_extra,
-                    ],
-                    "web_search_results": [
-                        WebSearchResult.Config.json_schema_extra,
-                    ],
+                    "chunk_search_results": [],
+                    "graph_search_results": [],
+                    "web_search_results": [],
                 },
+                "citations": {
+                    "citations": [
+                        {
+                            "index": 1,
+                            "startIndex": 25,
+                            "endIndex": 28,
+                            "uri": "https://example.com/doc1",
+                            "title": "example_document_1.pdf",
+                            "license": "CC-BY-4.0",
+                        }
+                    ]
+                },
+                "metadata": {},
             }
         }
 

--- a/py/shared/utils/__init__.py
+++ b/py/shared/utils/__init__.py
@@ -13,6 +13,9 @@ from .base_utils import (
     generate_id,
     generate_user_id,
     increment_version,
+    my_extract_citations,
+    my_map_citations_to_sources,
+    reassign_citations_in_order,
     to_async_generator,
     validate_uuid,
 )
@@ -29,6 +32,9 @@ __all__ = [
     "generate_user_id",
     "generate_default_prompt_id",
     "generate_entity_document_id",
+    "my_map_citations_to_sources",
+    "my_extract_citations",
+    "reassign_citations_in_order",
     # Other
     "increment_version",
     "decrement_version",

--- a/py/shared/utils/base_utils.py
+++ b/py/shared/utils/base_utils.py
@@ -4,7 +4,16 @@ import math
 import re
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, AsyncGenerator, Dict, Iterable, List, Optional, TypeVar
+from typing import (
+    Any,
+    AsyncGenerator,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 from uuid import NAMESPACE_DNS, UUID, uuid4, uuid5
 
 from ..abstractions.search import (
@@ -22,70 +31,102 @@ from ..abstractions.vector import VectorQuantizationType
 logger = logging.getLogger()
 
 
-def my_extract_citations(text: str) -> List[Dict[str, int]]:
+def _expand_citation_span_to_sentence(
+    full_text: str, start: int, end: int
+) -> Tuple[int, int]:
     """
-    Finds references to the pattern [#] in the LLM-generated text and returns
-    a list of dictionaries containing:
-       - the citation index (as integer)
-       - startIndex (character offset)
-       - endIndex (character offset)
+    Return (sentence_start, sentence_end) for the sentence containing the bracket [n].
+    We define a sentence boundary as a '.', '?', or '!', optionally followed by
+    spaces or a newline. This is a simple heuristic; you can refine it as needed.
+    """
 
-    Example:
-      "Paris is the capital of France [1]."
-      => { index: 1, startIndex: 31, endIndex: 34 }
-    """
+    # Define characters that end a sentence (you could add semicolons, etc. if you like)
+    sentence_enders = {".", "?", "!"}
+
+    # 1) Move backward from 'start' until we find a sentence ender or reach index 0
+    s = start
+    while s > 0:
+        # If we see a possible ender, check if the next char is whitespace or the end of text
+        if full_text[s] in sentence_enders:
+            s += 1
+            # Skip spaces after the punctuation
+            while s < len(full_text) and full_text[s].isspace():
+                s += 1
+            break
+        s -= 1
+
+    sentence_start = s
+
+    # 2) Move forward from 'end' until we find a sentence ender or end of text
+    e = end
+    while e < len(full_text):
+        if full_text[e] in sentence_enders:
+            e += 1
+            # Skip spaces after the punctuation
+            while e < len(full_text) and full_text[e].isspace():
+                e += 1
+            break
+        e += 1
+
+    sentence_end = e
+
+    return (sentence_start, sentence_end)
+
+
+def my_extract_citations(text: str) -> List[Dict[str, Any]]:
     pattern = r"\[(\d+)\]"
     citations = []
+
     for match in re.finditer(pattern, text):
+        bracket_index = int(match.group(1))
+        bracket_start = match.start()
+        bracket_end = match.end()
+
+        # ******* SWAP HERE: *******
+        snippet_start, snippet_end = _expand_citation_span_to_sentence(
+            text, bracket_start, bracket_end
+        )
+        snippet_text = text[snippet_start:snippet_end]
+
         citations.append(
             {
-                "index": int(match.group(1)),  # e.g. the '1' in "[1]"
-                "startIndex": match.start(),  # character offset in text
-                "endIndex": match.end(),
+                "index": bracket_index,
+                "startIndex": bracket_start,
+                "endIndex": bracket_end,
+                "snippetStartIndex": snippet_start,
+                "snippetEndIndex": snippet_end,
+                # "snippet": snippet_text,
             }
         )
+
     return citations
 
 
 def reassign_citations_in_order(
-    text: str, citations: List[Dict[str, int]]
-) -> (str, List[Dict[str, int]]):
+    text: str, citations: List[Dict[str, Any]]
+) -> Tuple[str, List[Dict[str, Any]]]:
     """
     Sorts the citations by their startIndex, then renumbers them [1], [2], [3], ...
-    in the order they appear in the text. Also does an *in-place* replacement
+    in the order they appear in the text. Also does an in-place replacement
     of the bracket references within 'text' so the final text has consecutively
     numbered citations.
 
     Returns:
       new_text: The text with bracket references replaced by the new indices
-      new_citations: A list of citations with updated 'index', 'startIndex', 'endIndex'.
-
-    Example:
-      Original text: "DeepSeek-R1 is ... [9]. Also see [2]."
-      Extracted citations:
-        [ {index:9, startIndex:30, endIndex:33},
-          {index:2, startIndex:45, endIndex:48} ]
-      We reorder them by startIndex -> [9] first, [2] second
-      We rename [9] -> [1], [2] -> [2].
+      new_citations: A list of citations with updated 'index', 'startIndex', 'endIndex',
+                     and snippet data (snippetStartIndex, snippetEndIndex, snippet).
     """
 
-    # 1) Sort citations by the order they appear
+    # 1) Sort the original citations by startIndex
     sorted_citations = sorted(citations, key=lambda c: c["startIndex"])
 
-    # We will reconstruct text as a list of characters for easier in-place editing
+    # Build a list of characters for easier in-place editing
     result_text_chars = list(text)
-    offset = 0  # how many chars we've added/removed so far from modifications
-    new_citations = []
 
-    # 2) Because we're changing lengths, we replace from the *end* to the start
-    #    so we don't disrupt the start/end indexes of upcoming replacements.
-    #    But we still want the new indices assigned in ascending order, so we must do a 2-step approach:
-    #      a) assign newIndex in ascending order
-    #      b) do textual replacements in descending order
-    #    We'll store these in a separate list for the actual replacement pass.
+    # 2) Assign new index in ascending order
     labeled_citations = []
     for i, cit in enumerate(sorted_citations):
-        new_idx = i + 1  # re-labeled index
+        new_idx = i + 1
         labeled_citations.append(
             {
                 "oldIndex": cit["index"],
@@ -94,112 +135,85 @@ def reassign_citations_in_order(
                 "endIndex": cit["endIndex"],
             }
         )
-
-    # Sort labeled citations in descending order of startIndex for safe replacement
+    # Sort in descending order for safe in-place replacement
     labeled_citations_desc = sorted(
-        labeled_citations, key=lambda c: c["startIndex"], reverse=True
+        labeled_citations, key=lambda x: x["startIndex"], reverse=True
     )
 
+    # 3) Replace the old bracket references with [1], [2], ...
     for citation_info in labeled_citations_desc:
         start = citation_info["startIndex"]
         end = citation_info["endIndex"]
         new_idx = citation_info["newIndex"]
-        # old substring might be e.g. "[9]"
-        old_length = end - start
         new_text_segment = f"[{new_idx}]"
-        new_length = len(new_text_segment)
-        # Replace in result_text_chars
         result_text_chars[start:end] = list(new_text_segment)
-        # This effectively changes the length if new_length != old_length
 
     new_text = "".join(result_text_chars)
 
-    # 3) Re-calculate final positions (startIndex/endIndex) for each citation
-    #    We can just re-run the regex on new_text to get their final positions
-    #    Or do a second pass of logic. Let's do the simpler approach: re-run the extraction
+    # 4) Re-extract citations from new_text, which will now yield updated snippet data
     re_extracted = my_extract_citations(new_text)
+    # Build a dict by the new index so we can merge them in ascending order
+    reassign_map = {ce["index"]: ce for ce in re_extracted}
 
-    # Now we have N re-extracted citations. They have the *same order* as the new labeled citations
-    # because the new text has them in ascending order. We'll map them by newIndex -> that citation info
-    reassign_map = {}
-    for c in re_extracted:
-        # c['index'] is the new index
-        reassign_map[c["index"]] = c
-
-    # 4) Build new_citations in ascending newIndex order
+    # 5) Final pass: build new_citations in ascending newIndex order
     labeled_citations_asc = sorted(
-        labeled_citations, key=lambda c: c["newIndex"]
+        labeled_citations, key=lambda x: x["newIndex"]
     )
-    for citation_info in labeled_citations_asc:
-        new_idx = citation_info["newIndex"]
-        old_idx = citation_info["oldIndex"]
-        # find the newly extracted position
-        final_positions = reassign_map.get(new_idx, {})
-        new_citations.append(
+    updated_citations = []
+    for item in labeled_citations_asc:
+        new_idx = item["newIndex"]
+        old_idx = item["oldIndex"]
+        found = reassign_map.get(new_idx, {})
+        # Merge the newly extracted snippet fields with the oldIndex
+        updated_citations.append(
             {
                 "oldIndex": old_idx,
                 "index": new_idx,
-                "startIndex": final_positions.get("startIndex"),
-                "endIndex": final_positions.get("endIndex"),
+                "startIndex": found.get("startIndex"),
+                "endIndex": found.get("endIndex"),
+                "snippetStartIndex": found.get("snippetStartIndex"),
+                "snippetEndIndex": found.get("snippetEndIndex"),
+                # "snippet": found.get("snippet"),
             }
         )
 
-    return new_text, new_citations
+    return new_text, updated_citations
 
 
 def my_map_citations_to_sources(
-    citations: List[Dict[str, int]], aggregated: "AggregateSearchResult"
+    citations: List[Dict[str, Any]],  # allow snippet fields, etc.
+    aggregated: AggregateSearchResult,
 ) -> List[Dict[str, Any]]:
-    """
-    Given the list of extracted citations (with indexes like 1,2,3...) and an
-    AggregateSearchResult, return a list of 'citation objects' that
-    include:
-       - index, startIndex, endIndex (from citation detection)
-       - sourceType: chunk, graph, web, or contextDoc
-       - all relevant fields (id, document_id, owner_id, collection_ids, score, etc.)
-       - any metadata, including text or titles
-
-    We flatten out the search results in the order they were enumerated in the final prompt:
-      1..N => chunk_search_results
-      N+1..M => graph_search_results
-      etc.
-    """
-
     flat_source_list = []
-
-    # 1) chunk_search_results
+    # Flatten your chunk, graph, web, contextDoc in order
     if aggregated.chunk_search_results:
         for chunk in aggregated.chunk_search_results:
             flat_source_list.append((chunk, "chunk"))
-
-    # 2) graph_search_results
     if aggregated.graph_search_results:
         for g in aggregated.graph_search_results:
             flat_source_list.append((g, "graph"))
-
-    # 3) web_search_results
     if aggregated.web_search_results:
         for w in aggregated.web_search_results:
             flat_source_list.append((w, "web"))
-
-    # 4) context_document_results
     if aggregated.context_document_results:
         for cdoc in aggregated.context_document_results:
             flat_source_list.append((cdoc, "contextDoc"))
 
     mapped_citations = []
-
     for c in citations:
         index_1_based = c["index"]
         idx_0_based = index_1_based - 1
 
-        # If the LLM references a source index that doesn't exist, store placeholders
+        # If out of range, placeholders
         if idx_0_based < 0 or idx_0_based >= len(flat_source_list):
             mapped_citations.append(
                 {
                     "index": index_1_based,
-                    "startIndex": c["startIndex"],
-                    "endIndex": c["endIndex"],
+                    "startIndex": c.get("startIndex"),
+                    "endIndex": c.get("endIndex"),
+                    "snippetStartIndex": c.get("snippetStartIndex"),
+                    "snippetEndIndex": c.get("snippetEndIndex"),
+                    # "snippet": c.get("snippet"),
                     "sourceType": None,
                     "id": None,
                     "document_id": None,
@@ -214,10 +228,14 @@ def my_map_citations_to_sources(
 
         source_obj, source_type = flat_source_list[idx_0_based]
 
+        # Build up base citation
         citation_obj = {
             "index": index_1_based,
-            "startIndex": c["startIndex"],
-            "endIndex": c["endIndex"],
+            "startIndex": c.get("startIndex"),
+            "endIndex": c.get("endIndex"),
+            "snippetStartIndex": c.get("snippetStartIndex"),
+            "snippetEndIndex": c.get("snippetEndIndex"),
+            # "snippet": c.get("snippet"),
             "sourceType": source_type,
             "id": None,
             "document_id": None,
@@ -225,13 +243,10 @@ def my_map_citations_to_sources(
             "collection_ids": None,
             "score": None,
             "text": None,
-            # We'll store all leftover fields in "metadata" to keep them structured
             "metadata": {},
         }
 
-        # Now handle each source type and gather relevant fields:
         if source_type == "chunk":
-            # source_obj is a ChunkSearchResult
             citation_obj.update(
                 {
                     "id": str(source_obj.id),
@@ -246,68 +261,38 @@ def my_map_citations_to_sources(
                     ],
                     "score": source_obj.score,
                     "text": source_obj.text,
-                    # For chunk metadata, let's unify them under "metadata"
                     "metadata": dict(source_obj.metadata),
                 }
             )
-
         elif source_type == "graph":
-            # source_obj is a GraphSearchResult
-            # e.g. source_obj.content might be GraphEntityResult or GraphRelationshipResult
             citation_obj.update(
                 {
-                    "id": None,  # GraphSearchResult doesn't have an "id" at top-level
-                    "document_id": None,
-                    "owner_id": None,
-                    "collection_ids": None,
                     "score": source_obj.score,
-                    "text": None,  # Not typical to have a 'text' in a graph result
-                    # entire "metadata" can go under citation_obj["metadata"]
                     "metadata": dict(source_obj.metadata),
                 }
             )
-            # You can add subfields from the content if you wish, e.g.:
             if source_obj.content:
                 citation_obj["metadata"][
                     "graphContent"
                 ] = source_obj.content.model_dump()
-
         elif source_type == "web":
-            # source_obj is a WebSearchResult
             citation_obj.update(
                 {
-                    "id": None,
-                    "document_id": None,
-                    "owner_id": None,
-                    "collection_ids": None,
-                    "score": None,
-                    "text": None,
                     "metadata": {
-                        # Here we can store link, title, snippet, etc.
                         "link": source_obj.link,
                         "title": source_obj.title,
-                        "snippet": source_obj.snippet,
+                        # "snippet": source_obj.snippet,
                         "position": source_obj.position,
-                    },
+                    }
                 }
             )
-
         elif source_type == "contextDoc":
-            # source_obj is a ContextDocumentResult
-            # That means source_obj.document is a dict with some fields:
             citation_obj.update(
                 {
-                    "id": None,
-                    "document_id": None,
-                    "owner_id": None,
-                    "collection_ids": None,
-                    "score": None,
-                    "text": None,
-                    # store the doc data (title, etc.) in metadata
                     "metadata": {
                         "document": source_obj.document,
                         "chunks": source_obj.chunks,
-                    },
+                    }
                 }
             )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add citation parsing and mapping functionality to enhance RAG responses with structured citation metadata.
> 
>   - **Behavior**:
>     - Adds citation parsing functions `my_extract_citations`, `reassign_citations_in_order`, and `my_map_citations_to_sources` in `base_utils.py`.
>     - Updates `rag()` in `retrieval_service.py` to include citation extraction, re-labeling, and mapping to sources.
>     - Modifies `RAGResponse` in `responses.py` to include `citations` field.
>   - **Models**:
>     - Introduces `Citation` model in `responses.py` to represent citation metadata.
>     - Updates `__init__.py` in `api/models` to include `Citation` in exports.
>   - **Misc**:
>     - Renames `reasoning_agent` to `reasoningAgent` in `retrieval.ts`.
>     - Removes unused `modalities` code in `llm.py`.
>     - Version bump in `package.json` from `0.4.24` to `0.4.25`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 4ad0abd9bfc6da15ec02a59a7be2e5f2e9f0602c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->