### PR TITLE
Fix: TS types for API key responses

### DIFF
--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -468,26 +468,26 @@ export interface PaginatedR2RResult<T> extends R2RResults<T> {
 // ---------------------------
 
 /**
- * Full API Key model (includes the private `api_key` which is only
+ * Full API Key model (includes the private `apiKey` which is only
  * returned ONCE at creation time).
  */
 export interface ApiKey {
-  public_key: string;
+  publicKey: string;
   /** The private key, only returned during creation. */
-  api_key: string;
-  key_id: string;
+  apiKey: string;
+  keyId: string;
   name?: string;
 }
 
 /**
- * API Key model that omits the private `api_key`. Typically used
+ * API Key model that omits the private `apiKey`. Typically used
  * for listing user keys.
  */
 export interface ApiKeyNoPriv {
-  public_key: string;
-  key_id: string;
+  publicKey: string;
+  keyId: string;
   name?: string;
-  updated_at: string; // or `Date` if your code auto-parses
+  updatedAt: string; // or `Date` if your code auto-parses
 }
 
 /**


### PR DESCRIPTION
The typescript SDK automatically converts the `snake_case` used by the python backend to `lowerCamelCase`. However, some of the types in the SDK pertaining to API key-related API responses still used `snake_case` which does not match what my code that's using the SDK sees (note `apiKey` and `publicKey` rather than `api_key` and `public_key`


![Screenshot 2025-03-21 at 1 13 00 PM](https://github.com/user-attachments/assets/8838e9ad-580b-485e-9bda-96afac0b28c8)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update TypeScript types in `js/sdk/src/types.ts` to use `lowerCamelCase` for API key-related responses.
> 
>   - **Type Changes**:
>     - In `ApiKey` and `ApiKeyNoPriv` interfaces, rename `public_key` to `publicKey`, `api_key` to `apiKey`, `key_id` to `keyId`, and `updated_at` to `updatedAt` in `js/sdk/src/types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 7c4db2590485e3d1ce5e4c9a6f1f0954e94d0346. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->