### PR TITLE
Remove network from compose files

### DIFF
--- a/compose.full.swarm.yaml
+++ b/compose.full.swarm.yaml
@@ -1,8 +1,3 @@
-networks:
-  r2r-network:
-    external: true
-    name: ${DOCKER_NETWORK_NAME:-r2r_r2r-network}
-
 volumes:
   hatchet_certs:
     name: ${VOLUME_HATCHET_CERTS:-hatchet_certs}
@@ -31,8 +26,6 @@ services:
       - PGPORT=${R2R_POSTGRES_PORT:-5432}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    networks:
-      - r2r-network
     ports:
       - "${R2R_POSTGRES_PORT:-5432}:${R2R_POSTGRES_PORT:-5432}"
     healthcheck:
@@ -56,8 +49,6 @@ services:
       POSTGRES_PASSWORD: ${HATCHET_POSTGRES_PASSWORD:-hatchet_password}
     volumes:
       - hatchet_postgres_data:/var/lib/postgresql/data
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${HATCHET_POSTGRES_USER:-hatchet_user} -d ${HATCHET_POSTGRES_DBNAME:-hatchet}"]
       interval: 10s
@@ -67,7 +58,6 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-
 
   hatchet-rabbitmq:
     image: "rabbitmq:3-management"
@@ -86,8 +76,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    networks:
-      - r2r-network
     deploy:
       replicas: 1
       restart_policy:
@@ -112,8 +100,6 @@ services:
       "
     environment:
       DATABASE_URL: "postgres://${HATCHET_POSTGRES_USER:-hatchet_user}:${HATCHET_POSTGRES_PASSWORD:-hatchet_password}@hatchet-postgres:5432/${HATCHET_POSTGRES_DBNAME:-hatchet}?sslmode=disable"
-    networks:
-      - r2r-network
     deploy:
       replicas: 1
       restart_policy:
@@ -125,8 +111,6 @@ services:
       DATABASE_URL: "postgres://${HATCHET_POSTGRES_USER:-hatchet_user}:${HATCHET_POSTGRES_PASSWORD:-hatchet_password}@hatchet-postgres:5432/${HATCHET_POSTGRES_DBNAME:-hatchet}?sslmode=disable"
     depends_on:
       - hatchet-create-db
-    networks:
-      - r2r-network
     deploy:
       replicas: 1
       restart_policy:
@@ -161,8 +145,6 @@ services:
     depends_on:
       - hatchet-migration
       - hatchet-rabbitmq
-    networks:
-      - r2r-network
     deploy:
       replicas: 1
       restart_policy:
@@ -185,8 +167,6 @@ services:
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8733/live"]
       interval: 10s
@@ -207,8 +187,6 @@ services:
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
-    networks:
-      - r2r-network
     ports:
       - "${R2R_HATCHET_DASHBOARD_PORT:-7274}:80"
     deploy:
@@ -224,8 +202,6 @@ services:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
       - hatchet_api_key:/hatchet_api_key
-    networks:
-      - r2r-network
     depends_on:
       - hatchet-setup-config
     deploy:
@@ -235,8 +211,6 @@ services:
 
   unstructured:
     image: ${UNSTRUCTURED_IMAGE:-ragtoriches/unst-prod}
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7275/health"]
       interval: 10s
@@ -251,8 +225,6 @@ services:
     image: ${GRAPH_CLUSTERING_IMAGE:-ragtoriches/cluster-prod}
     ports:
       - "${R2R_GRAPH_CLUSTERING_PORT:-7276}:7276"
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7276/health"]
       interval: 10s
@@ -378,8 +350,6 @@ services:
         fi
         exec uvicorn core.main.app_entry:app --host $${R2R_HOST} --port $${R2R_PORT}
       '
-    networks:
-      - r2r-network
     volumes:
       - ${R2R_CONFIG_PATH:-/}:${R2R_CONFIG_PATH:-/app/config}
       - hatchet_api_key:/hatchet_api_key:ro
