### PR TITLE
fix document creation providing collection_ids in js sdk

### DIFF
--- a/js/sdk/src/v3/clients/documents.ts
+++ b/js/sdk/src/v3/clients/documents.ts
@@ -121,10 +121,8 @@ export class DocumentsClient {
         JSON.stringify(options.ingestionConfig),
       );
     }
-    if (options.collectionIds) {
-      options.collectionIds.forEach((id) => {
-        formData.append("collection_ids", id);
-      });
+    if (options.collectionIds?.length) {
+      formData.append("collection_ids", JSON.stringify(options.collectionIds));
     }
     if (options.runWithOrchestration !== undefined) {
       formData.append(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `collectionIds` handling in `DocumentsClient.create` by appending them as a JSON string to `formData`.
> 
>   - **Behavior**:
>     - Fixes `collectionIds` handling in `create` method of `DocumentsClient` in `documents.ts`.
>     - Appends `collectionIds` as a JSON string to `formData` instead of appending each ID individually.
>     - Ensures `collectionIds` are only appended if the array is not empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for a142963ca2835cade94ae3498361af02b64ec284. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->