### PR TITLE
fix collection ids filter logic

### DIFF
--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -1774,9 +1774,12 @@ class RetrievalService(Service):
                 ]
 
                 user_id = filter_starts_with_and_then_or[0]["owner_id"]["$eq"]
-                collection_ids = filter_starts_with_and_then_or[1][
-                    "collection_ids"
-                ]["$overlap"]
+                collection_ids = [
+                    UUID(ele)
+                    for ele in filter_starts_with_and_then_or[1][
+                        "collection_ids"
+                    ]["$overlap"]
+                ]
                 return user_id, [str(ele) for ele in collection_ids]
             except Exception as e:
                 logger.error(
@@ -1787,8 +1790,11 @@ class RetrievalService(Service):
         elif filter_starts_with_or:
             try:
                 user_id = filter_starts_with_or[0]["owner_id"]["$eq"]
-                collection_ids = filter_starts_with_or[1]["collection_ids"][
-                    "$overlap"
+                collection_ids = [
+                    UUID(ele)
+                    for ele in filter_starts_with_or[1]["collection_ids"][
+                        "$overlap"
+                    ]
                 ]
                 return user_id, [str(ele) for ele in collection_ids]
             except Exception as e:

--- a/py/core/providers/database/chunks.py
+++ b/py/core/providers/database/chunks.py
@@ -422,7 +422,6 @@ class PostgresChunksHandler(Handler):
             OFFSET ${len(params) + 2}
             """
             params.extend([search_settings.limit, search_settings.offset])
-
         results = await self.connection_manager.fetch_query(query, params)
 
         return [

--- a/py/sdk/sync_methods/prompts.py
+++ b/py/sdk/sync_methods/prompts.py
@@ -101,7 +101,7 @@ class PromptsSDK:
         if template:
             data["template"] = template
         if input_types:
-            data["input_types"] = json.dumps(input_types)
+            data["input_types"] = input_types
         response_dict = self.client._make_request(
             "PUT",
             f"prompts/{name}",

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -2984,7 +2984,7 @@ wheels = [
 
 [[package]]
 name = "r2r"
-version = "3.5.0"
+version = "3.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -2997,6 +2997,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-json-logger" },
     { name = "requests" },
+    { name = "tiktoken" },
     { name = "toml" },
     { name = "types-aiofiles" },
     { name = "types-requests" },
@@ -3055,7 +3056,6 @@ core = [
     { name = "sqlalchemy" },
     { name = "striprtf" },
     { name = "supabase" },
-    { name = "tiktoken" },
     { name = "tokenizers" },
     { name = "unstructured-client" },
     { name = "uvicorn" },
@@ -3151,7 +3151,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'core'", specifier = ">=2.0.30,<3.0.0" },
     { name = "striprtf", marker = "extra == 'core'", specifier = ">=0.0.28,<0.0.29" },
     { name = "supabase", marker = "extra == 'core'", specifier = ">=2.7.4,<3.0.0" },
-    { name = "tiktoken", marker = "extra == 'core'", specifier = ">=0.8.0,<0.9.0" },
+    { name = "tiktoken", specifier = ">=0.8.0,<0.9.0" },
     { name = "tokenizers", marker = "extra == 'core'", specifier = "==0.19" },
     { name = "toml", specifier = ">=0.10.2,<0.11.0" },
     { name = "types-aiofiles", specifier = ">=24.1.0.20240626,<25.0.0" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix collection ID filter logic by ensuring UUIDs are correctly handled and add tests to verify functionality.
> 
>   - **Filter Logic Fixes**:
>     - In `retrieval_service.py`, convert collection IDs to UUIDs before processing.
>     - In `filters.py`, update `_build_collection_id_condition()` to use array operators for UUID comparisons.
>   - **Tests**:
>     - Add `test_collection_id_filters()` in `test_retrieval.py` to verify collection ID filtering logic.
>   - **Miscellaneous**:
>     - Remove unnecessary line in `chunks.py`.
>     - Update `r2r` version to `3.5.3` in `uv.lock` and adjust dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 581d075b9aac3fba8e12bd0e6d412cd159d1eefc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->