### PR TITLE
Introduce config setting for one page/chunk for VLM/OCR

### DIFF
--- a/py/core/base/providers/ingestion.py
+++ b/py/core/base/providers/ingestion.py
@@ -36,6 +36,7 @@ class IngestionConfig(ProviderConfig):
         "audio_transcription_model": None,
         "vlm": None,
         "vlm_batch_size": 5,
+        "vlm_ocr_one_page_per_chunk": True,
         "skip_document_summary": False,
         "document_summary_system_prompt": "system",
         "document_summary_task_prompt": "summary",
@@ -80,6 +81,11 @@ class IngestionConfig(ProviderConfig):
     )
     vlm_batch_size: int = Field(
         default_factory=lambda: IngestionConfig._defaults["vlm_batch_size"]
+    )
+    vlm_ocr_one_page_per_chunk: bool = Field(
+        default_factory=lambda: IngestionConfig._defaults[
+            "vlm_ocr_one_page_per_chunk"
+        ]
     )
     skip_document_summary: bool = Field(
         default_factory=lambda: IngestionConfig._defaults[

--- a/py/r2r/r2r.toml
+++ b/py/r2r/r2r.toml
@@ -106,6 +106,7 @@ chunk_overlap = 512
 excluded_parsers = ["mp4"]
 automatic_extraction = true # enable automatic extraction of entities and relations
 vlm_batch_size=20
+vlm_ocr_one_page_per_chunk = true
 
   [ingestion.chunk_enrichment_settings]
     chunk_enrichment_prompt = "chunk_enrichment"

--- a/py/shared/abstractions/document.py
+++ b/py/shared/abstractions/document.py
@@ -322,10 +322,11 @@ class IngestionConfig(R2RSerializable):
         ChunkEnrichmentSettings()
     )
     extra_parsers: dict[str, Any] = {}
-
     audio_transcription_model: str = ""
+
     vlm: Optional[str] = None
     vlm_batch_size: int = 5
+    vlm_ocr_one_page_per_chunk: bool = True
 
     skip_document_summary: bool = False
     document_summary_system_prompt: str = "system"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `vlm_ocr_one_page_per_chunk` setting to control OCR/VLM processing, affecting document parsing behavior.
> 
>   - **Behavior**:
>     - Introduces `vlm_ocr_one_page_per_chunk` setting in `IngestionConfig` to control OCR/VLM processing.
>     - Default is `True`, meaning one page per chunk for OCR/VLM.
>     - Affects `parse()` in `r2r/base.py` and `parse_fallback()` in `unstructured/base.py`.
>   - **Config**:
>     - Adds `vlm_ocr_one_page_per_chunk` to `IngestionConfig` in `ingestion.py` and `document.py`.
>     - Updates `r2r.toml` to include `vlm_ocr_one_page_per_chunk` setting.
>   - **Misc**:
>     - Adjusts logging in `r2r/base.py` and `unstructured/base.py` to reflect new chunking behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 137d6a6b70b4731599c99b8ce8490ba9956cb2c8. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->