### PR TITLE
Fix middleware for containers

### DIFF
--- a/py/core/main/app_entry.py
+++ b/py/core/main/app_entry.py
@@ -12,6 +12,7 @@ from core.base import R2RException
 from core.utils.logging_config import configure_logging
 
 from .assembly import R2RBuilder, R2RConfig
+from .middleware.project_schema import ProjectSchemaMiddleware
 
 log_file = configure_logging()
 
@@ -122,4 +123,9 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+)
+
+app.add_middleware(
+    ProjectSchemaMiddleware,
+    default_schema="r2r_default",
 )

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "r2r"
-version = "3.6.2"
+version = "3.6.3"
 description = "SciPhi R2R"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Patches an issue where x-project-name was not working in containers—probably need to look at harmonizing how the containerized and non-containerized FastAPI is created to remove duplicate code and redundancy. 

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `ProjectSchemaMiddleware` to FastAPI app and updates version to 3.6.3.
> 
>   - **Middleware**:
>     - Adds `ProjectSchemaMiddleware` to `app_entry.py` with `default_schema="r2r_default"`.
>   - **Versioning**:
>     - Updates version in `pyproject.toml` from `3.6.2` to `3.6.3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 3572ed1a51b10a92cc5c6c1b48c3a9fd5e776766. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->