### PR TITLE
Check raw file size, not the size of base64 encoded content

### DIFF
--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -2171,11 +2171,10 @@ class DocumentsRouter(BaseRouterV3):
         import base64
 
         content = await file.read()
-        content_length = len(content)
 
         return {
             "filename": file.filename,
             "content": base64.b64encode(content).decode("utf-8"),
             "content_type": file.content_type,
-            "content_length": content_length,
+            "content_length": len(content),
         }

--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -453,7 +453,6 @@ class DocumentsRouter(BaseRouterV3):
             else:
                 if file:
                     file_data = await self._process_file(file)
-                    content_length = len(file_data["content"])
 
                     if not file.filename:
                         raise R2RException(
@@ -468,7 +467,7 @@ class DocumentsRouter(BaseRouterV3):
                         user_id=auth_user.id, file_type_or_ext=file_ext
                     )
 
-                    if content_length > max_allowed_size:
+                    if file_data["content_length"] > max_allowed_size:
                         raise R2RException(
                             status_code=413,  # HTTP 413: Payload Too Large
                             message=(
@@ -476,6 +475,8 @@ class DocumentsRouter(BaseRouterV3):
                                 f"for extension '{file_ext}'."
                             ),
                         )
+
+                    content_length = file_data["content_length"]
 
                     file_content = BytesIO(
                         base64.b64decode(file_data["content"])
@@ -2170,8 +2171,11 @@ class DocumentsRouter(BaseRouterV3):
         import base64
 
         content = await file.read()
+        content_length = len(content)
+
         return {
             "filename": file.filename,
             "content": base64.b64encode(content).decode("utf-8"),
             "content_type": file.content_type,
+            "content_length": content_length,
         }

--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -467,7 +467,9 @@ class DocumentsRouter(BaseRouterV3):
                         user_id=auth_user.id, file_type_or_ext=file_ext
                     )
 
-                    if file_data["content_length"] > max_allowed_size:
+                    content_length = file_data["content_length"]
+
+                    if content_length > max_allowed_size:
                         raise R2RException(
                             status_code=413,  # HTTP 413: Payload Too Large
                             message=(
@@ -475,8 +477,6 @@ class DocumentsRouter(BaseRouterV3):
                                 f"for extension '{file_ext}'."
                             ),
                         )
-
-                    content_length = file_data["content_length"]
 
                     file_content = BytesIO(
                         base64.b64decode(file_data["content"])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Check raw file size instead of base64 encoded size in `create_document` to ensure accurate file size validation.
> 
>   - **Behavior**:
>     - In `create_document`, file size is now checked using raw file size (`content_length`) instead of base64 encoded size.
>     - Raises `R2RException` if raw file size exceeds `max_allowed_size`.
>   - **Functions**:
>     - `_process_file` now returns `content_length` as the length of raw content.
>     - Removed calculation of `content_length` from base64 encoded content in `create_document`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 1f048d0df0a5f102fdaf425225091690644d6e99. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->