### PR TITLE
Fix JS WrappedTokenResponse type

### DIFF
--- a/js/sdk/package-lock.json
+++ b/js/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/js/sdk/src/r2rClient.ts
+++ b/js/sdk/src/r2rClient.ts
@@ -154,12 +154,9 @@ export class r2rClient extends BaseClient {
 
           // Attempt refresh
           try {
-            //@ts-ignore
             const refreshResponse = await this.users.refreshAccessToken();
-            //@ts-ignore
-            const newAccessToken = refreshResponse.results.accessToken?.token;
-            //@ts-ignore
-            const newRefreshToken = refreshResponse.results.refreshToken?.token;
+            const newAccessToken = refreshResponse.results.accessToken.token;
+            const newRefreshToken = refreshResponse.results.refreshToken.token;
 
             // set new tokens
             this.setTokens(newAccessToken, newRefreshToken);

--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -278,9 +278,16 @@ export interface SettingsResponse {
 
 // User types
 
+export type TokenType = "access" | "refresh";
+
 export interface Token {
-  accessToken: string;
-  refreshToken: string;
+  token: string;
+  tokenType: TokenType;
+}
+
+export interface TokenResponse {
+  accessToken: Token;
+  refreshToken: Token;
 }
 
 export interface User {
@@ -424,7 +431,7 @@ export type WrappedSettingsResponse = ResultsWrapper<SettingsResponse>;
 export type WrappedServerStatsResponse = ResultsWrapper<ServerStats>;
 
 // User Responses
-export type WrappedTokenResponse = ResultsWrapper<Token>;
+export type WrappedTokenResponse = ResultsWrapper<TokenResponse>;
 export type WrappedUserResponse = ResultsWrapper<User>;
 export type WrappedUsersResponse = PaginatedResultsWrapper<User[]>;
 export type WrappedLimitsResponse = ResultsWrapper<LimitsResponse>;

--- a/js/sdk/src/v3/clients/collections.ts
+++ b/js/sdk/src/v3/clients/collections.ts
@@ -328,11 +328,16 @@ export class CollectionsClient {
    * @param name The name of the collection to retrieve.
    * @returns A promise that resolves with the collection details.
    */
-  async retrieveByName(options: { name: string; ownerId?: string }): Promise<WrappedCollectionResponse> {
+  async retrieveByName(options: {
+    name: string;
+    ownerId?: string;
+  }): Promise<WrappedCollectionResponse> {
     const queryParams: Record<string, any> = {};
     if (options.ownerId) {
       queryParams.owner_id = options.ownerId;
     }
-    return this.client.makeRequest("GET", `collections/name/${options.name}`, { params: queryParams });
+    return this.client.makeRequest("GET", `collections/name/${options.name}`, {
+      params: queryParams,
+    });
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix `WrappedTokenResponse` type in JS SDK and remove unnecessary `@ts-ignore` comments in `r2rClient.ts`.
> 
>   - **Type Fixes**:
>     - Correct `WrappedTokenResponse` type in `types.ts` to use `TokenResponse` instead of `Token`.
>     - Update `Token` interface to include `token` and `tokenType` fields.
>   - **Code Cleanup**:
>     - Remove `@ts-ignore` comments in `r2rClient.ts` for `refreshAccessToken()` usage.
>   - **Version Update**:
>     - Increment version in `package.json` from `0.4.27` to `0.4.28`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for bf0dfa4289c5f1047ec69e617de021f28adba804. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->