### PR TITLE
Remove vision_img_model and vision_pdf_model

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -11085,8 +11085,6 @@ chunk_size = 1024
 chunk_overlap = 512
 excluded_parsers = ["mp4"]
 document_summary_model = "openai/gpt-4o-mini"
-vision_img_model = "openai/gpt-4o"
-vision_pdf_model = "openai/gpt-4o"
 
   [ingestion.chunk_enrichment_settings]
     enable_chunk_enrichment = false

--- a/py/all_possible_config.toml
+++ b/py/all_possible_config.toml
@@ -228,9 +228,7 @@ automatic_extraction = true
 # Audio transcription and vision model settings
 audio_transcription_model = ""
 vision_img_prompt_name = "vision_img"
-vision_img_model = ""
 vision_pdf_prompt_name = "vision_pdf"
-vision_pdf_model = ""
 skip_document_summary = false
 document_summary_system_prompt = "system"
 document_summary_task_prompt = "summary"

--- a/py/core/base/providers/ingestion.py
+++ b/py/core/base/providers/ingestion.py
@@ -40,9 +40,7 @@ class IngestionConfig(ProviderConfig):
         "extra_parsers": {},
         "audio_transcription_model": None,
         "vision_img_prompt_name": "vision_img",
-        "vision_img_model": None,
         "vision_pdf_prompt_name": "vision_pdf",
-        "vision_pdf_model": None,
         "skip_document_summary": False,
         "document_summary_system_prompt": "system",
         "document_summary_task_prompt": "summary",
@@ -84,16 +82,10 @@ class IngestionConfig(ProviderConfig):
             "vision_img_prompt_name"
         ]
     )
-    vision_img_model: Optional[str] = Field(
-        default_factory=lambda: IngestionConfig._defaults["vision_img_model"]
-    )
     vision_pdf_prompt_name: str = Field(
         default_factory=lambda: IngestionConfig._defaults[
             "vision_pdf_prompt_name"
         ]
-    )
-    vision_pdf_model: Optional[str] = Field(
-        default_factory=lambda: IngestionConfig._defaults["vision_pdf_model"]
     )
     skip_document_summary: bool = Field(
         default_factory=lambda: IngestionConfig._defaults[

--- a/py/core/configs/full_azure.toml
+++ b/py/core/configs/full_azure.toml
@@ -31,8 +31,6 @@ max_characters = 4_096
 combine_under_n_chars = 1_024
 overlap = 1_024
 document_summary_model = "azure/gpt-4o-mini"
-vision_img_model = "azure/gpt-4o"
-vision_pdf_model = "azure/gpt-4o"
 automatic_extraction = true # enable automatic extraction of entities and relations
 
   [ingestion.extra_parsers]

--- a/py/core/parsers/media/img_parser.py
+++ b/py/core/parsers/media/img_parser.py
@@ -109,7 +109,7 @@ class ImageParser(AsyncParser[str | bytes]):
                 image_data = data
 
             generation_config = GenerationConfig(
-                model=self.config.vision_img_model or self.config.app.vlm,
+                model=self.config.app.vlm,
                 stream=False,
             )
 

--- a/py/core/parsers/media/pdf_parser.py
+++ b/py/core/parsers/media/pdf_parser.py
@@ -93,11 +93,11 @@ class VLMPDFParser(AsyncParser[str | bytes]):
             image_data = buf.read()
             image_base64 = base64.b64encode(image_data).decode("utf-8")
 
-            model = self.config.vision_pdf_model or self.config.app.vlm
+            model = self.config.app.vlm
 
             # Configure generation parameters
             generation_config = GenerationConfig(
-                model=self.config.vision_pdf_model or self.config.app.vlm,
+                model=self.config.app.vlm,
                 stream=False,
             )
 

--- a/py/core/parsers/structured/tiff_parser.py
+++ b/py/core/parsers/structured/tiff_parser.py
@@ -70,7 +70,7 @@ class TIFFParser(AsyncParser[str | bytes]):
 
             # Use vision model to analyze image
             generation_config = GenerationConfig(
-                model=self.config.vision_img_model or self.config.app.vlm,
+                model=self.config.app.vlm,
                 stream=False,
             )
 

--- a/py/shared/abstractions/document.py
+++ b/py/shared/abstractions/document.py
@@ -319,10 +319,8 @@ class IngestionConfig(R2RSerializable):
     audio_transcription_model: str = ""
 
     vision_img_prompt_name: str = "vision_img"
-    vision_img_model: str = ""
 
     vision_pdf_prompt_name: str = "vision_pdf"
-    vision_pdf_model: str = ""
 
     skip_document_summary: bool = False
     document_summary_system_prompt: str = "system"
@@ -350,9 +348,7 @@ class IngestionConfig(R2RSerializable):
                 extra_parsers={},
                 audio_transcription_model="",
                 vision_img_prompt_name="vision_img",
-                vision_img_model="",
                 vision_pdf_prompt_name="vision_pdf",
-                vision_pdf_model="",
                 skip_document_summary=False,
                 document_summary_system_prompt="system",
                 document_summary_task_prompt="summary",
@@ -369,9 +365,7 @@ class IngestionConfig(R2RSerializable):
                 extra_parsers={},
                 audio_transcription_model="",
                 vision_img_prompt_name="vision_img",
-                vision_img_model="",
                 vision_pdf_prompt_name="vision_pdf",
-                vision_pdf_model="",
                 skip_document_summary=True,  # skip summaries
                 document_summary_system_prompt="system",
                 document_summary_task_prompt="summary",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `vision_img_model` and `vision_pdf_model` configurations, updating parsers to use `vlm` from `app` configuration.
> 
>   - **Configuration Changes**:
>     - Remove `vision_img_model` and `vision_pdf_model` from `llms.txt`, `all_possible_config.toml`, and `full_azure.toml`.
>     - Update `IngestionConfig` in `ingestion.py` to remove `vision_img_model` and `vision_pdf_model` fields.
>   - **Parser Updates**:
>     - Modify `img_parser.py`, `pdf_parser.py`, and `tiff_parser.py` to use `self.config.app.vlm` instead of `vision_img_model` or `vision_pdf_model`.
>   - **Miscellaneous**:
>     - Remove `vision_img_model` and `vision_pdf_model` from `document.py` and update related logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 9f65427e6350787e7a5af6c8e37d8689474547b8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->