### PR TITLE
Feature/improve auto naming logic

### DIFF
--- a/js/sdk/src/v3/clients/retrieval.ts
+++ b/js/sdk/src/v3/clients/retrieval.ts
@@ -167,6 +167,7 @@ export class RetrievalClient {
    * @param maxToolContextLength Maximum context length for tool replies
    * @param useSystemContext Use system context for generation
    * @param mode Mode to use, either "rag" or "research"
+   * @param needsInitialConversationName Whether the conversation needs an initial name
    * @returns
    */
   async agent(options: {
@@ -184,6 +185,7 @@ export class RetrievalClient {
     researchTools?: Array<string>;
     useSystemContext?: boolean;
     mode?: "rag" | "research";
+    needsInitialConversationName?: boolean;
   }): Promise<any | ReadableStream<Uint8Array>> {
     const data: Record<string, any> = {
       message: options.message,
@@ -227,6 +229,9 @@ export class RetrievalClient {
       }),
       ...(options.mode && {
         mode: options.mode,
+      }),
+      ...(options.needsInitialConversationName && {
+        needsInitialConversationName: options.needsInitialConversationName,
       }),
     };
 

--- a/py/core/main/api/v3/retrieval_router.py
+++ b/py/core/main/api/v3/retrieval_router.py
@@ -424,6 +424,10 @@ class RetrievalRouter(BaseRouterV3):
                 default="rag",
                 description="Mode to use for generation: 'rag' for standard retrieval or 'research' for deep analysis with reasoning capabilities",
             ),
+            needs_initial_conversation_name: Optional[bool] = Body(
+                default=None,
+                description="If true, the system will automatically assign a conversation name if not already specified previously.",
+            ),
             auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedAgentResponse:
             """
@@ -478,6 +482,7 @@ class RetrievalRouter(BaseRouterV3):
 
             Maintain context across multiple turns by including `conversation_id` in each request.
             After your first call, store the returned `conversation_id` and include it in subsequent calls.
+            If no conversation name has already been set for the conversation, the system will automatically assign one.
 
             """
             # Handle backward compatibility for task_prompt
@@ -525,6 +530,7 @@ class RetrievalRouter(BaseRouterV3):
                     rag_tools=rag_tools,  # type: ignore
                     research_tools=research_tools,  # type: ignore
                     mode=mode,
+                    needs_initial_conversation_name=needs_initial_conversation_name,
                 )
 
                 if effective_generation_config.stream:

--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -1648,10 +1648,6 @@ class RetrievalService(Service):
                 )
 
                 # Generate conversation name if needed
-                print(
-                    "needs_initial_conversation_name  = ",
-                    needs_initial_conversation_name,
-                )
                 if needs_initial_conversation_name:
                     conversation_name = None
                     try:

--- a/py/core/main/services/retrieval_service.py
+++ b/py/core/main/services/retrieval_service.py
@@ -1387,10 +1387,14 @@ class RetrievalService(Service):
                     )
                     if needs_initial_conversation_name is None:
                         overview = await self.providers.database.conversations_handler.get_conversations_overview(
+                            offset=0,
+                            limit=1,
                             conversation_ids=[conversation_id],
                         )
                         if overview.get("total_entries", 0) > 0:
-                            needs_initial_conversation_name = overview.results[0].get("name") is None
+                            needs_initial_conversation_name = (
+                                overview.get("results")[0].get("name") is None  # type: ignore
+                            )
                 except Exception as e:
                     logger.error(f"Error fetching conversation: {str(e)}")
 
@@ -1644,6 +1648,10 @@ class RetrievalService(Service):
                 )
 
                 # Generate conversation name if needed
+                print(
+                    "needs_initial_conversation_name  = ",
+                    needs_initial_conversation_name,
+                )
                 if needs_initial_conversation_name:
                     conversation_name = None
                     try:

--- a/py/sdk/sync_methods/retrieval.py
+++ b/py/sdk/sync_methods/retrieval.py
@@ -238,6 +238,7 @@ def agent_arg_parser(
     research_tools: Optional[list[str]] = None,
     tools: Optional[list[str]] = None,  # For backward compatibility
     mode: Optional[str] = "rag",
+    needs_initial_conversation_name: Optional[bool] = None,
 ) -> dict:
     if rag_generation_config and not isinstance(rag_generation_config, dict):
         rag_generation_config = rag_generation_config.model_dump()
@@ -273,6 +274,11 @@ def agent_arg_parser(
 
     if search_mode:
         data["search_mode"] = search_mode
+
+    if needs_initial_conversation_name:
+        data["needs_initial_conversation_name"] = (
+            needs_initial_conversation_name
+        )
 
     if message:
         cast_message: Message = (
@@ -441,6 +447,7 @@ class RetrievalSDK:
         research_tools: Optional[list[str]] = None,
         tools: Optional[list[str]] = None,  # For backward compatibility
         mode: Optional[str] = "rag",
+        needs_initial_conversation_name: Optional[bool] = None,
     ) -> (
         WrappedAgentResponse
         | Generator[
@@ -496,6 +503,7 @@ class RetrievalSDK:
             research_tools=research_tools,
             tools=tools,
             mode=mode,
+            needs_initial_conversation_name=needs_initial_conversation_name,
         )
 
         # Determine if streaming is enabled


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logic to automatically name new conversations after the first agent interaction and preserve existing names during interactions.
> 
>   - **Behavior**:
>     - Adds `needsInitialConversationName` parameter to `agent()` in `retrieval.ts` to determine if a conversation needs an initial name.
>     - Updates `agent_app()` in `retrieval_router.py` to handle `needs_initial_conversation_name` parameter.
>     - Modifies `agent()` in `retrieval_service.py` to check and set conversation names if `needs_initial_conversation_name` is true.
>   - **Tests**:
>     - Adds `test_new_conversation_gets_named_after_first_agent_interaction()` in `test_conversations.py` to verify new conversations are named after first interaction.
>     - Adds `test_existing_named_conversation_preserves_name_after_agent_interaction()` in `test_conversations.py` to ensure existing names are preserved.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for fb21b83136eb018db6f20facc264d20ade5df93a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->