### PR TITLE
LLM Timeouts

### DIFF
--- a/py/core/parsers/media/pdf_parser.py
+++ b/py/core/parsers/media/pdf_parser.py
@@ -141,7 +141,6 @@ class VLMPDFParser(AsyncParser[str | bytes]):
                 ]
 
             logger.debug(f"Sending page {page_num} to vision model.")
-            req_start = time.perf_counter()
 
             if is_anthropic:
                 response = await self.llm_provider.aget_completion(

--- a/py/r2r/r2r.toml
+++ b/py/r2r/r2r.toml
@@ -46,6 +46,7 @@ default_admin_password = "change_me_immediately"
 [completion]
 provider = "r2r"
 concurrent_request_limit = 64
+request_timeout = 8
 
   [completion.generation_config]
   temperature = 0.1

--- a/py/r2r/r2r.toml
+++ b/py/r2r/r2r.toml
@@ -46,7 +46,7 @@ default_admin_password = "change_me_immediately"
 [completion]
 provider = "r2r"
 concurrent_request_limit = 64
-request_timeout = 8
+request_timeout = 15
 
   [completion.generation_config]
   temperature = 0.1


### PR DESCRIPTION
Some LLM providers have extremely high variability in their response times. To improve hi-res ingestion speed, this PR introduces configurable timeouts for non-streaming LLM calls, allowing for longer than optimal calls that aren't resolving to be retried.

Based on my testing with Gemini Flash 2.0, where I have an average latency of ~6.5 seconds, I found that setting a timeout _just barely_ above my average led to ~3x speedups.

<img width="1253" alt="Screenshot 2025-04-17 at 2 50 43 PM" src="https://github.com/user-attachments/assets/c422da7a-7691-4716-9685-557c477597f7" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces configurable timeouts for non-streaming LLM calls in `llm.py` and updates `r2r.toml` to improve ingestion speed.
> 
>   - **Behavior**:
>     - Introduces `request_timeout` in `CompletionConfig` in `llm.py` to set timeouts for non-streaming LLM calls.
>     - Uses `asyncio.wait_for` in `_execute_with_backoff_async()` and `future.result()` in `_execute_with_backoff_sync()` to apply timeouts.
>   - **Configuration**:
>     - Adds `request_timeout` setting to `[completion]` in `r2r.toml` with a default of 15 seconds.
>   - **Misc**:
>     - Removes unused `req_start` variable in `process_page()` in `pdf_parser.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for f1b645225f2c6bda65959a74957053d5932df1c2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->