### PR TITLE
Allow passing explicit filename via metadata title

### DIFF
--- a/py/core/main/api/v3/documents_router.py
+++ b/py/core/main/api/v3/documents_router.py
@@ -454,13 +454,16 @@ class DocumentsRouter(BaseRouterV3):
                 if file:
                     file_data = await self._process_file(file)
 
-                    if not file.filename:
+                    if metadata.get("title"):
+                        file_data["filename"] = metadata["title"]
+
+                    if not file_data["filename"]:
                         raise R2RException(
                             status_code=422,
                             message="Uploaded file must have a filename.",
                         )
 
-                    file_ext = file.filename.split(".")[
+                    file_ext = file_data["filename"].split(".")[
                         -1
                     ]  # e.g. "pdf", "txt"
                     max_allowed_size = await self.services.management.get_max_upload_size_by_type(


### PR DESCRIPTION
Solves https://github.com/SciPhi-AI/R2R/issues/2218
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `create_document`, use `metadata['title']` as filename for uploaded files if original filename is missing, addressing issue #2218.
> 
>   - **Behavior**:
>     - In `create_document` in `documents_router.py`, if `metadata['title']` is provided, it is used as the filename for uploaded files when the original filename is missing.
>     - Raises `R2RException` if no filename is available after checking `metadata['title']`.
>   - **Misc**:
>     - Addresses issue #2218.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for e25a3ed2cf46d55e190558bf9a71f34d69b1b02a. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->