### PR TITLE
Allow overlap filters for collections in agent

### DIFF
--- a/.github/workflows/build-r2r-docker.yml
+++ b/.github/workflows/build-r2r-docker.yml
@@ -15,7 +15,7 @@ on:
       - main
 
 env:
-  REGISTRY_BASE: ragtoriches
+  REGISTRY_BASE: sciphiai
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -82,8 +82,8 @@ jobs:
       - name: Docker Auth
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.RAGTORICHES_DOCKER_UNAME }}
-          password: ${{ secrets.RAGTORICHES_DOCKER_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push image
         uses: docker/build-push-action@v5
@@ -106,8 +106,8 @@ jobs:
       - name: Docker Auth
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.RAGTORICHES_DOCKER_UNAME }}
-          password: ${{ secrets.RAGTORICHES_DOCKER_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Create and push multi-arch manifest
         run: |

--- a/docker/compose.full.swarm.yaml
+++ b/docker/compose.full.swarm.yaml
@@ -236,8 +236,7 @@ services:
         condition: on-failure
 
   r2r:
-    image: ${R2R_IMAGE:-ragtoriches/prod:latest}
-    # image: sciphiai/r2r Replace on the next release
+    image: sciphiai/r2r:latest
     ports:
       - "${R2R_PORT:-7272}:${R2R_PORT:-7272}"
     environment:

--- a/docker/compose.full.yaml
+++ b/docker/compose.full.yaml
@@ -160,8 +160,7 @@ services:
       retries: 5
 
   r2r:
-    image: ragtoriches/prod:latest
-    # image: sciphiai/r2r Replace on the next release
+    image: sciphiai/r2r:latest
     ports:
       - "7272:7272"
     env_file:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -23,8 +23,7 @@ services:
       -c max_connections=${R2R_POSTGRES_MAX_CONNECTIONS:-1024}
 
   r2r:
-    image: ${R2R_IMAGE:-ragtoriches/prod:latest}
-    # image: sciphiai/r2r Replace on the next release
+    image: sciphiai/r2r:latest
     ports:
       - "${R2R_PORT:-7272}:${R2R_PORT:-7272}"
     env_file:

--- a/py/core/main/api/v3/retrieval_router.py
+++ b/py/core/main/api/v3/retrieval_router.py
@@ -623,6 +623,7 @@ class RetrievalRouter(BaseRouterV3):
                     ),
                     use_system_context=use_system_context,
                     override_tools=tools,
+                    auth_user=auth_user,
                 )
 
                 if rag_generation_config.stream:

--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -1162,46 +1162,6 @@ class RetrievalService(Service):
 
         return results
 
-    def _parse_user_and_collection_filters(
-        self,
-        filters: dict[str, Any],
-    ):
-        ### TODO - Come up with smarter way to extract owner / collection ids for non-admin
-        filter_starts_with_and = filters.get("$and")
-        filter_starts_with_or = filters.get("$or")
-        if filter_starts_with_and:
-            try:
-                filter_starts_with_and_then_or = filter_starts_with_and[0][
-                    "$or"
-                ]
-
-                user_id = filter_starts_with_and_then_or[0]["owner_id"]["$eq"]
-                collection_ids = filter_starts_with_and_then_or[1][
-                    "collection_ids"
-                ]["$overlap"]
-                return user_id, [str(ele) for ele in collection_ids]
-            except Exception as e:
-                logger.error(
-                    f"Error: {e}.\n\n While"
-                    + """ parsing filters: expected format {'$or': [{'owner_id': {'$eq': 'uuid-string-here'}, 'collection_ids': {'$overlap': ['uuid-of-some-collection']}}]}, if you are a superuser then this error can be ignored."""
-                )
-                return None, []
-        elif filter_starts_with_or:
-            try:
-                user_id = filter_starts_with_or[0]["owner_id"]["$eq"]
-                collection_ids = filter_starts_with_or[1]["collection_ids"][
-                    "$overlap"
-                ]
-                return user_id, [str(ele) for ele in collection_ids]
-            except Exception:
-                logger.error(
-                    """Error parsing filters: expected format {'$or': [{'owner_id': {'$eq': 'uuid-string-here'}, 'collection_ids': {'$overlap': ['uuid-of-some-collection']}}]}, if you are a superuser then this error can be ignored."""
-                )
-                return None, []
-        else:
-            # Admin user
-            return None, []
-
     async def _build_documents_context(
         self,
         filter_user_id: Optional[UUID] = None,

--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -1167,7 +1167,7 @@ class RetrievalService(Service):
         filter_user_id: Optional[UUID] = None,
         filter_collection_ids: Optional[list[UUID]] = None,
         max_summary_length: int = 128,
-        limit: int = 1000,
+        limit: int = 100,
     ) -> str:
         """Fetches documents matching the given filters and returns a formatted
         string enumerating them."""

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "r2r"
-version = "3.4.3"
+version = "3.4.4"
 description = "SciPhi R2R"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Allows for overlap filters for collections when using the agent.

Note: filtering is still a bit scattered, and we really need to review how we handle/build/maintain filters.

```
# type: ignore
from r2r import R2RClient, Message, SearchSettings

client = R2RClient("http://localhost:7272")

search_settings = SearchSettings(
    filters={
        "collection_ids": {
            "$overlap": ["021b6392-05b5-48e3-8f6b-a353eb20dc6b", "4187fde0-497f-493b-8033-407adcaa2dfa"]
        }
    }
)

response = client.retrieval.agent(
    message = Message(
        role="user",
        content="Does they plan to impose a risk penalty as provided by North Dakota law?",
        name=None,
        function_call=None,
        tool_calls=None,
        tool_call_id=None,
        metadata=None,
    ),
    search_settings=search_settings
)
```


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds overlap filters for collections in the agent and updates Docker configurations and versioning.
> 
>   - **Behavior**:
>     - Adds support for `$overlap` operator in `collection_ids` filter in `agent()` in `retrieval_service.py`.
>     - Updates `agent_app()` in `retrieval_router.py` to pass `auth_user` to `agent()`.
>   - **Docker Configurations**:
>     - Changes Docker image references from `ragtoriches` to `sciphiai` in `compose.full.swarm.yaml`, `compose.full.yaml`, and `compose.yaml`.
>     - Updates Docker authentication secrets in `build-r2r-docker.yml`.
>   - **Misc**:
>     - Bumps version to `3.4.4` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for fb34802a9d04ebe72501f9dbdd0c47972fced5b2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->