### PR TITLE
fix(ollama): correct API base URL for Ollama integration

### DIFF
--- a/py/core/configs/full_ollama.toml
+++ b/py/core/configs/full_ollama.toml
@@ -43,7 +43,7 @@ concurrent_request_limit = 1
   top_p = 1
   max_tokens_to_sample = 1_024
   stream = false
-  api_base = "http://localhost:11434/v1"
+  api_base = "http://host.docker.internal:11434"
 
 [ingestion]
 provider = "unstructured_local"


### PR DESCRIPTION
Fixed issue #2177 where Ollama connections were failing with "All connection attempts failed" errors. The problem was caused by an incorrect API base URL format in the full_ollama.toml configuration.

Changed:
- Removed the "/v1" suffix from the Ollama API base URL
- Updated from "http://localhost:11434/v1" to "http://host.docker.internal:11434"

This change aligns with LiteLLM's expected format for Ollama connections and resolves the connection errors reported in the issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects API base URL in `full_ollama.toml` to fix Ollama connection errors.
> 
>   - **Configuration**:
>     - Corrected API base URL in `full_ollama.toml` by removing "/v1" suffix.
>     - Updated URL from `http://localhost:11434/v1` to `http://host.docker.internal:11434`.
>   - **Issue Fix**:
>     - Resolves issue #2177 related to "All connection attempts failed" errors in Ollama connections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 4a83aa4272ac2a02ab5d0182e7ad2b7b80554675. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->