### PR TITLE
fix: use pg_largeobject_metadata table to verify if file exists

### DIFF
--- a/py/core/providers/database/files.py
+++ b/py/core/providers/database/files.py
@@ -217,7 +217,7 @@ class PostgresFilesHandler(Handler):
         async with conn.transaction():
             try:
                 lo_exists = await conn.fetchval(
-                    "SELECT EXISTS(SELECT 1 FROM pg_largeobject WHERE loid = $1)",
+                    "SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_largeobject_metadata WHERE oid = $1);",
                     oid,
                 )
                 if not lo_exists:


### PR DESCRIPTION
This PR updates the SQL query used to check the existence of large objects in PostgreSQL. Previously, the query referenced `pg_largeobject`, which requires superuser privileges. The updated query now checks `pg_largeobject_metadata`, allowing non-superuser users to run R2R successfully.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update SQL query in `files.py` to use `pg_largeobject_metadata` for non-superuser large object existence checks.
> 
>   - **Behavior**:
>     - Update SQL query in `_read_lobject` in `files.py` to use `pg_largeobject_metadata` instead of `pg_largeobject` for checking large object existence.
>     - Allows non-superuser users to verify large object existence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 30aac0ace5030f0a4295a7808d4b7c03b07cac13. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->