### PR TITLE
Fix incorrect project name

### DIFF
--- a/py/core/main/app_entry.py
+++ b/py/core/main/app_entry.py
@@ -78,7 +78,7 @@ port = int(os.getenv("R2R_PORT", "7272"))
 config = R2RConfig.load(config_name=config_name, config_path=config_path)
 
 project_name = (
-    os.getenv("R2R_PROJECT_NAME") or config.app.project_name or "default"
+    os.getenv("R2R_PROJECT_NAME") or config.app.project_name or "r2r_default"
 )
 
 logging.info(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default project name to `r2r_default` in `app_entry.py` when environment and config settings are absent.
> 
>   - **Behavior**:
>     - Change default project name from `default` to `r2r_default` in `app_entry.py` when `R2R_PROJECT_NAME` and `config.app.project_name` are not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for fdbe4a9140a753de35dcb17e44f69f62a4ebb18c. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->