### PR TITLE
update: add $in filter to delete_documents_and_chunks_by_filter

### DIFF
--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -156,6 +156,10 @@ class ManagementService(Service):
                 document_ids.add(
                     UUID(value) if isinstance(value, str) else value
                 )
+            elif isinstance(doc_id, dict) and "$in" in doc_id:
+                values = doc_id["$in"]
+                document_ids.update([UUID(value) for value in values])
+
 
         # Delete matching chunks from the database
         delete_results = await self.providers.database.chunks_handler.delete(

--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -158,7 +158,7 @@ class ManagementService(Service):
                 )
             elif isinstance(doc_id, dict) and "$in" in doc_id:
                 values = doc_id["$in"]
-                document_ids.update([UUID(value) for value in values])
+                document_ids.update([UUID(value) if isinstance(value, str) else value for value in values])
 
 
         # Delete matching chunks from the database


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for `$in` filter in `delete_documents_and_chunks_by_filter` in `management_service.py` to allow deletion of multiple document IDs.
> 
>   - **Behavior**:
>     - Adds support for `$in` filter in `delete_documents_and_chunks_by_filter` in `management_service.py` to allow deletion of multiple document IDs.
>     - Updates `document_ids` set with UUIDs from `$in` filter values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for c095ff856bc5615f028f9973c5516472dc8ff7f0. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

Example of specifying in the body: 
```json
{
    "document_id": {
        "$in": ["id1", "id2"]
    }
}
```