### PR TITLE
Fix graph clustering to be remote only

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -22,6 +22,14 @@ services:
       postgres
       -c max_connections=1024
 
+  unstructured:
+    image: ragtoriches/unst-prod
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7275/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   r2r:
     image: sciphiai/r2r:latest
     ports:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -22,16 +22,18 @@ services:
       postgres
       -c max_connections=1024
 
-  unstructured:
-    image: ragtoriches/unst-prod
+  graph_clustering:
+    image: ragtoriches/cluster-prod
+    ports:
+      - "7276:7276"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7275/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:7276/health"]
       interval: 10s
       timeout: 5s
       retries: 5
 
   r2r:
-    image: sciphiai/r2r:latest
+    image: r2r/test
     ports:
       - "7272:7272"
     env_file:

--- a/llms.txt
+++ b/llms.txt
@@ -11042,7 +11042,6 @@ default_collection_description = "Your default collection."
 batch_size = 256
 
   [database.graph_creation_settings]
-    clustering_mode = "local"
     graph_entity_description_prompt = "graph_entity_description"
     entity_types = []
     relation_types = []

--- a/py/core/configs/full.toml
+++ b/py/core/configs/full.toml
@@ -2,10 +2,6 @@
 provider = "litellm"
 concurrent_request_limit = 128
 
-[database]
-  [database.graph_creation_settings]
-    clustering_mode = "remote"
-
 [ingestion]
 provider = "unstructured_local"
 strategy = "auto"

--- a/py/core/main/services/graph_service.py
+++ b/py/core/main/services/graph_service.py
@@ -634,13 +634,9 @@ class GraphService(Service):
     ) -> dict:
         """The actual clustering logic (previously in
         GraphClusteringPipe.cluster_graph_search_results)."""
-        clustering_mode = (
-            self.config.database.graph_creation_settings.clustering_mode
-        )
         num_communities = await self.providers.database.graphs_handler.perform_graph_clustering(
             collection_id=collection_id,
             leiden_params=leiden_params,
-            clustering_mode=clustering_mode,
         )
         return {"num_communities": num_communities}
 
@@ -714,9 +710,6 @@ class GraphService(Service):
         )
 
         # We can optionally re-run the clustering to produce fresh community assignments
-        clustering_mode = (
-            self.config.database.graph_creation_settings.clustering_mode
-        )
         (
             _,
             community_clusters,
@@ -724,22 +717,13 @@ class GraphService(Service):
             relationships=all_relationships,
             leiden_params=leiden_params,
             collection_id=collection_id,
-            clustering_mode=clustering_mode,
         )
 
         # Group clusters
         clusters: dict[Any, list[str]] = {}
         for item in community_clusters:
-            # item is either a dict (remote) or an object (local)
-            # unify logic accordingly
-            cluster_id = (
-                item["cluster"]
-                if clustering_mode == "remote"
-                else item.cluster
-            )
-            node_name = (
-                item["node"] if clustering_mode == "remote" else item.node
-            )
+            cluster_id = item["cluster"]
+            node_name = item["node"]
             clusters.setdefault(cluster_id, []).append(node_name)
 
         # create an async job for each cluster

--- a/py/shared/abstractions/graph.py
+++ b/py/shared/abstractions/graph.py
@@ -148,11 +148,6 @@ class StoreType(str, Enum):
 class GraphCreationSettings(R2RSerializable):
     """Settings for knowledge graph creation."""
 
-    clustering_mode: str = Field(
-        default="local",
-        description="Whether to use remote clustering for graph creation.",
-    )
-
     graph_extraction_prompt: str = Field(
         default="graph_extraction",
         description="The prompt to use for knowledge graph extraction.",

--- a/py/tests/unit/test_config.py
+++ b/py/tests/unit/test_config.py
@@ -70,9 +70,6 @@ def merged_config(base_config, full_config):
 
 def test_base_config_loading(base_config):
     """Test that the base config loads correctly with the new expected values.
-
-    (For example, the old 'clustering_mode' key is gone, and now we check that
-    keys like 'graph_entity_description_prompt' are present.)
     """
     config = R2RConfig(base_config)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR removes local clustering logic, enforcing remote-only graph clustering, and updates configurations and services accordingly.
> 
>   - **Behavior**:
>     - Removed `clustering_mode` from `graph_service.py`, `graphs.py`, and `full.toml`, enforcing remote-only clustering.
>     - Updated `docker/compose.yaml` to add `graph_clustering` service with health check.
>   - **Configuration**:
>     - Removed `clustering_mode` from `GraphCreationSettings` in `graph.py`.
>     - Updated `full.toml` to remove `clustering_mode` setting.
>   - **Code Simplification**:
>     - Removed local clustering logic from `_create_graph_and_cluster()` and `_cluster_and_add_community_info()` in `graphs.py`.
>     - Simplified `_perform_graph_clustering()` and `_summarize_communities()` in `graph_service.py` by removing local mode handling.
>   - **Testing**:
>     - Updated `test_config.py` to remove references to `clustering_mode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 7513277844aed0d9086d3f73d78b0781d5e87890. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->