### PR TITLE
feat: add disable_create_extension database setting

### DIFF
--- a/py/all_possible_config.toml
+++ b/py/all_possible_config.toml
@@ -116,6 +116,7 @@ default_collection_description = "Your default collection."
 collection_summary_system_prompt = "system"
 collection_summary_prompt = "collection_summary"
 enable_fts = false
+disable_create_extension = false
 batch_size = 1
 kg_store_path = ""
 

--- a/py/core/base/providers/database.py
+++ b/py/core/base/providers/database.py
@@ -138,6 +138,7 @@ class DatabaseConfig(ProviderConfig):
     collection_summary_system_prompt: str = "system"
     collection_summary_prompt: str = "collection_summary"
     enable_fts: bool = False
+    disable_create_extension: bool = False
 
     # Graph settings
     batch_size: Optional[int] = 1

--- a/py/core/providers/database/postgres.py
+++ b/py/core/providers/database/postgres.py
@@ -212,10 +212,11 @@ class PostgresDatabaseProvider(DatabaseProvider):
         await self.connection_manager.initialize(self.pool)
 
         async with self.pool.get_connection() as conn:
-            await conn.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
-            await conn.execute("CREATE EXTENSION IF NOT EXISTS vector;")
-            await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
-            await conn.execute("CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;")
+            if not self.config.disable_create_extension:
+                await conn.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
+                await conn.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+                await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+                await conn.execute("CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;")
 
             # Create schema if it doesn't exist
             await conn.execute(


### PR DESCRIPTION
We are running R2R with a non-superuser PostgreSQL user; therefore, the `CREATE EXTENSION` commands fail on startup.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `disable_create_extension` setting to control PostgreSQL extension creation in non-superuser environments.
> 
>   - **Behavior**:
>     - Adds `disable_create_extension` setting to `DatabaseConfig` in `database.py` and `all_possible_config.toml`.
>     - In `postgres.py`, modifies `initialize()` in `PostgresDatabaseProvider` to conditionally execute `CREATE EXTENSION` commands based on `disable_create_extension`.
>   - **Configuration**:
>     - New `disable_create_extension` boolean setting in `all_possible_config.toml` and `DatabaseConfig`.
>   - **Misc**:
>     - Updates `initialize()` in `postgres.py` to respect `disable_create_extension` setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 2a41bf37eef9edee6b177c818cf4b06eb1f77653. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->