### PR TITLE
fix(agent): remove extra argument on tools call

### DIFF
--- a/py/core/base/agent/agent.py
+++ b/py/core/base/agent/agent.py
@@ -162,7 +162,6 @@ class Agent(ABC):
                             "parameters": tool.parameters,
                         },
                         "type": "function",
-                        "name": tool.name,
                     }
                     for tool in self.tools
                 ]


### PR DESCRIPTION
Playing around with `vLLM` and `mistral-7B` with tools calls.
I needed this little diff, without it we get a `ChatCompletionRequest` `Pydantic` validation Error on the request object because of this:
https://github.com/mistralai/mistral-common/blob/f4a06998b75ed78bbf5aaf569590b772ea26c9f6/src/mistral_common/base.py#L9

Extra Arguments are never allowed when using Mistral SDK