### PR TITLE
Add package installation test

### DIFF
--- a/.github/workflows/r2r-light-py-integration-tests.yml
+++ b/.github/workflows/r2r-light-py-integration-tests.yml
@@ -48,6 +48,7 @@ jobs:
           exit 1
 
   integration-test:
+    needs: package-install-test
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -145,6 +146,7 @@ jobs:
           exit 1
 
   integration-test-gemini:
+    needs: package-install-test
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/r2r-light-py-integration-tests.yml
+++ b/.github/workflows/r2r-light-py-integration-tests.yml
@@ -20,6 +20,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  package-install-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install package and test import
+        run: |
+          cd py
+          pip install -e .
+          python -c "from r2r import R2RClient; print('Import successful!')"
+
+      - name: Check for import errors
+        if: failure()
+        run: |
+          echo "::error::Package installation or import test failed."
+          exit 1
+
   integration-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `package-install-test` job to GitHub Actions to verify package installation and import before integration tests.
> 
>   - **New Job**:
>     - Adds `package-install-test` job to `.github/workflows/r2r-light-py-integration-tests.yml`.
>     - Runs on `ubuntu-latest` with a 5-minute timeout.
>     - Checks out code, sets up Python 3.12, installs the package, and tests import of `R2RClient`.
>     - Logs error and exits if package installation or import fails.
>   - **Integration Tests**:
>     - `integration-test` and `integration-test-gemini` jobs now depend on `package-install-test` to ensure package is installed correctly before running.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 4870cd4e5cfb80cf58f881dc15717b439853ae32. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->