### PR TITLE
Remove 'R2R_PR2R_PROJECT_NAME' log

### DIFF
--- a/py/core/main/app_entry.py
+++ b/py/core/main/app_entry.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 from contextlib import asynccontextmanager
 from typing import Optional
 
@@ -81,16 +81,17 @@ logging.info(
 )
 logging.info(f"Environment R2R_PROJECT_NAME: {os.getenv('R2R_PROJECT_NAME')}")
 
-logging.info(f"Environment R2R_POSTGRES_HOST: {os.getenv('R2R_POSTGRES_HOST')}")
+logging.info(
+    f"Environment R2R_POSTGRES_HOST: {os.getenv('R2R_POSTGRES_HOST')}"
+)
 logging.info(
     f"Environment R2R_POSTGRES_DBNAME: {os.getenv('R2R_POSTGRES_DBNAME')}"
 )
-logging.info(f"Environment R2R_POSTGRES_PORT: {os.getenv('R2R_POSTGRES_PORT')}")
 logging.info(
-    f"Environment R2R_POSTGRES_PASSWORD: {os.getenv('R2R_POSTGRES_PASSWORD')}"
+    f"Environment R2R_POSTGRES_PORT: {os.getenv('R2R_POSTGRES_PORT')}"
 )
 logging.info(
-    f"Environment R2R_PROJECT_NAME: {os.getenv('R2R_PR2R_PROJECT_NAME')}"
+    f"Environment R2R_POSTGRES_PASSWORD: {os.getenv('R2R_POSTGRES_PASSWORD')}"
 )
 
 # Create the FastAPI app

--- a/py/core/utils/logging_config.py
+++ b/py/core/utils/logging_config.py
@@ -71,7 +71,9 @@ class HTTPStatusFilter(logging.Filter):
 
 
 log_level = os.environ.get("R2R_LOG_LEVEL", "INFO").upper()
-log_console_formatter = os.environ.get("R2R_LOG_CONSOLE_FORMATTER", "colored").lower() # colored or json
+log_console_formatter = os.environ.get(
+    "R2R_LOG_CONSOLE_FORMATTER", "colored"
+).lower()  # colored or json
 
 log_dir = Path.cwd() / "logs"
 log_dir.mkdir(exist_ok=True)
@@ -104,8 +106,12 @@ log_config = {
         },
         "json": {
             "()": "pythonjsonlogger.json.JsonFormatter",
-            "format": "%(name)s %(levelname)s %(message)s", # these become keys in the JSON log
-            "rename_fields": {"asctime": "time", "levelname": "level", "name": "logger"},
+            "format": "%(name)s %(levelname)s %(message)s",  # these become keys in the JSON log
+            "rename_fields": {
+                "asctime": "time",
+                "levelname": "level",
+                "name": "logger",
+            },
         },
     },
     "handlers": {
@@ -148,6 +154,7 @@ log_config = {
         },
     },
 }
+
 
 def configure_logging() -> Path:
     logging.config.dictConfig(log_config)


### PR DESCRIPTION
Not sure why/how this was here.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant logging of `R2R_PR2R_PROJECT_NAME` and adjust line breaks for consistency in `app_entry.py` and `logging_config.py`.
> 
>   - **Logging**:
>     - Remove redundant logging of `R2R_PR2R_PROJECT_NAME` in `app_entry.py`.
>   - **Formatting**:
>     - Adjust line breaks for logging statements in `app_entry.py` and `logging_config.py` for consistency and readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 5b37b75fad0b4fa0bea25617f6fb866a03a44f6b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->