### PR TITLE
fix document creation providing collection_ids in js sdk

### DIFF
--- a/js/sdk/src/v3/clients/documents.ts
+++ b/js/sdk/src/v3/clients/documents.ts
@@ -121,10 +121,8 @@ export class DocumentsClient {
         JSON.stringify(options.ingestionConfig),
       );
     }
-    if (options.collectionIds) {
-      options.collectionIds.forEach((id) => {
-        formData.append("collection_ids", id);
-      });
+    if (options.collectionIds?.length) {
+      formData.append("collection_ids", JSON.stringify(options.collectionIds));
     }
     if (options.runWithOrchestration !== undefined) {
       formData.append(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `DocumentsClient.create()` to append `collectionIds` as JSON string in `documents.ts`.
> 
>   - **Behavior**:
>     - In `DocumentsClient.create()`, `collectionIds` are now appended as a JSON string instead of individual entries.
>     - Handles cases where `collectionIds` is an empty array by not appending anything.
>   - **Misc**:
>     - Simplifies `formData` appending logic for `collectionIds` in `documents.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for c37d1c1d6f0f7c474b10fabbc3c40d5f02352f6c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->