### PR TITLE
add suport for dashscope openai client

### DIFF
--- a/py/core/providers/llm/openai.py
+++ b/py/core/providers/llm/openai.py
@@ -131,7 +131,8 @@ class OpenAICompletionProvider(CompletionProvider):
         # Initialize Dashscope clients if credentials exist.
         dashscope_api_key = os.getenv("DASHSCOPE_API_KEY")
         dashscope_api_base = os.getenv(
-            "DASHSCOPE_API_BASE", "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            "DASHSCOPE_API_BASE",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
         )
         if dashscope_api_key and dashscope_api_base:
             self.dashscope_client = OpenAI(
@@ -152,7 +153,6 @@ class OpenAICompletionProvider(CompletionProvider):
                 self.lmstudio_client,
                 self.azure_foundry_client,
                 self.dashscope_client,
-
             ]
         ):
             raise ValueError(
@@ -208,7 +208,8 @@ class OpenAICompletionProvider(CompletionProvider):
                 raise ValueError(
                     "Dashscope OpenAI credentials not configured but dashscope/ model prefix used"
                 )
-            return self.dashscope_client, model[len("dashscope/"):]  # Strip prefix
+            prefix_len = len("dashscope/")
+            return self.dashscope_client, model[prefix_len:]  # Strip prefix
         else:
             # Default to OpenAI if no prefix is provided.
             if self.openai_client:
@@ -267,7 +268,8 @@ class OpenAICompletionProvider(CompletionProvider):
                 raise ValueError(
                     "Dashscope OpenAI credentials not configured but dashscope/ model prefix used"
                 )
-            return self.async_dashscope_client, model[len("dashscope/"):]
+            prefix_len = len("dashscope/")
+            return self.async_dashscope_client, model[prefix_len:]
         else:
             if self.async_openai_client:
                 return self.async_openai_client, model


### PR DESCRIPTION
Support the openai online services provided by Alibaba.

**Behavior**: 
- Init dashscope client in `openai. py`.
- Use dashscope client to execute task if modle name has a prefix like 'dashscope/' in `openai. py`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for Dashscope OpenAI clients in `openai.py`, handling models with 'dashscope/' prefix.
> 
>   - **Behavior**:
>     - Initialize Dashscope clients in `openai.py` if `DASHSCOPE_API_KEY` and `DASHSCOPE_API_BASE` are set.
>     - Use Dashscope client for models with 'dashscope/' prefix in `_get_client_and_model()` and `_get_async_client_and_model()`.
>   - **Error Handling**:
>     - Raise `ValueError` if 'dashscope/' prefix is used without Dashscope credentials in `_get_client_and_model()` and `_get_async_client_and_model()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 89b537510012bff602a36514547285416e511c4f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->