### PR TITLE
Fix use_extended_prompt on sync client

### DIFF
--- a/js/sdk/__tests__/RetrievalIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/RetrievalIntegrationSuperUser.test.ts
@@ -123,6 +123,30 @@ describe("r2rClient V3 Documents Integration Tests", () => {
   //   expect(content.length).toBeGreaterThan(0);
   // }, 30000);
 
+  test("Get an agent answer with a task prompt override", async () => {
+    const overrideMessage = {
+      role: "user" as const,
+      content: "What is the capital of France?",
+    };
+
+    const overridePrompt = "Antworte auf Deutsch.";
+
+    const response = await client.retrieval.agent({
+      message: overrideMessage,
+      taskPromptOverride: overridePrompt,
+      useSystemContext: false,
+    });
+
+    expect(response.results).toBeDefined();
+    expect(response.results.messages.length).toBeGreaterThan(0);
+    expect(response.results.messages[0].role).toBe("assistant");
+    expect(response.results.messages[0].content).toContain("Paris");
+
+    const germanWords = ["Die", "Hauptstadt", "von", "Frankreich", "ist"];
+    const responseText = response.results.messages[0].content;
+    expect(germanWords.some((word) => responseText.includes(word))).toBe(true);
+  }, 30000);
+
   test("List and delete conversations", async () => {
     const listResponse = await client.conversations.list();
     expect(listResponse.results).toBeDefined();

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -121,7 +121,7 @@ line-ending = "auto"
 
 [tool.mypy]
 ignore_missing_imports = true
-exclude = 'core/parsers/media/pyzerox/.*|playground/.*|deprecated/.*|dump/.*|docs/source|vecs/*|core/examples/*|sdk/examples/*|cli/examples/*|tests/*'
+exclude = 'core/parsers/media/pyzerox/.*|playground/.*|deprecated/.*|dump/.*|docs/source|vecs/*|core/examples/*|sdk/examples/*|tests/*'
 
 [[tool.mypy.overrides]]
 module = "yaml"
@@ -143,5 +143,5 @@ packages = { find = { where = [ "." ], include = [ "r2r*", "sdk*", "shared*", "c
 include-package-data = true
 
 [tool.setuptools.package-data]
-core = ["configs/*.toml"]
+core = ["configs/*.toml", "providers/database/prompts/*.yaml"]
 r2r = ["r2r.toml"]

--- a/py/sdk/sync_methods/retrieval.py
+++ b/py/sdk/sync_methods/retrieval.py
@@ -173,7 +173,7 @@ class RetrievalSDK:
         conversation_id: Optional[str | uuid.UUID] = None,
         tools: Optional[list[dict]] = None,
         max_tool_context_length: Optional[int] = None,
-        use_extended_prompt: Optional[bool] = True,
+        use_system_context: Optional[bool] = True,
     ) -> WrappedAgentResponse | AsyncGenerator[Message, None]:
         """Performs a single turn in a conversation with a RAG agent.
 
@@ -203,7 +203,7 @@ class RetrievalSDK:
             ),
             "tools": tools,
             "max_tool_context_length": max_tool_context_length,
-            "use_extended_prompt": use_extended_prompt,
+            "use_system_context": use_system_context,
         }
         if search_mode:
             data["search_mode"] = search_mode


### PR DESCRIPTION
Closes #2029

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `agent()` in `retrieval.py` by replacing `use_extended_prompt` with `use_system_context` and add a test for task prompt override.
> 
>   - **Behavior**:
>     - Fix `agent()` in `retrieval.py` by replacing `use_extended_prompt` with `use_system_context`.
>     - Add test case in `RetrievalIntegrationSuperUser.test.ts` to verify agent response with task prompt override in German.
>   - **Configuration**:
>     - Update `pyproject.toml` to include `providers/database/prompts/*.yaml` in package data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 12c3f61dad79f0dd549d5a4ed3b507de6bcf99e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->