### PR TITLE
Fix useFulltextSearch in SearchSettings JS SDK

### DIFF
--- a/js/sdk/package-lock.json
+++ b/js/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",

--- a/js/sdk/src/baseClient.ts
+++ b/js/sdk/src/baseClient.ts
@@ -241,7 +241,9 @@ export abstract class BaseClient {
   }
 
   setApiKey(apiKey: string): void {
-    if (!apiKey) throw new Error("API key is required");
+    if (!apiKey) {
+      throw new Error("API key is required");
+    }
     this.apiKey = apiKey;
   }
 }

--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -209,9 +209,9 @@ export interface GenerationConfig {
 }
 
 export interface HybridSearchSettings {
-  fullTextWeight?: number;
+  fulltextWeight?: number;
   semanticWeight?: number;
-  fullTextLimit?: number;
+  fulltextLimit?: number;
   rrfK?: number;
 }
 

--- a/js/sdk/src/types.ts
+++ b/js/sdk/src/types.ts
@@ -228,7 +228,7 @@ export interface GraphSearchSettings {
 export interface SearchSettings {
   useHybridSearch?: boolean;
   useSemanticSearch?: boolean;
-  useFullTextSearch?: boolean;
+  useFulltextSearch?: boolean;
   filters?: Record<string, any>;
   limit?: number;
   offset?: number;

--- a/js/sdk/src/v3/clients/retrieval.ts
+++ b/js/sdk/src/v3/clients/retrieval.ts
@@ -8,22 +8,6 @@ import {
 } from "../../types";
 import { ensureSnakeCase } from "../../utils";
 
-function parseSseEvent(raw: { event: string; data: string }) {
-  // Some SSE servers send a "done" event at the end:
-  if (raw.event === "done") return null;
-
-  try {
-    const parsedJson = JSON.parse(raw.data);
-    return {
-      event: raw.event,
-      data: parsedJson,
-    };
-  } catch (err) {
-    console.error("Failed to parse SSE line:", raw.data, err);
-    return null;
-  }
-}
-
 export class RetrievalClient {
   constructor(private client: r2rClient) {}
 

--- a/py/core/main/api/v3/examples.py
+++ b/py/core/main/api/v3/examples.py
@@ -98,9 +98,9 @@ search_app_examples = {
                         indexMeasure: "l2_distance",
                         useHybridSearch: true,
                         hybridSettings: {
-                            fullTextWeight: 1.0,
+                            fulltextWeight: 1.0,
                             semanticWeight: 5.0,
-                            fullTextLimit: 200,
+                            fulltextLimit: 200,
                         },
                         filters: {"title": {"$in": ["DeepSeek_R1.pdf"]}},
                     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames `useFullTextSearch` to `useFulltextSearch` in `SearchSettings` and related fields, removes unused function, and updates package version.
> 
>   - **Behavior**:
>     - Renames `useFullTextSearch` to `useFulltextSearch` in `SearchSettings` in `types.ts` and updates related examples in `examples.py`.
>     - Renames `fullTextWeight` to `fulltextWeight` and `fullTextLimit` to `fulltextLimit` in `HybridSearchSettings` in `types.ts`.
>   - **Refactoring**:
>     - Removes unused `parseSseEvent` function from `retrieval.ts`.
>   - **Misc**:
>     - Updates package version in `package.json` from `0.4.36` to `0.4.37`.
>     - Adds braces to `setApiKey` method in `baseClient.ts` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 439b43c9ddfb6327926d70792adcc973e7c2c144. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->