### PR TITLE
Expose max tokens to sample for VLM

### DIFF
--- a/py/all_possible_config.toml
+++ b/py/all_possible_config.toml
@@ -223,6 +223,10 @@ chunk_size = 1024
 # Extra field handled by extra_fields – not defined explicitly in IngestionConfig:
 chunk_overlap = 512
 automatic_extraction = true
+vlm_batch_size=20
+vlm_max_tokens_to_sample=1024
+max_concurrent_vlm_tasks=20
+vlm_ocr_one_page_per_chunk = true
 # Audio transcription and vision model settings
 audio_transcription_model = ""
 skip_document_summary = false

--- a/py/core/base/providers/ingestion.py
+++ b/py/core/base/providers/ingestion.py
@@ -36,6 +36,7 @@ class IngestionConfig(ProviderConfig):
         "audio_transcription_model": None,
         "vlm": None,
         "vlm_batch_size": 5,
+        "vlm_max_tokens_to_sample": 1_024,
         "max_concurrent_vlm_tasks": 5,
         "vlm_ocr_one_page_per_chunk": True,
         "skip_document_summary": False,
@@ -82,6 +83,11 @@ class IngestionConfig(ProviderConfig):
     )
     vlm_batch_size: int = Field(
         default_factory=lambda: IngestionConfig._defaults["vlm_batch_size"]
+    )
+    vlm_max_tokens_to_sample: int = Field(
+        default_factory=lambda: IngestionConfig._defaults[
+            "vlm_max_tokens_to_sample"
+        ]
     )
     max_concurrent_vlm_tasks: int = Field(
         default_factory=lambda: IngestionConfig._defaults[

--- a/py/core/parsers/media/pdf_parser.py
+++ b/py/core/parsers/media/pdf_parser.py
@@ -85,6 +85,9 @@ class VLMPDFParser(AsyncParser[str | bytes]):
         self.config = config
         self.vision_prompt_text = None
         self.vlm_batch_size = self.config.vlm_batch_size or 5
+        self.vlm_max_tokens_to_sample = (
+            self.config.vlm_max_tokens_to_sample or 1024
+        )
         self.max_concurrent_vlm_tasks = (
             self.config.max_concurrent_vlm_tasks or 5
         )
@@ -106,6 +109,7 @@ class VLMPDFParser(AsyncParser[str | bytes]):
             generation_config = GenerationConfig(
                 model=self.config.vlm or self.config.app.vlm,
                 stream=False,
+                max_tokens_to_sample=self.vlm_max_tokens_to_sample,
             )
 
             is_anthropic = model and "anthropic/" in model

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "r2r"
-version = "3.5.16"
+version = "3.5.17"
 description = "SciPhi R2R"
 readme = "README.md"
 license = {text = "MIT"}

--- a/py/shared/abstractions/document.py
+++ b/py/shared/abstractions/document.py
@@ -326,6 +326,7 @@ class IngestionConfig(R2RSerializable):
 
     vlm: Optional[str] = None
     vlm_batch_size: int = 5
+    vlm_max_tokens_to_sample: int = 1024
     max_concurrent_vlm_tasks: int = 5
     vlm_ocr_one_page_per_chunk: bool = True
 


### PR DESCRIPTION
Previously, the configuration file did not expose a way to cap the max tokens for VLM processing—for long context models, this was problematic and increasing latency. This breaks out that parameter, allowing for more granular control and ability to tune deployments.