### PR TITLE
Switch model prefix to ollama in reference config

### DIFF
--- a/py/core/configs/full_ollama.toml
+++ b/py/core/configs/full_ollama.toml
@@ -1,21 +1,21 @@
 [app]
 # LLM used for internal operations, like deriving conversation names
-fast_llm = "openai/llama3.1"
+fast_llm = "ollama/llama3.1"
 
 # LLM used for user-facing output, like RAG replies
-quality_llm = "openai/llama3.1"
+quality_llm = "ollama/llama3.1"
 
 # LLM used for ingesting visual inputs
-vlm = "openai/llama3.1" # TODO - Replace with viable candidate
+vlm = "ollama/llama3.1" # TODO - Replace with viable candidate
 
 # LLM used for transcription
-audio_lm = "openai/llama3.1" # TODO - Replace with viable candidate
+audio_lm = "ollama/llama3.1" # TODO - Replace with viable candidate
 
 
 # Reasoning model, used for `research` agent
-reasoning_llm = "openai/llama3.1"
+reasoning_llm = "ollama/llama3.1"
 # Planning model, used for `research` agent
-planning_llm = "openai/llama3.1"
+planning_llm = "ollama/llama3.1"
 
 [embedding]
 provider = "ollama"

--- a/py/core/configs/ollama.toml
+++ b/py/core/configs/ollama.toml
@@ -1,21 +1,21 @@
 [app]
 # LLM used for internal operations, like deriving conversation names
-fast_llm = "openai/llama3.1" ### NOTE - RECOMMENDED TO USE `openai` with `api_base = "http://localhost:11434/v1"` for best results, otherwise `ollama` with `litellm` is acceptable
+fast_llm = "ollama/llama3.1" ### NOTE - RECOMMENDED TO USE `openai` with `api_base = "http://localhost:11434/v1"` for best results, otherwise `ollama` with `litellm` is acceptable
 
 # LLM used for user-facing output, like RAG replies
-quality_llm = "openai/llama3.1"
+quality_llm = "ollama/llama3.1"
 
 # LLM used for ingesting visual inputs
-vlm = "openai/llama3.1" # TODO - Replace with viable candidate
+vlm = "ollama/llama3.1" # TODO - Replace with viable candidate
 
 # LLM used for transcription
-audio_lm = "openai/llama3.1" # TODO - Replace with viable candidate
+audio_lm = "ollama/llama3.1" # TODO - Replace with viable candidate
 
 
 # Reasoning model, used for `research` agent
-reasoning_llm = "openai/llama3.1"
+reasoning_llm = "ollama/llama3.1"
 # Planning model, used for `research` agent
-planning_llm = "openai/llama3.1"
+planning_llm = "ollama/llama3.1"
 
 [embedding]
 provider = "ollama"


### PR DESCRIPTION
I wasn't able to get the local installation working unless I changed the model prefixes to `ollama`. This also aligns with the sample config shown in https://r2r-docs.sciphi.ai/cookbooks/local-llms#configuring-r2r

The `fast_llm` comment in ollama.toml is not really clear but I left it alone.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch model prefix from `openai` to `ollama` in configuration files to ensure local installation works.
> 
>   - **Configuration Changes**:
>     - Switch model prefix from `openai` to `ollama` in `full_ollama.toml` and `ollama.toml` for `fast_llm`, `quality_llm`, `vlm`, `audio_lm`, `reasoning_llm`, and `planning_llm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 8550d66f9764c3302cb0d5d74351b7fe05f73e1c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->