### PR TITLE
feat: update fastapi

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "aiofiles >=24.1.0,<25.0.0",
     "alembic >=1.13.3,<2.0.0",
-    "fastapi >=0.114.0,<0.115.0",
+    "fastapi >=0.115.11,<0.116.0",
     "httpx >=0.27.0,<0.28.0",
     "openai >=1.11.1,<2.0.0",
     "posthog >=3.5.0,<4.0.0",


### PR DESCRIPTION
Unfortunately `fastapi` is part of the SDK dependency which forced us to downgrade. This PR updates the dependency range.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `fastapi` version range in `pyproject.toml` to `>=0.115.11,<0.116.0`.
> 
>   - **Dependencies**:
>     - Update `fastapi` version range in `pyproject.toml` from `>=0.114.0,<0.115.0` to `>=0.115.11,<0.116.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for dd86bcc773cebcf6b7180c2fbe9b697400dbcbba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->