### PR TITLE
No timeout by default, only for VLM PDF parsing for now

### DIFF
--- a/py/core/base/providers/llm.py
+++ b/py/core/base/providers/llm.py
@@ -56,7 +56,7 @@ class CompletionProvider(Provider):
     async def _execute_with_backoff_async(
         self,
         task: dict[str, Any],
-        timeout: bool = False,
+        apply_timeout: bool = False,
     ):
         retries = 0
         backoff = self.config.initial_backoff
@@ -64,7 +64,7 @@ class CompletionProvider(Provider):
             try:
                 # A semaphore allows us to limit concurrent requests
                 async with self.semaphore:
-                    if not timeout:
+                    if not apply_timeout:
                         return await self._execute_task(task)
 
                     try:  # Use asyncio.wait_for to set a timeout for the request
@@ -114,12 +114,12 @@ class CompletionProvider(Provider):
     def _execute_with_backoff_sync(
         self,
         task: dict[str, Any],
-        timeout: bool = False,
+        apply_timeout: bool = False,
     ):
         retries = 0
         backoff = self.config.initial_backoff
         while retries < self.config.max_retries:
-            if not timeout:
+            if not apply_timeout:
                 return self._execute_task_sync(task)
 
             try:
@@ -170,7 +170,7 @@ class CompletionProvider(Provider):
         self,
         messages: list[dict],
         generation_config: GenerationConfig,
-        timeout: bool = False,
+        apply_timeout: bool = False,
         **kwargs,
     ) -> LLMChatCompletion:
         task = {
@@ -179,7 +179,7 @@ class CompletionProvider(Provider):
             "kwargs": kwargs,
         }
         response = await self._execute_with_backoff_async(
-            task=task, timeout=timeout
+            task=task, apply_timeout=apply_timeout
         )
         return LLMChatCompletion(**response.dict())
 

--- a/py/core/base/providers/llm.py
+++ b/py/core/base/providers/llm.py
@@ -53,21 +53,27 @@ class CompletionProvider(Provider):
             max_workers=config.concurrent_request_limit
         )
 
-    async def _execute_with_backoff_async(self, task: dict[str, Any]):
+    async def _execute_with_backoff_async(
+        self,
+        task: dict[str, Any],
+        timeout: bool = False,
+    ):
         retries = 0
         backoff = self.config.initial_backoff
         while retries < self.config.max_retries:
             try:
                 # A semaphore allows us to limit concurrent requests
                 async with self.semaphore:
-                    # And we use asyncio.wait_for to set a timeout for the request
-                    try:
+                    if not timeout:
+                        return await self._execute_task(task)
+
+                    try:  # Use asyncio.wait_for to set a timeout for the request
                         return await asyncio.wait_for(
                             self._execute_task(task),
                             timeout=self.config.request_timeout,
                         )
                     except asyncio.TimeoutError as e:
-                        raise Exception(
+                        raise TimeoutError(
                             f"Request timed out after {self.config.request_timeout} seconds"
                         ) from e
             except AuthenticationError:
@@ -105,15 +111,22 @@ class CompletionProvider(Provider):
                 await asyncio.sleep(random.uniform(0, backoff))
                 backoff = min(backoff * 2, self.config.max_backoff)
 
-    def _execute_with_backoff_sync(self, task: dict[str, Any]):
+    def _execute_with_backoff_sync(
+        self,
+        task: dict[str, Any],
+        timeout: bool = False,
+    ):
         retries = 0
         backoff = self.config.initial_backoff
         while retries < self.config.max_retries:
+            if not timeout:
+                return self._execute_task_sync(task)
+
             try:
                 future = self.thread_pool.submit(self._execute_task_sync, task)
                 return future.result(timeout=self.config.request_timeout)
             except TimeoutError as e:
-                raise Exception(
+                raise TimeoutError(
                     f"Request timed out after {self.config.request_timeout} seconds"
                 ) from e
             except Exception as e:
@@ -157,6 +170,7 @@ class CompletionProvider(Provider):
         self,
         messages: list[dict],
         generation_config: GenerationConfig,
+        timeout: bool = False,
         **kwargs,
     ) -> LLMChatCompletion:
         task = {
@@ -164,7 +178,9 @@ class CompletionProvider(Provider):
             "generation_config": generation_config,
             "kwargs": kwargs,
         }
-        response = await self._execute_with_backoff_async(task)
+        response = await self._execute_with_backoff_async(
+            task=task, timeout=timeout
+        )
         return LLMChatCompletion(**response.dict())
 
     async def aget_completion_stream(

--- a/py/core/parsers/media/pdf_parser.py
+++ b/py/core/parsers/media/pdf_parser.py
@@ -155,6 +155,7 @@ class VLMPDFParser(AsyncParser[str | bytes]):
                 response = await self.llm_provider.aget_completion(
                     messages=messages,
                     generation_config=generation_config,
+                    timeout=True,
                     tools=[
                         {
                             "name": "parse_pdf_page",
@@ -198,7 +199,9 @@ class VLMPDFParser(AsyncParser[str | bytes]):
                     return {"page": str(page_num), "content": ""}
             else:
                 response = await self.llm_provider.aget_completion(
-                    messages=messages, generation_config=generation_config
+                    messages=messages,
+                    generation_config=generation_config,
+                    timeout=True,
                 )
 
                 if response.choices and response.choices[0].message:

--- a/py/core/parsers/media/pdf_parser.py
+++ b/py/core/parsers/media/pdf_parser.py
@@ -155,7 +155,7 @@ class VLMPDFParser(AsyncParser[str | bytes]):
                 response = await self.llm_provider.aget_completion(
                     messages=messages,
                     generation_config=generation_config,
-                    timeout=True,
+                    apply_timeout=True,
                     tools=[
                         {
                             "name": "parse_pdf_page",
@@ -201,7 +201,7 @@ class VLMPDFParser(AsyncParser[str | bytes]):
                 response = await self.llm_provider.aget_completion(
                     messages=messages,
                     generation_config=generation_config,
-                    timeout=True,
+                    apply_timeout=True,
                 )
 
                 if response.choices and response.choices[0].message:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add optional timeout feature for VLM PDF parsing in `VLMPDFParser` using `apply_timeout` parameter in `llm.py`.
> 
>   - **Behavior**:
>     - Introduces `apply_timeout` parameter in `_execute_with_backoff_async` and `_execute_with_backoff_sync` in `llm.py` to optionally apply timeouts.
>     - `VLMPDFParser` in `pdf_parser.py` now uses `apply_timeout=True` when calling `aget_completion` for PDF page processing.
>   - **Error Handling**:
>     - Raises `TimeoutError` instead of `Exception` on request timeout in `llm.py`.
>   - **Misc**:
>     - Minor refactoring in `llm.py` to handle optional timeout logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for e1f87d1fd136dadb5927915a2319f6603902f1ff. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->