### PR TITLE
Remove old update metadata workflows

### DIFF
--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -138,11 +138,6 @@ class DocumentsRouter(BaseRouterV3):
                     if self.providers.orchestration.config.provider != "simple"
                     else "Chunk update completed successfully."
                 ),
-                "update-document-metadata": (
-                    "Update document metadata task queued successfully."
-                    if self.providers.orchestration.config.provider != "simple"
-                    else "Document metadata update completed successfully."
-                ),
                 "create-vector-index": (
                     "Vector index creation task queued successfully."
                     if self.providers.orchestration.config.provider != "simple"

--- a/py/core/main/orchestration/hatchet/ingestion_workflow.py
+++ b/py/core/main/orchestration/hatchet/ingestion_workflow.py
@@ -658,56 +658,10 @@ def hatchet_ingestion_factory(
 
             return {"status": "Vector index deleted successfully."}
 
-    @orchestration_provider.workflow(
-        name="update-document-metadata",
-        timeout="30m",
-    )
-    class HatchetUpdateDocumentMetadataWorkflow:
-        def __init__(self, ingestion_service: IngestionService):
-            self.ingestion_service = ingestion_service
-
-        @orchestration_provider.step(timeout="30m")
-        async def update_document_metadata(self, context: Context) -> dict:
-            try:
-                input_data = context.workflow_input()["request"]
-                parsed_data = IngestionServiceAdapter.parse_update_document_metadata_input(
-                    input_data
-                )
-
-                document_id = UUID(parsed_data["document_id"])
-                metadata = parsed_data["metadata"]
-                user = parsed_data["user"]
-
-                await self.ingestion_service.update_document_metadata(
-                    document_id=document_id,
-                    metadata=metadata,
-                    user=user,
-                )
-
-                return {
-                    "message": "Document metadata update completed successfully.",
-                    "document_id": str(document_id),
-                    "task_id": context.workflow_run_id(),
-                }
-
-            except Exception as e:
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Error during document metadata update: {str(e)}",
-                ) from e
-
-        @orchestration_provider.failure()
-        async def on_failure(self, context: Context) -> None:
-            # Handle failure case if necessary
-            pass
-
     # Add this to the workflows dictionary in hatchet_ingestion_factory
     ingest_files_workflow = HatchetIngestFilesWorkflow(service)
     ingest_chunks_workflow = HatchetIngestChunksWorkflow(service)
     update_chunks_workflow = HatchetUpdateChunkWorkflow(service)
-    update_document_metadata_workflow = HatchetUpdateDocumentMetadataWorkflow(
-        service
-    )
     create_vector_index_workflow = HatchetCreateVectorIndexWorkflow(service)
     delete_vector_index_workflow = HatchetDeleteVectorIndexWorkflow(service)
 
@@ -715,7 +669,6 @@ def hatchet_ingestion_factory(
         "ingest_files": ingest_files_workflow,
         "ingest_chunks": ingest_chunks_workflow,
         "update_chunk": update_chunks_workflow,
-        "update_document_metadata": update_document_metadata_workflow,
         "create_vector_index": create_vector_index_workflow,
         "delete_vector_index": delete_vector_index_workflow,
     }

--- a/py/core/main/orchestration/simple/ingestion_workflow.py
+++ b/py/core/main/orchestration/simple/ingestion_workflow.py
@@ -556,43 +556,10 @@ def simple_ingestion_factory(service: IngestionService):
                 detail=f"Error during vector index deletion: {str(e)}",
             ) from e
 
-    async def update_document_metadata(input_data):
-        try:
-            from core.main import IngestionServiceAdapter
-
-            parsed_data = (
-                IngestionServiceAdapter.parse_update_document_metadata_input(
-                    input_data
-                )
-            )
-
-            document_id = parsed_data["document_id"]
-            metadata = parsed_data["metadata"]
-            user = parsed_data["user"]
-
-            await service.update_document_metadata(
-                document_id=document_id,
-                metadata=metadata,
-                user=user,
-            )
-
-            return {
-                "message": "Document metadata update completed successfully.",
-                "document_id": str(document_id),
-                "task_id": None,
-            }
-
-        except Exception as e:
-            raise HTTPException(
-                status_code=500,
-                detail=f"Error during document metadata update: {str(e)}",
-            ) from e
-
     return {
         "ingest-files": ingest_files,
         "ingest-chunks": ingest_chunks,
         "update-chunk": update_chunk,
-        "update-document-metadata": update_document_metadata,
         "create-vector-index": create_vector_index,
         "delete-vector-index": delete_vector_index,
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `update-document-metadata` workflow and related methods from orchestration and ingestion service.
> 
>   - **Workflows**:
>     - Remove `update-document-metadata` workflow from `ingestion_workflow.py` and `simple/ingestion_workflow.py`.
>     - Delete `HatchetUpdateDocumentMetadataWorkflow` class and its methods.
>   - **Service Methods**:
>     - Remove `update_document_metadata` method from `IngestionService`.
>     - Delete `parse_update_document_metadata_input` from `IngestionServiceAdapter`.
>   - **API Changes**:
>     - Remove `update-document-metadata` from `_register_workflows` in `documents_router.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 67694c7dd69015f7c5bad90854de744457867727. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->