### PR TITLE
chore: update r2r.toml

### DIFF
--- a/py/r2r/r2r.toml
+++ b/py/r2r/r2r.toml
@@ -96,7 +96,7 @@ automatic_extraction = true # enable automatic extraction of entities and relati
   [ingestion.chunk_enrichment_settings]
     chunk_enrichment_prompt = "chunk_enrichment"
     enable_chunk_enrichment = false # disabled by default
-    n_chunks = 2 # the number of chunks (both preceeding and succeeding) to use in enrichment
+    n_chunks = 2 # the number of chunks (both preceding and succeeding) to use in enrichment
 
   [ingestion.extra_parsers]
     pdf = "zerox"


### PR DESCRIPTION
preceeding -> preceding
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in `r2r.toml` by changing "preceeding" to "preceding" in a comment.
> 
>   - **Typo Fix**:
>     - Corrects typo in `r2r.toml`: "preceeding" to "preceding" in a comment under `[ingestion.chunk_enrichment_settings]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 194a3433df8e73da6e678c21aae478f92b746e9d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->