### PR TITLE
Expand user management flow to allow super user to set verification

### DIFF
--- a/js/sdk/__tests__/UsersIntegrationSuperUser.test.ts
+++ b/js/sdk/__tests__/UsersIntegrationSuperUser.test.ts
@@ -224,7 +224,7 @@ describe("r2rClient V3 Users Integration Tests", () => {
     expect(response.results.isSuperuser).toBe(false);
     expect(response.results.createdAt).toBeDefined();
     expect(response.results.updatedAt).toBeDefined();
-    expect(response.results.isVerified).toBe(false);
+    expect(response.results.isVerified).toBe(true);
     expect(response.results.collectionIds).toBeDefined();
     expect(response.results.hashedPassword).toBeDefined();
     expect(response.results.verificationCodeExpiry).toBeNull();

--- a/js/sdk/src/v3/clients/users.ts
+++ b/js/sdk/src/v3/clients/users.ts
@@ -36,6 +36,7 @@ export class UsersClient {
     name?: string;
     bio?: string;
     profilePicture?: string;
+    isVerified?: boolean;
   }): Promise<WrappedUserResponse> {
     const data = {
       ...(options.email && { email: options.email }),
@@ -44,6 +45,9 @@ export class UsersClient {
       ...(options.bio && { bio: options.bio }),
       ...(options.profilePicture && {
         profile_picture: options.profilePicture,
+      }),
+      ...(options.isVerified !== undefined && {
+        is_verified: options.isVerified,
       }),
     };
 

--- a/js/sdk/src/v3/clients/users.ts
+++ b/js/sdk/src/v3/clients/users.ts
@@ -28,6 +28,7 @@ export class UsersClient {
    * @param name The name for the new user
    * @param bio The bio for the new user
    * @param profilePicture The profile picture for the new user
+   * @param isVerified Whether the user is verified
    * @returns WrappedUserResponse
    */
   async create(options: {

--- a/py/core/main/api/v3/users_router.py
+++ b/py/core/main/api/v3/users_router.py
@@ -112,33 +112,24 @@ class UsersRouter(BaseRouterV3):
             profile_picture: str | None = Body(
                 None, description="Updated user profile picture"
             ),
-            # auth_user=Depends(self.providers.auth.auth_wrapper()),
+            is_verified: bool = Body(
+                False,
+                description="Whether to verify the user immediately",
+            ),
+            auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedUserResponse:
             """Register a new user with the given email and password."""
 
-            # TODO: Do we really want this validation? The default password for the superuser would not pass...
-            def validate_password(password: str) -> bool:
-                if len(password) < 10:
-                    return False
-                if not any(c.isupper() for c in password):
-                    return False
-                if not any(c.islower() for c in password):
-                    return False
-                if not any(c.isdigit() for c in password):
-                    return False
-                if not any(c in "!@#$%^&*" for c in password):
-                    return False
-                return True
-
-            # if not validate_password(password):
-            #     raise R2RException(
-            #         f"Password must be at least 10 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character from '!@#$%^&*'.",
-            #         400,
-            #     )
+            if is_verified and not auth_user.is_superuser:
+                raise R2RException(
+                    "Non-superuser cannot verify users during registration.",
+                    403,
+                )
 
             registration_response = await self.services.auth.register(
                 email=email,
                 password=password,
+                is_verified=is_verified,
                 name=name,
                 bio=bio,
                 profile_picture=profile_picture,

--- a/py/core/main/services/auth_service.py
+++ b/py/core/main/services/auth_service.py
@@ -29,6 +29,7 @@ class AuthService(Service):
         self,
         email: str,
         password: str,
+        is_verified: bool = False,
         name: Optional[str] = None,
         bio: Optional[str] = None,
         profile_picture: Optional[str] = None,
@@ -36,6 +37,7 @@ class AuthService(Service):
         return await self.providers.auth.register(
             email=email,
             password=password,
+            is_verified=is_verified,
             name=name,
             bio=bio,
             profile_picture=profile_picture,

--- a/py/core/providers/auth/jwt.py
+++ b/py/core/providers/auth/jwt.py
@@ -124,6 +124,7 @@ class JwtAuthProvider(AuthProvider):
         self,
         email: str,
         password: str,
+        is_verified: bool = False,
         name: Optional[str] = None,
         bio: Optional[str] = None,
         profile_picture: Optional[str] = None,

--- a/py/core/providers/auth/r2r_auth.py
+++ b/py/core/providers/auth/r2r_auth.py
@@ -246,6 +246,7 @@ class R2RAuthProvider(AuthProvider):
             email=normalize_email(email),
             password=password,
             is_superuser=is_superuser,
+            is_verified=is_verified,
             account_type=account_type,
             github_id=github_id,
             google_id=google_id,
@@ -275,16 +276,6 @@ class R2RAuthProvider(AuthProvider):
         if self.config.require_email_verification and not is_verified:
             verification_code, _ = await self.send_verification_email(
                 email=normalize_email(email), user=new_user
-            )
-        elif is_verified:
-            expiry = datetime.now(timezone.utc) + timedelta(hours=366 * 10)
-            await self.database_provider.users_handler.store_verification_code(
-                id=new_user.id,
-                verification_code=str(-1),
-                expiry=expiry,
-            )
-            await self.database_provider.users_handler.mark_user_as_verified(
-                id=new_user.id
             )
 
         return new_user

--- a/py/core/providers/auth/r2r_auth.py
+++ b/py/core/providers/auth/r2r_auth.py
@@ -276,7 +276,7 @@ class R2RAuthProvider(AuthProvider):
             verification_code, _ = await self.send_verification_email(
                 email=normalize_email(email), user=new_user
             )
-        else:
+        elif is_verified:
             expiry = datetime.now(timezone.utc) + timedelta(hours=366 * 10)
             await self.database_provider.users_handler.store_verification_code(
                 id=new_user.id,

--- a/py/core/providers/auth/r2r_auth.py
+++ b/py/core/providers/auth/r2r_auth.py
@@ -217,6 +217,7 @@ class R2RAuthProvider(AuthProvider):
         email: str,
         password: Optional[str] = None,
         is_superuser: bool = False,
+        is_verified: bool = False,
         account_type: str = "password",
         github_id: Optional[str] = None,
         google_id: Optional[str] = None,
@@ -271,7 +272,7 @@ class R2RAuthProvider(AuthProvider):
             new_user.id
         )
 
-        if self.config.require_email_verification:
+        if self.config.require_email_verification and not is_verified:
             verification_code, _ = await self.send_verification_email(
                 email=normalize_email(email), user=new_user
             )

--- a/py/core/providers/auth/supabase.py
+++ b/py/core/providers/auth/supabase.py
@@ -76,6 +76,7 @@ class SupabaseAuthProvider(AuthProvider):
         self,
         email: str,
         password: str,
+        is_verified: bool = False,
         name: Optional[str] = None,
         bio: Optional[str] = None,
         profile_picture: Optional[str] = None,

--- a/py/core/providers/database/users.py
+++ b/py/core/providers/database/users.py
@@ -251,6 +251,7 @@ class PostgresUserHandler(Handler):
         google_id: Optional[str] = None,
         github_id: Optional[str] = None,
         is_superuser: bool = False,
+        is_verified: bool = False,
         name: Optional[str] = None,
         bio: Optional[str] = None,
         profile_picture: Optional[str] = None,
@@ -310,7 +311,7 @@ class PostgresUserHandler(Handler):
                     # !!WARNING - Upstream checks are required to treat oauth differently from password!!
                     "google_id": google_id,
                     "github_id": github_id,
-                    "is_verified": account_type != "password",
+                    "is_verified": is_verified or (account_type != "password"),
                     "name": name,
                     "bio": bio,
                     "profile_picture": profile_picture,

--- a/py/sdk/asnyc_methods/users.py
+++ b/py/sdk/asnyc_methods/users.py
@@ -26,6 +26,7 @@ class UsersSDK:
         name: Optional[str] = None,
         bio: Optional[str] = None,
         profile_picture: Optional[str] = None,
+        is_verified: Optional[bool] = None,
     ) -> WrappedUserResponse:
         """Register a new user.
 
@@ -48,6 +49,8 @@ class UsersSDK:
             data["bio"] = bio
         if profile_picture is not None:
             data["profile_picture"] = profile_picture
+        if is_verified is not None:
+            data["is_verified"] = is_verified
 
         response_dict = await self.client._make_request(
             "POST",

--- a/py/sdk/sync_methods/users.py
+++ b/py/sdk/sync_methods/users.py
@@ -26,6 +26,7 @@ class UsersSDK:
         name: Optional[str] = None,
         bio: Optional[str] = None,
         profile_picture: Optional[str] = None,
+        is_verified: Optional[bool] = None,
     ) -> WrappedUserResponse:
         """Register a new user.
 
@@ -48,6 +49,8 @@ class UsersSDK:
             data["bio"] = bio
         if profile_picture is not None:
             data["profile_picture"] = profile_picture
+        if is_verified is not None:
+            data["is_verified"] = is_verified
 
         response_dict = self.client._make_request(
             "POST",


### PR DESCRIPTION
Allows the super user to create clients that are verified, rather than requiring them to go through the standard email verification process.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Expand user management to allow superusers to set verification status during registration, with updated tests and database logic.
> 
>   - **Behavior**:
>     - Superusers can now set `isVerified` during user registration in `users_router.py` and `users.ts`.
>     - Non-superusers attempting to set `isVerified` will receive a 403 error.
>   - **Tests**:
>     - Updated `UsersIntegrationSuperUser.test.ts` to test registration with `isVerified` set to true and false.
>     - Added tests for sending verification emails and handling already verified emails.
>   - **Database**:
>     - `create_user` in `users.py` now accepts `is_verified` parameter.
>     - Verification code logic adjusted to handle pre-verified users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for b6eec51158c18c50568c3a6bfa30cfffd8692f01. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->