### PR TITLE
Don't reference core in SDK

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "r2r"
-version = "3.5.2"
+version = "3.5.3"
 description = "SciPhi R2R"
 readme = "README.md"
 license = {text = "MIT"}

--- a/py/r2r/__init__.py
+++ b/py/r2r/__init__.py
@@ -1,16 +1,6 @@
 from importlib import metadata
 
 from sdk.async_client import R2RAsyncClient
-from sdk.models import (
-    CitationEvent,
-    FinalAnswerEvent,
-    MessageEvent,
-    R2RException,
-    SearchResultsEvent,
-    ThinkingEvent,
-    ToolCallEvent,
-    ToolResultEvent,
-)
 from sdk.sync_client import R2RClient
 from shared import *
 
@@ -21,13 +11,6 @@ __all__ = [
     "R2RClient",
     "__version__",
     "R2RException",
-    "CitationEvent",
-    "ThinkingEvent",
-    "ToolCallEvent",
-    "ToolResultEvent",
-    "FinalAnswerEvent",
-    "MessageEvent",
-    "SearchResultsEvent",
 ]
 
 

--- a/py/sdk/models.py
+++ b/py/sdk/models.py
@@ -25,6 +25,7 @@ from shared.abstractions.graph import (
     GraphEnrichmentSettings,
 )
 from shared.api.models import (
+    AgentEvent,
     AgentResponse,
     Citation,
     CitationData,
@@ -33,6 +34,7 @@ from shared.api.models import (
     DeltaPayload,
     FinalAnswerData,
     FinalAnswerEvent,
+    MessageData,
     MessageDelta,
     MessageEvent,
     RAGResponse,
@@ -73,10 +75,12 @@ __all__ = [
     # "RAGResponse",
     "Citation",
     "RAGResponse",
+    "AgentEvent",
     "AgentResponse",
     "SSEEventBase",
     "SearchResultsData",
     "SearchResultsEvent",
+    "MessageData",
     "MessageDelta",
     "MessageEvent",
     "DeltaPayload",

--- a/py/sdk/sync_methods/retrieval.py
+++ b/py/sdk/sync_methods/retrieval.py
@@ -2,26 +2,7 @@ import json
 import uuid
 from typing import Any, Generator, Optional
 
-from core.base.api.models import (
-    AgentEvent,
-    CitationData,
-    CitationEvent,
-    Delta,
-    DeltaPayload,
-    FinalAnswerData,
-    FinalAnswerEvent,
-    MessageData,
-    MessageDelta,
-    MessageEvent,
-    SearchResultsData,
-    SearchResultsEvent,
-    ThinkingData,
-    ThinkingEvent,
-    ToolCallData,
-    ToolCallEvent,
-    ToolResultData,
-    ToolResultEvent,
-    UnknownEvent,
+from shared.api.models import (
     WrappedAgentResponse,
     WrappedEmbeddingResponse,
     WrappedLLMChatCompletion,
@@ -30,10 +11,29 @@ from core.base.api.models import (
 )
 
 from ..models import (
+    AgentEvent,
+    CitationData,
+    CitationEvent,
+    Delta,
+    DeltaPayload,
+    FinalAnswerData,
+    FinalAnswerEvent,
     GenerationConfig,
     Message,
+    MessageData,
+    MessageDelta,
+    MessageEvent,
     SearchMode,
+    SearchResultsData,
+    SearchResultsEvent,
     SearchSettings,
+    ThinkingData,
+    ThinkingEvent,
+    ToolCallData,
+    ToolCallEvent,
+    ToolResultData,
+    ToolResultEvent,
+    UnknownEvent,
 )
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `core` references in SDK and update version to 3.5.3.
> 
>   - **Imports**:
>     - Remove imports of `CitationEvent`, `FinalAnswerEvent`, `MessageEvent`, `R2RException`, `SearchResultsEvent`, `ThinkingEvent`, `ToolCallEvent`, `ToolResultEvent` from `r2r/__init__.py`.
>     - Change import source from `core.base.api.models` to `shared.api.models` in `sdk/sync_methods/retrieval.py`.
>   - **Versioning**:
>     - Increment version in `pyproject.toml` from `3.5.2` to `3.5.3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 215d2847ce61e03c71190d3a9a08f8185809cd58. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->