### PR TITLE
Fix community summary errors where openai returns non xml entity strings

### DIFF
--- a/py/core/main/services/graph_service.py
+++ b/py/core/main/services/graph_service.py
@@ -813,7 +813,9 @@ class GraphService(Service):
                         "No <community> XML found in LLM response"
                     )
 
-                xml_content = match.group(0)
+                xml_content = re.sub(
+                    r"&(?!amp;|quot;|apos;|lt;|gt;)", "&amp;", match.group(0)
+                ).strip()
                 root = ET.fromstring(xml_content)
 
                 # extract fields


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes XML parsing errors in `_process_community_summary` by replacing invalid XML entities with `&amp;` in `graph_service.py`.
> 
>   - **Behavior**:
>     - Fixes XML parsing errors in `_process_community_summary` in `graph_service.py` by replacing invalid XML entities with `&amp;`.
>     - Specifically targets cases where `&` is not followed by `amp;`, `quot;`, `apos;`, `lt;`, or `gt;`.
>   - **Misc**:
>     - Uses `re.sub` to perform the replacement before parsing XML content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 49778a2820d5689a7615d150dbaee4e997508b6a. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->