### PR TITLE
Resolve CSV export column mismatch for relationships and communities

### DIFF
--- a/py/core/providers/database/graphs.py
+++ b/py/core/providers/database/graphs.py
@@ -1181,7 +1181,22 @@ class PostgresRelationshipsHandler(Handler):
                         if not rows:
                             break
                         for row in rows:
-                            writer.writerow(row)
+                            row_dict = {
+                                "id": row["id"],
+                                "subject": row["subject"],
+                                "predicate": row["predicate"],
+                                "object": row["object"],
+                                "description": row["description"],
+                                "subject_id": row["subject_id"],
+                                "object_id": row["object_id"],
+                                "weight": row["weight"],
+                                "chunk_ids": row["chunk_ids"],
+                                "parent_id": row["parent_id"],
+                                "metadata": row["metadata"],
+                                "created_at": row["created_at"],
+                                "updated_at": row["updated_at"],
+                            }
+                            writer.writerow([row_dict[col] for col in columns])
 
             temp_file.flush()
             return temp_file.name, temp_file
@@ -1586,7 +1601,21 @@ class PostgresCommunitiesHandler(Handler):
                         if not rows:
                             break
                         for row in rows:
-                            writer.writerow(row)
+                            row_dict = {
+                                "id": row[0],
+                                "collection_id": row[1],
+                                "community_id": row[2],
+                                "level": row[3],
+                                "name": row[4],
+                                "summary": row[5],
+                                "findings": row[6],
+                                "rating": row[7],
+                                "rating_explanation": row[8],
+                                "created_at": row[9],
+                                "updated_at": row[10],
+                                "metadata": row[11],
+                            }
+                            writer.writerow([row_dict[col] for col in columns])
 
             temp_file.flush()
             return temp_file.name, temp_file


### PR DESCRIPTION
Fixes #2140
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CSV export column mismatch in `graphs.py` by ensuring only specified columns are written using a dictionary for column mapping.
> 
>   - **Behavior**:
>     - Fixes CSV export column mismatch in `export_to_csv()` for relationships and communities in `graphs.py`.
>     - Ensures only specified columns are written to CSV by using a dictionary to map row data to column names.
>   - **Functions**:
>     - Updates `export_to_csv()` in `PostgresRelationshipsHandler` to use a dictionary for column mapping.
>     - Updates `export_to_csv()` in `PostgresCommunitiesHandler` similarly for column mapping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 08a1dac4a946048a9633f1d5344de3a63789c90a. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->