### PR TITLE
Add OCR Provider to Unstructured Provider

### DIFF
--- a/py/core/main/assembly/factory.py
+++ b/py/core/main/assembly/factory.py
@@ -170,7 +170,10 @@ class R2RProviderFactory:
             )
 
             return UnstructuredIngestionProvider(
-                unstructured_ingestion_config, database_provider, llm_provider
+                config=unstructured_ingestion_config,
+                database_provider=database_provider,
+                llm_provider=llm_provider,
+                ocr_provider=ocr_provider,
             )
         else:
             raise ValueError(

--- a/py/core/providers/ingestion/unstructured/base.py
+++ b/py/core/providers/ingestion/unstructured/base.py
@@ -23,6 +23,7 @@ from core.base import (
 )
 from core.base.abstractions import R2RSerializable
 from core.base.providers.ingestion import IngestionConfig, IngestionProvider
+from core.providers.ocr import MistralOCRProvider
 from core.utils import generate_extraction_id
 
 from ...database import PostgresDatabaseProvider
@@ -128,6 +129,7 @@ class UnstructuredIngestionProvider(IngestionProvider):
             | OpenAICompletionProvider
             | R2RCompletionProvider
         ),
+        ocr_provider: MistralOCRProvider,
     ):
         super().__init__(config, database_provider, llm_provider)
         self.config: UnstructuredIngestionConfig = config
@@ -137,6 +139,7 @@ class UnstructuredIngestionProvider(IngestionProvider):
             | OpenAICompletionProvider
             | R2RCompletionProvider
         ) = llm_provider
+        self.ocr_provider: MistralOCRProvider = ocr_provider
 
         if config.provider == "unstructured_api":
             try:
@@ -187,16 +190,29 @@ class UnstructuredIngestionProvider(IngestionProvider):
                         llm_provider=self.llm_provider,
                     )
         # TODO - Reduce code duplication between Unstructured & R2R
-        for doc_type, doc_parser_name in self.config.extra_parsers.items():
-            self.parsers[f"{doc_parser_name}_{str(doc_type)}"] = (
-                UnstructuredIngestionProvider.EXTRA_PARSERS[doc_type][
-                    doc_parser_name
-                ](
-                    config=self.config,
-                    database_provider=self.database_provider,
-                    llm_provider=self.llm_provider,
-                )
-            )
+        for doc_type, parser_names in self.config.extra_parsers.items():
+            if not isinstance(parser_names, list):
+                parser_names = [parser_names]
+
+            for parser_name in parser_names:
+                parser_key = f"{parser_name}_{str(doc_type)}"
+
+                try:
+                    self.parsers[parser_key] = self.EXTRA_PARSERS[doc_type][
+                        parser_name
+                    ](
+                        config=self.config,
+                        database_provider=self.database_provider,
+                        llm_provider=self.llm_provider,
+                        ocr_provider=self.ocr_provider,
+                    )
+                    logger.info(
+                        f"Initialized extra parser {parser_name} for {doc_type}"
+                    )
+                except KeyError as e:
+                    logger.error(
+                        f"Parser {parser_name} for document type {doc_type} not found: {e}"
+                    )
 
     async def parse_fallback(
         self,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add OCR provider to Unstructured Ingestion Provider, enabling OCR capabilities in document parsing.
> 
>   - **Behavior**:
>     - Add `ocr_provider` parameter to `create_ingestion_provider()` in `factory.py`.
>     - Update `UnstructuredIngestionProvider` in `base.py` to include `ocr_provider` in initialization and parser setup.
>   - **Error Handling**:
>     - Log error if parser not found in `_initialize_parsers()` in `base.py`.
>   - **Misc**:
>     - Modify parser initialization to handle lists in `base.py`.
>     - Add logging for parser initialization in `base.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 33685f197b9e7f5a72885c9e2d68d91a02d4d0e9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->