### PR TITLE
Fix: Add support for Halfwidth and Fullwidth Forms in BasicPDFParser

### DIFF
--- a/py/core/parsers/media/pdf_parser.py
+++ b/py/core/parsers/media/pdf_parser.py
@@ -398,6 +398,7 @@ class BasicPDFParser(AsyncParser[str | bytes]):
                             or "\u0e00" <= x <= "\u0e7f"  # Thai
                             or "\u3040" <= x <= "\u309f"  # Japanese Hiragana
                             or "\u30a0" <= x <= "\u30ff"  # Katakana
+                            or "\uFF00" <= x <= "\uFFEF"  # Halfwidth and Fullwidth Forms
                             or x in string.printable
                         ),
                         page_text,


### PR DESCRIPTION
Halfwidth and Fullwidth Forms frequently appear in Japanese documents. Allowing this Unicode block has improved the accuracy of responses.
<!-- ELLIPSIS_HIDDEN -->

> [!IMPORTANT]
> Adds support for Halfwidth and Fullwidth Forms in `BasicPDFParser.ingest()` by including Unicode range `\uFF00` to `\uFFEF`.
> 
>   - **Behavior**:
>     - Adds support for Halfwidth and Fullwidth Forms in `BasicPDFParser.ingest()` by including Unicode range `\uFF00` to `\uFFEF` in character filter.
>   - **Files**:
>     - Modified `pdf_parser.py` to include the new Unicode range in `BasicPDFParser`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for c6197571bbb2326a94fbec6968017469acffdb40. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

