### PR TITLE
Fix bug on unstructured fallback parsing

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "r2r"
-version = "3.4.1"
+version = "3.4.2"
 description = "SciPhi R2R"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `parse_fallback` in `base.py` to handle dictionary and string outputs, updating version to 3.4.2.
> 
>   - **Behavior**:
>     - Fixes `parse_fallback` in `base.py` to handle both dictionary and string outputs from parsers, ensuring backward compatibility.
>     - Adds handling for `page_number` in metadata if present in content.
>   - **Versioning**:
>     - Updates version in `pyproject.toml` from `3.4.1` to `3.4.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 59363fc831f6ed0c0a5ac75023c116abef840161. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->