### PR TITLE
Remove Docker Logging Configuration

### DIFF
--- a/docker/compose.full.swarm.yaml
+++ b/docker/compose.full.swarm.yaml
@@ -378,12 +378,6 @@ services:
       rollback_config:
         parallelism: 1
         delay: 30s
-    logging:
-      driver: fluentd
-      options:
-        fluentd-address: host.docker.internal:24224
-        fluentd-sub-second-precision: "true"
-        tag: backend
 
   r2r-dashboard:
     image: sciphiai/r2r-dashboard:1.0.3
@@ -396,29 +390,3 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-
-  fluent-bit:
-    image: fluent/fluent-bit:latest
-    volumes:
-    - ./docker/fluent-bit:/fluent-bit/etc:ro
-    ports:
-    - "24224:24224"
-    depends_on:
-    - victoria-logs
-
-  grafana:
-    image: grafana/grafana:latest
-    ports:
-    - "3001:3000"
-    env_file:
-    - .env
-    volumes:
-    - ./.data/grafana:/var/lib/grafana
-
-  victoria-logs:
-    image: victoriametrics/victoria-logs:v1.10.1-victorialogs
-    ports:
-    - "9428:9428"
-    volumes:
-    - ./.data/victoria-logs:/data
-    command: -storageDataPath=/data -retentionPeriod=60d

--- a/docker/compose.full.yaml
+++ b/docker/compose.full.yaml
@@ -185,12 +185,6 @@ services:
         condition: service_healthy
       graph_clustering:
         condition: service_healthy
-    logging:
-      driver: fluentd
-      options:
-        fluentd-address: host.docker.internal:24224
-        fluentd-sub-second-precision: "true"
-        tag: backend
 
   r2r-dashboard:
     image: sciphiai/r2r-dashboard:1.0.3
@@ -198,27 +192,3 @@ services:
       - ./env/r2r-dashboard.env
     ports:
       - "7273:3000"
-
-  fluent-bit:
-    image: fluent/fluent-bit:latest
-    volumes:
-    - ./fluent-bit:/fluent-bit/etc:ro
-    ports:
-    - "24224:24224"
-    depends_on:
-    - victoria-logs
-
-  grafana:
-    image: grafana/grafana:latest
-    ports:
-    - "3001:3000"
-    volumes:
-    - ./.data/grafana:/var/lib/grafana
-
-  victoria-logs:
-    image: victoriametrics/victoria-logs:v1.10.1-victorialogs
-    ports:
-    - "9428:9428"
-    volumes:
-    - ./.data/victoria-logs:/data
-    command: -storageDataPath=/data -retentionPeriod=60d


### PR DESCRIPTION
Removes logging configurations in Docker until we move to a different provider. Seems that Victoria Logs had issues with some distributions of Ubuntu. 

Closes #2139
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove Fluentd logging configuration and related services from Docker Compose files due to Victoria Logs' compatibility issues with Ubuntu.
> 
>   - **Logging Configuration Removal**:
>     - Removed Fluentd logging configuration from `compose.full.swarm.yaml` and `compose.full.yaml`.
>     - Removed `fluent-bit`, `grafana`, and `victoria-logs` services from both files.
>   - **Reason**:
>     - Victoria Logs had compatibility issues with some Ubuntu distributions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 73a03825bf8fa96cb9186fdf321bd2ed75e27282. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->