### PR TITLE
Context for rag tool and extended thinking with non-claude models

### DIFF
--- a/py/core/agent/research.py
+++ b/py/core/agent/research.py
@@ -115,6 +115,7 @@ class ResearchAgentMixin(RAGAgentMixin):
                 },
                 "required": ["query"],
             },
+            context=self,
         )
 
     def reasoning_tool(self) -> Tool:

--- a/py/core/base/agent/agent.py
+++ b/py/core/base/agent/agent.py
@@ -227,7 +227,17 @@ class Agent(ABC):
                     )
                 )
                 # HACK - to fix issues with claude thinking + tool use [https://github.com/anthropics/anthropic-cookbook/blob/main/extended_thinking/extended_thinking_with_tool_use.ipynb]
-                if self.rag_generation_config.extended_thinking:
+                logger.debug(
+                    f"Extended thinking - Claude needs a particular message continuation which however breaks other models. Model in use : {self.rag_generation_config.model}"
+                )
+                is_anthropic = (
+                    self.rag_generation_config.model
+                    and "anthropic/" in self.rag_generation_config.model
+                )
+                if (
+                    self.rag_generation_config.extended_thinking
+                    and is_anthropic
+                ):
                     await self.conversation.add_message(
                         Message(
                             role="user",


### PR DESCRIPTION
## 🛠️ Fixes & Improvements

This pull request addresses two key issues:

### 1. RAG Tool Context Injection in Research Agent
- **Fixes** [issue #2198](https://github.com/SciPhi-AI/R2R/issues/2198)
- The Research Agent was previously lacking proper context injection into the RAG tool.
- This PR ensures the necessary context is now passed correctly, improving relevance and performance in document retrieval tasks.

### 2. Extended Thinking Flow with Non-Anthropic Models
- Resolved a breaking issue caused by how "Continue" messages were handled during extended thinking with **non-Anthropic models**.
- Previously, this flow would trigger the following error:
  ```
  Agent error: Error code: 400 - {'error': {'message': "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: {...}"}
  ```
- The root cause was a violation of the expected sequence:
  ```
  assistant: tool call -> tool: tool reply
  ```
- This PR implements a proper chaining mechanism that maintains the required format, ensuring stability and compatibility across model types.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes context injection for RAG tool in `research.py` and handles "Continue" messages for non-Anthropic models in `agent.py`.
> 
>   - **RAG Tool Context Injection**:
>     - Adds `context=self` to `rag_tool()` in `research.py` to fix context injection issue.
>   - **Extended Thinking with Non-Anthropic Models**:
>     - Adds check for "anthropic/" in model name in `handle_function_or_tool_call()` in `agent.py` to conditionally add "Continue..." message.
>     - Fixes error handling for "Continue" messages in non-Anthropic models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 91787bcbf3be5c4420e8d0986d79a9790b7a0237. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->