### PR TITLE
Add ability to set API key for JS client

### DIFF
--- a/js/sdk/src/baseClient.ts
+++ b/js/sdk/src/baseClient.ts
@@ -1,8 +1,8 @@
 import axios, {
   AxiosInstance,
-  Method,
-  AxiosResponse,
   AxiosRequestConfig,
+  AxiosResponse,
+  Method,
 } from "axios";
 import FormData from "form-data";
 import { ensureCamelCase } from "./utils";
@@ -238,5 +238,10 @@ export abstract class BaseClient {
   setTokens(accessToken: string, refreshToken: string): void {
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
+  }
+
+  setApiKey(apiKey: string): void {
+    if (!apiKey) throw new Error("API key is required");
+    this.apiKey = apiKey;
   }
 }

--- a/js/sdk/src/r2rClient.ts
+++ b/js/sdk/src/r2rClient.ts
@@ -1,4 +1,4 @@
-import axios, { Method, AxiosError } from "axios";
+import axios, { AxiosError, Method } from "axios";
 import { BaseClient } from "./baseClient";
 
 import { ChunksClient } from "./v3/clients/chunks";


### PR DESCRIPTION
Add method to `BaseClient` that allows setting an API key through the javascript client; to allow API key-based auth
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `setApiKey` method to `BaseClient` for API key-based authentication in `baseClient.ts`.
> 
>   - **Behavior**:
>     - Add `setApiKey(apiKey: string)` method to `BaseClient` in `baseClient.ts` for setting API key for authentication.
>     - Throws error if `apiKey` is not provided.
>   - **Imports**:
>     - Reorder imports in `baseClient.ts` and `r2rClient.ts` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for a6eca2ebef2245de3f7f5ac56aba3a1fb5dded13. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->