### PR TITLE
Temp fix: Anthropic VLM

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "r2r"
-version = "3.5.0"
+version = "3.5.1"
 description = "SciPhi R2R"
 readme = "README.md"
 license = {text = "MIT"}

--- a/py/r2r/serve.py
+++ b/py/r2r/serve.py
@@ -33,7 +33,9 @@ async def create_app(
     config_path = config_path or os.getenv("R2R_CONFIG_PATH")
 
     if config_path and config_name:
-        raise ValueError("Cannot specify both config_path and config_name")
+        raise ValueError(
+            f"Cannot specify both config_path and config_name, got {config_path} and {config_name}"
+        )
 
     if not config_path and not config_name:
         # If neither is specified nor set in environment,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Temporary fix for Anthropic model handling in `VLMPDFParser`, version bump to 3.5.1, and improved error message in `serve.py`.
> 
>   - **Behavior**:
>     - Temporary fix in `process_page()` in `pdf_parser.py` to handle Anthropic models by checking if the model string contains "anthropic/" and adjusting the message format accordingly.
>     - If Anthropic model, uses base64 image format; otherwise, uses OpenAI image URL format.
>   - **Versioning**:
>     - Bump version from `3.5.0` to `3.5.1` in `pyproject.toml`.
>   - **Error Handling**:
>     - Improved error message in `create_app()` in `serve.py` to include both `config_path` and `config_name` values when both are specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for c8376af23ee4d8d7e9397d3cc571d71a4f9fa5aa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->