### PR TITLE
Fix NaN comparison

### DIFF
--- a/py/core/main/assembly/factory.py
+++ b/py/core/main/assembly/factory.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 from typing import Any, Optional
 
@@ -311,7 +312,12 @@ class R2RProviderFactory:
         **kwargs,
     ) -> R2RProviders:
         if (
-            self.config.embedding.base_dimension
+            math.isnan(self.config.embedding.base_dimension)
+            != math.isnan(self.config.completion_embedding.base_dimension)
+        ) or (
+            not math.isnan(self.config.embedding.base_dimension)
+            and not math.isnan(self.config.completion_embedding.base_dimension)
+            and self.config.embedding.base_dimension
             != self.config.completion_embedding.base_dimension
         ):
             raise ValueError(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes NaN comparison in `create_providers` method of `factory.py` to ensure consistent embedding dimensions.
> 
>   - **Behavior**:
>     - Fixes NaN comparison in `create_providers` method of `factory.py`.
>     - Ensures `embedding.base_dimension` and `completion_embedding.base_dimension` are either both NaN or equal.
>   - **Imports**:
>     - Adds `import math` to handle NaN comparisons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for e0671c8b6a1e60b4b111fe79f6fbce57db917125. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->