### PR TITLE
compose.yaml R2R service image name fix

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -33,7 +33,7 @@ services:
       retries: 5
 
   r2r:
-    image: r2r/test
+    image: sciphiai/r2r:latest
     ports:
       - "7272:7272"
     env_file:


### PR DESCRIPTION
Previously was the image for R2R was pointing to `r2r/test` this image did not exist. 

This changed it to 'sciphiai/r2r:latest' which is current the R2R path.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes image name for `r2r` service in `compose.yaml` to `sciphiai/r2r:latest`.
> 
>   - **Behavior**:
>     - Fixes image name for `r2r` service in `compose.yaml` from `r2r/test` to `sciphiai/r2r:latest` to use the correct existing image.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 111b8a4bd6e796b4158f0671fe90e6885e64888d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->