### PR TITLE
Add back MSG parsing

### DIFF
--- a/py/core/__init__.py
+++ b/py/core/__init__.py
@@ -132,7 +132,7 @@ __all__ = [
     "EMLParser",
     "EPUBParser",
     "JSONParser",
-    # "MSGParser",
+    "MSGParser",
     "ORGParser",
     "P7SParser",
     "RSTParser",

--- a/py/core/parsers/__init__.py
+++ b/py/core/parsers/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
     "EMLParser",
     "EPUBParser",
     "JSONParser",
-    # "MSGParser",
+    "MSGParser",
     "ORGParser",
     "P7SParser",
     "RSTParser",

--- a/py/core/parsers/structured/__init__.py
+++ b/py/core/parsers/structured/__init__.py
@@ -3,8 +3,7 @@ from .csv_parser import CSVParser, CSVParserAdvanced
 from .eml_parser import EMLParser
 from .epub_parser import EPUBParser
 from .json_parser import JSONParser
-
-# from .msg_parser import MSGParser
+from .msg_parser import MSGParser
 from .org_parser import ORGParser
 from .p7s_parser import P7SParser
 from .rst_parser import RSTParser
@@ -19,7 +18,7 @@ __all__ = [
     "EMLParser",
     "EPUBParser",
     "JSONParser",
-    # "MSGParser",
+    "MSGParser",
     "ORGParser",
     "P7SParser",
     "RSTParser",

--- a/py/core/parsers/structured/msg_parser.py
+++ b/py/core/parsers/structured/msg_parser.py
@@ -14,7 +14,7 @@ from core.base.providers import (
 class MSGParser(AsyncParser[str | bytes]):
     """Parser for MSG (Outlook Message) files."""
 
-    def init(
+    def __init__(
         self,
         config: IngestionConfig,
         database_provider: DatabaseProvider,

--- a/py/core/parsers/structured/msg_parser.py
+++ b/py/core/parsers/structured/msg_parser.py
@@ -1,67 +1,64 @@
-# # type: ignore
-# from typing import AsyncGenerator
+# type: ignore
+from typing import AsyncGenerator
 
-# import extract_msg
+from msg_parser import MsOxMessage
 
-# from core.base.parsers.base_parser import AsyncParser
-# from core.base.providers import (
-#     CompletionProvider,
-#     DatabaseProvider,
-#     IngestionConfig,
-# )
+from core.base.parsers.base_parser import AsyncParser
+from core.base.providers import (
+    CompletionProvider,
+    DatabaseProvider,
+    IngestionConfig,
+)
 
-# class MSGParser(AsyncParser[str | bytes]):
-#     """Parser for MSG (Outlook Message) files."""
 
-#     def __init__(
-#         self,
-#         config: IngestionConfig,
-#         database_provider: DatabaseProvider,
-#         llm_provider: CompletionProvider,
-#     ):
-#         self.database_provider = database_provider
-#         self.llm_provider = llm_provider
-#         self.config = config
-#         self.extract_msg = extract_msg
+class MSGParser(AsyncParser[str | bytes]):
+    """Parser for MSG (Outlook Message) files."""
 
-#     async def ingest(
-#         self, data: str | bytes, **kwargs
-#     ) -> AsyncGenerator[str, None]:
-#         """Ingest MSG data and yield email content."""
-#         if isinstance(data, str):
-#             raise ValueError("MSG data must be in bytes format.")
+    def init(
+        self,
+        config: IngestionConfig,
+        database_provider: DatabaseProvider,
+        llm_provider: CompletionProvider,
+    ):
+        self.database_provider = database_provider
+        self.llm_provider = llm_provider
+        self.config = config
 
-#         from io import BytesIO
+    async def ingest(
+        self, data: str | bytes, **kwargs
+    ) -> AsyncGenerator[str, None]:
+        """Ingest MSG data and yield email content."""
+        if isinstance(data, str):
+            raise ValueError("MSG data must be in bytes format.")
 
-#         file_obj = BytesIO(data)
+        try:
+            # MsOxMessage can be initialized with file_bytes
+            msg = MsOxMessage(file_bytes=data)
 
-#         try:
-#             msg = self.extract_msg.Message(file_obj)
+            # Extract metadata
+            metadata = []
+            subject = msg.get_subject()
+            if subject:
+                metadata.append(f"Subject: {subject}")
 
-#             # Extract metadata
-#             metadata = []
-#             if msg.subject:
-#                 metadata.append(f"Subject: {msg.subject}")
-#             if msg.sender:
-#                 metadata.append(f"From: {msg.sender}")
-#             if msg.to:
-#                 metadata.append(f"To: {msg.to}")
-#             if msg.date:
-#                 metadata.append(f"Date: {msg.date}")
+            if sender := msg.get_sender():
+                metadata.append(f"From: {sender}")
 
-#             if metadata:
-#                 yield "\n".join(metadata)
+            if recipients := msg.get_recipients() or []:
+                metadata.append(f"To: {', '.join(recipients)}")
 
-#             # Extract body
-#             if msg.body:
-#                 yield msg.body.strip()
+            if sent_date := msg.get_sent_date():
+                metadata.append(f"Date: {sent_date}")
 
-#             # Extract attachments (optional)
-#             for attachment in msg.attachments:
-#                 if hasattr(attachment, "name"):
-#                     yield f"\nAttachment: {attachment.name}"
+            if metadata:
+                yield "\n".join(metadata)
 
-#         except Exception as e:
-#             raise ValueError(f"Error processing MSG file: {str(e)}")
-#         finally:
-#             file_obj.close()
+            if body := msg.body:
+                yield body.strip()
+
+            # Extract attachments
+            for attach_name, _attach_data in (msg.attachments or {}).items():
+                yield f"\nAttachment: {attach_name}"
+
+        except Exception as e:
+            raise ValueError(f"Error processing MSG file: {str(e)}") from e

--- a/py/core/providers/ingestion/r2r/base.py
+++ b/py/core/providers/ingestion/r2r/base.py
@@ -48,7 +48,7 @@ class R2RIngestionProvider(IngestionProvider):
         DocumentType.HTM: parsers.HTMLParser,
         DocumentType.ODT: parsers.ODTParser,
         DocumentType.JSON: parsers.JSONParser,
-        # DocumentType.MSG: parsers.MSGParser,
+        DocumentType.MSG: parsers.MSGParser,
         DocumentType.ORG: parsers.ORGParser,
         DocumentType.MD: parsers.MDParser,
         DocumentType.PDF: parsers.BasicPDFParser,

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -54,6 +54,7 @@ core = [
     "hatchet-sdk ==0.47.0",
     "litellm >=1.58.2,<2.0.0",
     "markdown >=3.6,<4.0",
+    "msg-parser>=1.2.0",
     "networkx >=3.3,<4.0",
     "numpy >=1.22.4,<1.29.0",
     "olefile >=0.47,<0.48",

--- a/py/tests/integration/test_ingestion.py
+++ b/py/tests/integration/test_ingestion.py
@@ -161,7 +161,7 @@ def client(config):
         ("jpeg", "core/examples/supported_file_types/jpeg.jpeg"),
         ("jpg", "core/examples/supported_file_types/jpg.jpg"),
         ("md", "core/examples/supported_file_types/md.md"),
-        # ("msg", "core/examples/supported_file_types/msg.msg"),
+        ("msg", "core/examples/supported_file_types/msg.msg"),
         ("odt", "core/examples/supported_file_types/odt.odt"),
         ("org", "core/examples/supported_file_types/org.org"),
         ("p7s", "core/examples/supported_file_types/p7s.p7s"),

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -1656,6 +1656,18 @@ wheels = [
 ]
 
 [[package]]
+name = "msg-parser"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "olefile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/29/07909e648a72a6cd054a1ad5acf55caac0e9d4c9c3a06498af18f30a1602/msg_parser-1.2.0.tar.gz", hash = "sha256:0de858d4fcebb6c8f6f028da83a17a20fe01cdce67c490779cf43b3b0162aa66", size = 9457398 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/8b/5738b32acc6acdf92d04d5e691bf70a379e78264e55843542e1888d4a10e/msg_parser-1.2.0-py2.py3-none-any.whl", hash = "sha256:d47a2f0b2a359cb189fad83cc991b63ea781ecc70d91410324273fbf93e95375", size = 101829 },
+]
+
+[[package]]
 name = "msrest"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2923,6 +2935,7 @@ core = [
     { name = "hatchet-sdk" },
     { name = "litellm" },
     { name = "markdown" },
+    { name = "msg-parser" },
     { name = "networkx" },
     { name = "numpy" },
     { name = "olefile" },
@@ -3000,6 +3013,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
     { name = "litellm", marker = "extra == 'core'", specifier = ">=1.58.2,<2.0.0" },
     { name = "markdown", marker = "extra == 'core'", specifier = ">=3.6,<4.0" },
+    { name = "msg-parser", marker = "extra == 'core'", specifier = ">=1.2.0" },
     { name = "networkx", marker = "extra == 'core'", specifier = ">=3.3,<4.0" },
     { name = "numpy", marker = "extra == 'core'", specifier = ">=1.22.4,<1.29.0" },
     { name = "olefile", marker = "extra == 'core'", specifier = ">=0.47,<0.48" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reintroduces MSG parsing using `msg-parser` library and updates dependencies and tests accordingly.
> 
>   - **Parsers**:
>     - Re-enable `MSGParser` in `__init__.py` files in `core` and `parsers`.
>     - Update `MSGParser` in `msg_parser.py` to use `msg_parser` library for parsing MSG files.
>   - **Dependencies**:
>     - Add `msg-parser>=1.2.0` to `pyproject.toml` and `uv.lock`.
>   - **Ingestion**:
>     - Enable MSG file support in `R2RIngestionProvider` in `base.py`.
>   - **Tests**:
>     - Re-enable MSG test case in `test_ingestion.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for a4b9443d2adf77581374051a233f339b42cf4cc0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->