### PR TITLE
Fix JS Message type

### DIFF
--- a/js/sdk/package-lock.json
+++ b/js/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -73,7 +73,12 @@ export interface ConversationResponse {
 
 export interface Message {
   role: string;
-  content: string;
+  content: any;
+  name?: string;
+  functionCall?: Record<string, any>;
+  toolCalls?: Array<Record<string, any>>;
+  toolCallId?: string;
+  metadata?: Record<string, any>;
 }
 
 export interface MessageResponse {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `Message` interface in `types.ts` to support flexible content types and additional fields, and bump version to `0.4.29`.
> 
>   - **Types**:
>     - Update `Message` interface in `types.ts`:
>       - Change `content` type from `string` to `any`.
>       - Add optional fields: `name`, `functionCall`, `toolCalls`, `toolCallId`, `metadata`.
>   - **Version**:
>     - Update version in `package.json` from `0.4.28` to `0.4.29`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for ae7bd16ce4f0844b56541f802dd04c149841d602. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->