@@ -412,8 +382,6 @@ services:
     environment:
       - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
       - NEXT_PUBLIC_HATCHET_DASHBOARD_URL=${HATCHET_DASHBOARD_URL:-http://localhost:${R2R_HATCHET_DASHBOARD_PORT:-7274}}
-    networks:
-      - r2r-network
     ports:
       - "${R2R_DASHBOARD_PORT:-7273}:3000"
     deploy:

--- a/compose.full.yaml
+++ b/compose.full.yaml
@@ -1,10 +1,3 @@
-networks:
-  r2r-network:
-    driver: bridge
-    attachable: true
-    labels:
-      - "com.docker.compose.recreate=always"
-
 volumes:
   hatchet_certs:
     name: ${VOLUME_HATCHET_CERTS:-hatchet_certs}
@@ -34,8 +27,6 @@ services:
       - PGPORT=${R2R_POSTGRES_PORT:-5432}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    networks:
-      - r2r-network
     ports:
       - "${R2R_POSTGRES_PORT:-5432}:${R2R_POSTGRES_PORT:-5432}"
     healthcheck:
@@ -56,8 +47,6 @@ services:
       POSTGRES_PASSWORD: ${HATCHET_POSTGRES_PASSWORD:-hatchet_password}
     volumes:
       - hatchet_postgres_data:/var/lib/postgresql/data
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${HATCHET_POSTGRES_USER:-hatchet_user} -d ${HATCHET_POSTGRES_DBNAME:-hatchet}"]
       interval: 10s
@@ -82,8 +71,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
-    networks:
-      - r2r-network
 
   hatchet-create-db:
     image: postgres:latest
@@ -104,8 +91,6 @@ services:
       "
     environment:
       DATABASE_URL: "postgres://${HATCHET_POSTGRES_USER:-hatchet_user}:${HATCHET_POSTGRES_PASSWORD:-hatchet_password}@hatchet-postgres:5432/${HATCHET_POSTGRES_DBNAME:-hatchet}?sslmode=disable"
-    networks:
-      - r2r-network
 
   hatchet-migration:
     image: ghcr.io/hatchet-dev/hatchet/hatchet-migrate:v0.53.15
@@ -114,8 +99,6 @@ services:
     depends_on:
       hatchet-create-db:
         condition: service_completed_successfully
-    networks:
-      - r2r-network
 
   hatchet-setup-config:
     image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:v0.53.15
@@ -148,8 +131,6 @@ services:
         condition: service_completed_successfully
       hatchet-rabbitmq:
         condition: service_healthy
-    networks:
-      - r2r-network
 
   hatchet-engine:
     image: ghcr.io/hatchet-dev/hatchet/hatchet-engine:v0.53.15
@@ -170,8 +151,6 @@ services:
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:8733/live"]
       interval: 10s
@@ -190,8 +169,6 @@ services:
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
-    networks:
-      - r2r-network
     ports:
       - "${R2R_HATCHET_DASHBOARD_PORT:-7274}:80"
 
@@ -248,8 +225,6 @@ services:
           echo 'Token payload appears to be valid JSON'
         fi
       "
-    networks:
-      - r2r-network
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config
@@ -260,8 +235,6 @@ services:
 
   unstructured:
     image: ${UNSTRUCTURED_IMAGE:-ragtoriches/unst-prod}
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7275/health"]
       interval: 10s
@@ -272,8 +245,6 @@ services:
     image: ${GRAPH_CLUSTERING_IMAGE:-ragtoriches/cluster-prod}
     ports:
       - "${R2R_GRAPH_CLUSTERING_PORT:-7276}:7276"
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7276/health"]
       interval: 10s
@@ -395,8 +366,6 @@ services:
         fi
         exec uvicorn core.main.app_entry:app --host $${R2R_HOST} --port $${R2R_PORT}
       '
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${R2R_PORT:-7272}/v3/health"]
       interval: 6s
@@ -421,7 +390,5 @@ services:
     environment:
       - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
       - NEXT_PUBLIC_HATCHET_DASHBOARD_URL=${HATCHET_DASHBOARD_URL:-http://localhost:${R2R_HATCHET_DASHBOARD_PORT:-7274}}
-    networks:
-      - r2r-network
     ports:
       - "${R2R_DASHBOARD_PORT:-7273}:3000"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,3 @@
-networks:
-  r2r-network:
-    driver: bridge
-    attachable: true
-    labels:
-      - "com.docker.compose.recreate=always"
-
 volumes:
   postgres_data:
     name: ${VOLUME_POSTGRES_DATA:-postgres_data}
@@ -22,8 +15,6 @@ services:
       - PGPORT=${R2R_POSTGRES_PORT:-5432}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    networks:
-      - r2r-network
     ports:
       - "${R2R_POSTGRES_PORT:-5432}:${R2R_POSTGRES_PORT:-5432}"
     healthcheck:
@@ -139,9 +130,6 @@ services:
       - R2R_SENTRY_ENVIRONMENT=${R2R_SENTRY_ENVIRONMENT}
       - R2R_SENTRY_TRACES_SAMPLE_RATE=${R2R_SENTRY_TRACES_SAMPLE_RATE}
       - R2R_SENTRY_PROFILES_SAMPLE_RATE=${R2R_SENTRY_PROFILES_SAMPLE_RATE}
-
-    networks:
-      - r2r-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${R2R_PORT:-7272}/v3/health"]
       interval: 6s
@@ -157,7 +145,5 @@ services:
     image: ${R2R_DASHBOARD_IMAGE:-emrgntcmplxty/r2r-dashboard:latest}
     environment:
       - NEXT_PUBLIC_R2R_DEPLOYMENT_URL=${R2R_DEPLOYMENT_URL:-http://localhost:7272}
-    networks:
-      - r2r-network
     ports:
       - "${R2R_DASHBOARD_PORT:-7273}:3000"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `r2r-network` from Docker Compose files, relying on default network behavior.
> 
>   - **Network Removal**:
>     - Removed `r2r-network` from `compose.full.swarm.yaml`, `compose.full.yaml`, and `compose.yaml`.
>     - Deleted network definition and removed from all services using it.
>   - **Services**:
>     - Services in `compose.full.swarm.yaml`, `compose.full.yaml`, and `compose.yaml` no longer specify `r2r-network`.
>     - Services rely on default network behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 74c23ab57cee725561742a28e28a4183c6b9bb30. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->