### PR TITLE
Add owner_only filter on collections

### DIFF
--- a/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
+++ b/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
@@ -258,6 +258,80 @@ describe("r2rClient V3 System Integration Tests User", () => {
   //   expect(response.results.documentCount).toBe(1);
   // });
 
+  test("Add user 1's document to user 2's collection", async () => {
+    const response = await user2Client.collections.addDocument({
+      id: user2CollectionId,
+      documentId: user1DocumentId,
+    });
+    expect(response.results).toBeDefined();
+    expect(response.results.message).toBeDefined();
+  });
+
+  test("List documents as user 1", async () => {
+    const response = await user1Client.documents.list();
+    expect(response.results).toBeDefined();
+    expect(Array.isArray(response.results)).toBe(true);
+    expect(response.results.length).toBeGreaterThanOrEqual(1);
+    expect(response.results.some((doc) => doc.id === user1DocumentId)).toBe(
+      true,
+    );
+  });
+
+  test("List documents as user 1 with ownerOnly set to true", async () => {
+    const response = await user1Client.documents.list({ ownerOnly: true });
+    expect(response.results).toBeDefined();
+    expect(Array.isArray(response.results)).toBe(true);
+    expect(response.results.length).toBeGreaterThanOrEqual(1);
+    expect(response.results.some((doc) => doc.id === user1DocumentId)).toBe(
+      true,
+    );
+    expect(response.results.some((doc) => doc.id === user2DocumentId)).toBe(
+      false,
+    );
+  });
+
+  test("Add user 2's document to user 1's collection", async () => {
+    const response = await user1Client.collections.addDocument({
+      id: user1CollectionId,
+      documentId: user2DocumentId,
+    });
+    expect(response.results).toBeDefined();
+    expect(response.results.message).toBeDefined();
+  });
+
+  test("List documents as user 2", async () => {
+    const response = await user2Client.documents.list();
+    expect(response.results).toBeDefined();
+    expect(Array.isArray(response.results)).toBe(true);
+    expect(response.results.length).toBeGreaterThanOrEqual(1);
+    expect(response.results.some((doc) => doc.id === user2DocumentId)).toBe(
+      true,
+    );
+  });
+
+  test("List documents as user 2 with ownerOnly set to true", async () => {
+    const response = await user2Client.documents.list({ ownerOnly: true });
+    expect(response.results).toBeDefined();
+    expect(Array.isArray(response.results)).toBe(true);
+    expect(response.results.length).toBeGreaterThanOrEqual(1);
+    expect(response.results.some((doc) => doc.id === user2DocumentId)).toBe(
+      true,
+    );
+    expect(response.results.some((doc) => doc.id === user1DocumentId)).toBe(
+      false,
+    );
+  });
+
+  test("List documents as superuser with ownerOnly set to true", async () => {
+    const response = await client.documents.list({ ownerOnly: true });
+    expect(response.results).toBeDefined();
+    expect(Array.isArray(response.results)).toBe(true);
+    const superuserId = (await client.users.me()).results.id;
+    for (const doc of response.results) {
+      expect(doc.ownerId).toBe(superuserId);
+    }
+  });
+
   test("Delete document as user 1", async () => {
     const response = await user1Client.documents.delete({
       id: user1DocumentId,

--- a/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
+++ b/js/sdk/__tests__/DocumentsAndCollectionsIntegrationUser.test.ts
@@ -294,6 +294,48 @@ describe("r2rClient V3 System Integration Tests User", () => {
   //   expect(response.results.documentCount).toBe(0);
   // });
 
+  test("Add user 1 to user 2's collection", async () => {
+    const response = await user2Client.collections.addUser({
+      id: user2CollectionId,
+      userId: user1Id,
+    });
+    expect(response.results).toBeDefined();
+    expect(response.results.success).toBe(true);
+  });
+
+  test("List collections as user 1", async () => {
+    const response = await user1Client.collections.list();
+    expect(response.results).toBeDefined();
+    expect(response.results.length).toBe(2);
+  });
+
+  test("List collections as user 1 with ownerOnly set to true", async () => {
+    const response = await user1Client.collections.list({ ownerOnly: true });
+    expect(response.results).toBeDefined();
+    expect(response.results.length).toBe(1);
+  });
+
+  test("Add user 2 to user 1's collection", async () => {
+    const response = await user1Client.collections.addUser({
+      id: user1CollectionId,
+      userId: user2Id,
+    });
+    expect(response.results).toBeDefined();
+    expect(response.results.success).toBe(true);
+  });
+
+  test("List collections as user 2", async () => {
+    const response = await user2Client.collections.list();
+    expect(response.results).toBeDefined();
+    expect(response.results.length).toBe(2);
+  });
+
+  test("List collections as user 2 with ownerOnly set to true", async () => {
+    const response = await user2Client.collections.list({ ownerOnly: true });
+    expect(response.results).toBeDefined();
+    expect(response.results.length).toBe(1);
+  });
+
   test("Delete user 1", async () => {
     const response = await client.users.delete({
       id: user1Id,

--- a/js/sdk/package-lock.json
+++ b/js/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/js/sdk/package.json
+++ b/js/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "r2r-js",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",
@@ -16,9 +16,10 @@
     "test": "jest --no-cache",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:users": "jest UsersIntegrationSuperUser",
+    "test:collections": "jest CollectionsIntegrationSuperUser CollectionsIntegrationUser",
+    "test:documents": "jest DocumentsIntegrationSuperUser",
     "test:retrieval": "jest RetrievalIntegrationSuperUser",
-    "test:documents": "jest DocumentsIntegrationSuperUser"
+    "test:users": "jest UsersIntegrationSuperUser"
   },
   "files": [
     "dist"

--- a/js/sdk/src/v3/clients/collections.ts
+++ b/js/sdk/src/v3/clients/collections.ts
@@ -37,12 +37,14 @@ export class CollectionsClient {
    * @param ids Optional list of collection IDs to filter by
    * @param offset Optional offset for pagination
    * @param limit Optional limit for pagination
+   * @param ownerOnly If true, only returns collections owned by the user, not all accessible collections
    * @returns
    */
   async list(options?: {
     ids?: string[];
     offset?: number;
     limit?: number;
+    ownerOnly?: boolean;
   }): Promise<WrappedCollectionsResponse> {
     const params: Record<string, any> = {
       offset: options?.offset ?? 0,
@@ -51,6 +53,10 @@ export class CollectionsClient {
 
     if (options?.ids && options.ids.length > 0) {
       params.ids = options.ids;
+    }
+
+    if (options?.ownerOnly) {
+      params.owner_only = options.ownerOnly;
     }
 
     return this.client.makeRequest("GET", "collections", {

--- a/js/sdk/src/v3/clients/documents.ts
+++ b/js/sdk/src/v3/clients/documents.ts
@@ -235,23 +235,28 @@ export class DocumentsClient {
    * @param offset Specifies the number of objects to skip. Defaults to 0.
    * @param limit Specifies a limit on the number of objects to return, ranging between 1 and 1000. Defaults to 100.
    * @param includeSummaryEmbeddings Specifies whether or not to include embeddings of each document summary. Defaults to false.
+   * @param ownerOnly If true, only returns documents owned by the user, not all accessible documents
    * @returns Promise<WrappedDocumentsResponse>
    */
   async list(options?: {
     ids?: string[];
     offset?: number;
     limit?: number;
-    includeSummaryEmbeddings?: boolean; // Added parameter
+    includeSummaryEmbeddings?: boolean;
+    ownerOnly?: boolean;
   }): Promise<WrappedDocumentsResponse> {
     const params: Record<string, any> = {
       offset: options?.offset ?? 0,
       limit: options?.limit ?? 100,
-      include_summary_embeddings: options?.includeSummaryEmbeddings ?? false, // Added mapping to snake_case
+      include_summary_embeddings: options?.includeSummaryEmbeddings ?? false,
     };
 
     if (options?.ids?.length) {
-      // Ensure 'ids' is only added if the array is not empty
       params.ids = options.ids;
+    }
+
+    if (options?.ownerOnly) {
+      params.owner_only = options.ownerOnly;
     }
 
     return this.client.makeRequest("GET", "documents", {

--- a/py/core/main/api/v3/collections_router.py
+++ b/py/core/main/api/v3/collections_router.py
@@ -338,6 +338,10 @@ class CollectionsRouter(BaseRouterV3):
                 le=1000,
                 description="Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.",
             ),
+            owner_only: bool = Query(
+                False,
+                description="If true, only returns collections owned by the user, not all accessible collections.",
+            ),
             auth_user=Depends(self.providers.auth.auth_wrapper()),
         ) -> WrappedCollectionsResponse:
             """Returns a paginated list of collections the authenticated user
@@ -350,9 +354,10 @@ class CollectionsRouter(BaseRouterV3):
             The collections are returned in order of last modification, with
             most recent first.
             """
-            requesting_user_id = (
-                None if auth_user.is_superuser else [auth_user.id]
-            )
+            if auth_user.is_superuser:
+                requesting_user_id = [auth_user.id] if owner_only else None
+            else:
+                requesting_user_id = [auth_user.id]
 
             collection_uuids = [UUID(collection_id) for collection_id in ids]
 
@@ -362,6 +367,7 @@ class CollectionsRouter(BaseRouterV3):
                     collection_ids=collection_uuids,
                     offset=offset,
                     limit=limit,
+                    owner_only=owner_only,
                 )
             )
 

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -603,6 +603,7 @@ class ManagementService(Service):
         user_ids: Optional[list[UUID]] = None,
         document_ids: Optional[list[UUID]] = None,
         collection_ids: Optional[list[UUID]] = None,
+        owner_only: bool = False,
     ) -> dict[str, list[CollectionResponse] | int]:
         return await self.providers.database.collections_handler.get_collections_overview(
             offset=offset,
@@ -610,6 +611,7 @@ class ManagementService(Service):
             filter_user_ids=user_ids,
             filter_document_ids=document_ids,
             filter_collection_ids=collection_ids,
+            owner_only=owner_only,
         )
 
     async def add_user_to_collection(

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -384,6 +384,7 @@ class ManagementService(Service):
         user_ids: Optional[list[UUID]] = None,
         collection_ids: Optional[list[UUID]] = None,
         document_ids: Optional[list[UUID]] = None,
+        owner_only: bool = False,
     ):
         return await self.providers.database.documents_handler.get_documents_overview(
             offset=offset,
@@ -391,6 +392,7 @@ class ManagementService(Service):
             filter_document_ids=document_ids,
             filter_user_ids=user_ids,
             filter_collection_ids=collection_ids,
+            owner_only=owner_only,
         )
 
     async def update_document_metadata(

--- a/py/core/providers/database/collections.py
+++ b/py/core/providers/database/collections.py
@@ -349,19 +349,23 @@ class PostgresCollectionsHandler(Handler):
         filter_user_ids: Optional[list[UUID]] = None,
         filter_document_ids: Optional[list[UUID]] = None,
         filter_collection_ids: Optional[list[UUID]] = None,
+        owner_only: bool = False,
     ) -> dict[str, list[CollectionResponse] | int]:
         conditions = []
         params: list[Any] = []
         param_index = 1
 
         if filter_user_ids:
-            conditions.append(f"""
-                c.id IN (
-                    SELECT unnest(collection_ids)
-                    FROM {self.project_name}.users
-                    WHERE id = ANY(${param_index})
-                )
-            """)
+            if owner_only:
+                conditions.append(f"c.owner_id = ANY(${param_index})")
+            else:
+                conditions.append(f"""
+                    c.id IN (
+                        SELECT unnest(collection_ids)
+                        FROM {self.project_name}.users
+                        WHERE id = ANY(${param_index})
+                    )
+                """)
             params.append(filter_user_ids)
             param_index += 1
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "r2r"
-version = "3.5.17"
+version = "3.5.18"
 description = "SciPhi R2R"
 readme = "README.md"
 license = {text = "MIT"}

--- a/py/sdk/asnyc_methods/collections.py
+++ b/py/sdk/asnyc_methods/collections.py
@@ -44,6 +44,7 @@ class CollectionsSDK:
         ids: Optional[list[str | UUID]] = None,
         offset: Optional[int] = 0,
         limit: Optional[int] = 100,
+        owner_only: Optional[bool] = False,
     ) -> WrappedCollectionsResponse:
         """List collections with pagination and filtering options.
 
@@ -51,6 +52,7 @@ class CollectionsSDK:
             ids (Optional[list[str | UUID]]): Filter collections by ids
             offset (int, optional): Specifies the number of objects to skip. Defaults to 0.
             limit (int, optional): Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.
+            owner_only (Optional[bool]): If true, only returns collections owned by the user, not all accessible collections.
 
         Returns:
             WrappedCollectionsResponse
@@ -58,6 +60,7 @@ class CollectionsSDK:
         params: dict = {
             "offset": offset,
             "limit": limit,
+            "owner_only": owner_only,
         }
         if ids:
             params["ids"] = ids

--- a/py/sdk/asnyc_methods/documents.py
+++ b/py/sdk/asnyc_methods/documents.py
@@ -614,13 +614,17 @@ class DocumentsSDK:
         ids: Optional[list[str | UUID]] = None,
         offset: Optional[int] = 0,
         limit: Optional[int] = 100,
+        include_summary_embeddings: Optional[bool] = False,
+        owner_only: Optional[bool] = False,
     ) -> WrappedDocumentsResponse:
         """List documents with pagination.
 
         Args:
-            ids (Optional[list[str | UUID]]): Optional list of document IDs to filter by
-            offset (int, optional): Specifies the number of objects to skip. Defaults to 0.
-            limit (int, optional): Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.
+            ids (Optional[list[str | UUID]]): Optional list of document IDs to filter by.
+            offset (int, optional): Number of objects to skip. Defaults to 0.
+            limit (int, optional): Max number of objects to return (1-1000). Defaults to 100.
+            include_summary_embeddings (Optional[bool]): Whether to include summary embeddings (default: False).
+            owner_only (Optional[bool]): If true, only returns documents owned by the user, not all accessible documents.
 
         Returns:
             WrappedDocumentsResponse
@@ -628,6 +632,8 @@ class DocumentsSDK:
         params = {
             "offset": offset,
             "limit": limit,
+            "include_summary_embeddings": include_summary_embeddings,
+            "owner_only": owner_only,
         }
         if ids:
             params["ids"] = [str(doc_id) for doc_id in ids]  # type: ignore

--- a/py/sdk/sync_methods/collections.py
+++ b/py/sdk/sync_methods/collections.py
@@ -44,6 +44,7 @@ class CollectionsSDK:
         ids: Optional[list[str | UUID]] = None,
         offset: Optional[int] = 0,
         limit: Optional[int] = 100,
+        owner_only: Optional[bool] = False,
     ) -> WrappedCollectionsResponse:
         """List collections with pagination and filtering options.
 
@@ -51,6 +52,7 @@ class CollectionsSDK:
             ids (Optional[list[str | UUID]]): Filter collections by ids
             offset (int, optional): Specifies the number of objects to skip. Defaults to 0.
             limit (int, optional): Specifies a limit on the number of objects to return, ranging between 1 and 100. Defaults to 100.
+            owner_only (bool, optional): If true, only returns collections owned by the user, not all accessible collections.
 
         Returns:
             WrappedCollectionsResponse
@@ -58,6 +60,7 @@ class CollectionsSDK:
         params: dict = {
             "offset": offset,
             "limit": limit,
+            "owner_only": owner_only,
         }
         if ids:
             params["ids"] = ids

--- a/py/sdk/sync_methods/documents.py
+++ b/py/sdk/sync_methods/documents.py
@@ -6,8 +6,8 @@ import uuid
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Optional  # Added list, dict for clarity
-from urllib.parse import urlparse  # Added quote for export filenames
+from typing import Any, Optional
+from urllib.parse import urlparse
 from uuid import UUID
 
 import requests
@@ -805,7 +805,8 @@ class DocumentsSDK:
         ids: Optional[list[str | UUID]] = None,
         offset: Optional[int] = 0,
         limit: Optional[int] = 100,
-        include_summary_embeddings: Optional[bool] = False,  # Added parameter
+        include_summary_embeddings: Optional[bool] = False,
+        owner_only: Optional[bool] = False,
     ) -> WrappedDocumentsResponse:
         """list documents with pagination.
 
@@ -816,6 +817,7 @@ class DocumentsSDK:
             offset (int, optional): Number of objects to skip. Defaults to 0.
             limit (int, optional): Max number of objects to return (1-1000). Defaults to 100.
             include_summary_embeddings (Optional[bool]): Whether to include summary embeddings (default: False).
+            owner_only (Optional[bool]): If true, only returns documents owned by the user, not all accessible documents.
 
         Returns:
             WrappedDocumentsResponse
@@ -823,11 +825,11 @@ class DocumentsSDK:
         params: dict[str, Any] = {
             "offset": offset,
             "limit": limit,
+            "include_summary_embeddings": include_summary_embeddings,
+            "owner_only": owner_only,
         }
         if ids:
             params["ids"] = [str(doc_id) for doc_id in ids]
-        if include_summary_embeddings:  # Only add if True
-            params["include_summary_embeddings"] = True
 
         response_dict = self.client._make_request(
             "GET",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `ownerOnly` filter to collections and documents listing, with tests for functionality and error handling.
> 
>   - **Behavior**:
>     - Adds `ownerOnly` filter to `list` methods in `collections.ts` and `documents.ts` to return only user-owned items.
>     - Updates `list_collections` and `get_documents` in `collections_router.py` and `documents_router.py` to handle `ownerOnly` parameter.
>     - Modifies `get_collections_overview` and `get_documents_overview` in `collections.py` and `documents.py` to support `ownerOnly` filtering.
>   - **Tests**:
>     - Adds tests in `test_users.py` to verify `ownerOnly` filter behavior for collections and documents.
>     - Includes tests for invalid `ownerOnly` parameter handling.
>   - **Misc**:
>     - Bumps version in `package.json` and `pyproject.toml` to reflect changes.
>     - Updates test scripts in `package.json` to include new test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 421a3b50a3ae65521ecbe674ab0e62a0fbf9f28f. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->