### PR TITLE
Fix: Convert the selected collection id to UUID type.

### DIFF
--- a/py/shared/abstractions/search.py
+++ b/py/shared/abstractions/search.py
@@ -580,7 +580,7 @@ def select_search_filters(
         user_collections = set(auth_user.collection_ids)
         for key in filters.keys():
             if "collection_ids" in key:
-                selected_collections = set(filters[key]["$overlap"])
+                selected_collections = set(map(UUID, filters[key]["$overlap"]))
                 break
 
         if selected_collections:


### PR DESCRIPTION
## Description
Fixed an issue in the select_search_filters function where the collection ID list passed by search_settings would end up empty upon return.

The issue occurred because the elements in user_collections were of type UUID, while the elements in selected_collections were of type str, resulting in incorrect results when using the set function's intersection method.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes type mismatch in `select_search_filters()` by converting `collection_ids` to `UUID` type for correct set operations.
> 
>   - **Behavior**:
>     - Fixes type mismatch in `select_search_filters()` in `search.py` by converting `collection_ids` to `UUID` type using `map(UUID, ...)`.
>     - Ensures correct intersection of `user_collections` and `selected_collections`.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for f1055f8fcd6a5cacfaffbc388f1d5bac1a3c501d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->