### PR TITLE
Generate tokens via api key

### DIFF
--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -59,21 +59,21 @@ class UsersRouter(BaseRouterV3):
                 "x-codeSamples": [
                     {
                         "lang": "cURL",
-                        "source": "curl -X POST https://api.example.com/v3/users/generate-tokens -H 'x-api-key: YOUR_API_KEY'"
+                        "source": "curl -X POST https://api.example.com/v3/users/generate-tokens -H 'x-api-key: YOUR_API_KEY'",
                     }
                 ]
-            }
+            },
         )
         @self.base_endpoint
         async def generate_tokens_via_api_key(
-            auth_user=Depends(self.providers.auth.auth_wrapper())
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedTokenResponse:
             """Generate new access and refresh tokens using API key authentication."""
             result = await self.services.auth.generate_tokens_via_api_key(
                 user_id=auth_user.id
             )
             return result
-        
+
         @self.router.post(
             "/users",
             # dependencies=[Depends(self.rate_limit_dependency)],

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -66,7 +66,7 @@ class UsersRouter(BaseRouterV3):
         )
         @self.base_endpoint
         async def generate_tokens_via_api_key(
-            auth_user=Depends(self.providers.auth.auth_wrapper(public=True))
+            auth_user=Depends(self.providers.auth.auth_wrapper())
         ) -> WrappedTokenResponse:
             """Generate new access and refresh tokens using API key authentication."""
             result = await self.services.auth.generate_tokens_via_api_key(

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -53,6 +53,28 @@ class UsersRouter(BaseRouterV3):
 
     def _setup_routes(self):
         @self.router.post(
+            "/users/generate-tokens",
+            response_model=WrappedTokenResponse,
+            openapi_extra={
+                "x-codeSamples": [
+                    {
+                        "lang": "cURL",
+                        "source": "curl -X POST https://api.example.com/v3/users/generate-tokens -H 'x-api-key: YOUR_API_KEY'"
+                    }
+                ]
+            }
+        )
+        @self.base_endpoint
+        async def generate_tokens_via_api_key(
+            auth_user=Depends(self.providers.auth.auth_wrapper(public=True))
+        ) -> WrappedTokenResponse:
+            """Generate new access and refresh tokens using API key authentication."""
+            result = await self.services.auth.generate_tokens_via_api_key(
+                user_id=auth_user.id
+            )
+            return result
+        
+        @self.router.post(
             "/users",
             # dependencies=[Depends(self.rate_limit_dependency)],
             response_model=WrappedUserResponse,

--- a/py/core/main/services/auth_service.py
+++ b/py/core/main/services/auth_service.py
@@ -330,3 +330,7 @@ class AuthService(Service):
             dict: Contains the list of API keys
         """
         return await self.providers.auth.list_user_api_keys(user_id)
+
+    async def generate_tokens_via_api_key(self, user_id: UUID) -> dict[str, Token]:
+        """Expose the provider method through the service layer."""
+        return await self.providers.auth.generate_tokens_via_api_key(user_id)

--- a/py/core/providers/auth/r2r_auth.py
+++ b/py/core/providers/auth/r2r_auth.py
@@ -700,10 +700,14 @@ class R2RAuthProvider(AuthProvider):
             "refresh_token": Token(token=refresh_token, token_type="refresh"),
         }
 
-    async def generate_tokens_via_api_key(self, user_id: UUID) -> dict[str, Token]:
+    async def generate_tokens_via_api_key(
+        self, user_id: UUID
+    ) -> dict[str, Token]:
         """Generate new tokens for API key authenticated users."""
-        user = await self.database_provider.users_handler.get_user_by_id(user_id)
-        
+        user = await self.database_provider.users_handler.get_user_by_id(
+            user_id
+        )
+
         access_token = self.create_access_token(
             data={"sub": normalize_email(user.email)}
         )

--- a/py/core/providers/auth/r2r_auth.py
+++ b/py/core/providers/auth/r2r_auth.py
@@ -699,3 +699,19 @@ class R2RAuthProvider(AuthProvider):
             "access_token": Token(token=access_token, token_type="access"),
             "refresh_token": Token(token=refresh_token, token_type="refresh"),
         }
+
+    async def generate_tokens_via_api_key(self, user_id: UUID) -> dict[str, Token]:
+        """Generate new tokens for API key authenticated users."""
+        user = await self.database_provider.users_handler.get_user_by_id(user_id)
+        
+        access_token = self.create_access_token(
+            data={"sub": normalize_email(user.email)}
+        )
+        refresh_token = self.create_refresh_token(
+            data={"sub": normalize_email(user.email)}
+        )
+
+        return {
+            "access_token": Token(token=access_token, token_type="access"),
+            "refresh_token": Token(token=refresh_token, token_type="refresh"),
+        }


### PR DESCRIPTION
- Implement POST /users/generate-tokens endpoint for secure JWT generation
  - Requires valid API key authentication via X-API-Key header
  - Generates fresh access/refresh token pair with standard expiration
  - Returns wrapped token response matching existing auth flows
- Add comprehensive OpenAPI documentation:
  - Includes cURL example demonstrating API key usage
  - Documents response schema with example values
  - Marks endpoint as authenticated operation in Swagger UI
- Integrates with existing auth infrastructure through auth_wrapper
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `POST /users/generate-tokens` endpoint for JWT generation via API key with comprehensive documentation and integration with existing auth infrastructure.
> 
>   - **New Endpoint**:
>     - Adds `POST /users/generate-tokens` in `users_router.py` for JWT generation using API key.
>     - Requires `X-API-Key` header for authentication.
>     - Returns access/refresh token pair.
>   - **Documentation**:
>     - OpenAPI documentation includes cURL example and response schema.
>     - Endpoint marked as authenticated in Swagger UI.
>   - **Integration**:
>     - Uses `auth_wrapper` for authentication in `users_router.py`.
>     - Implements `generate_tokens_via_api_key` in `auth_service.py` and `r2r_auth.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for f6ecb6db6bce28cd0ecc8c3fb03f6617ece2ae47. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->