### PR TITLE
Refactor ConversationsSDK to use JSON for request payload in async and sync methods

### DIFF
--- a/py/core/providers/ingestion/unstructured/base.py
+++ b/py/core/providers/ingestion/unstructured/base.py
@@ -140,6 +140,7 @@ class UnstructuredIngestionProvider(IngestionProvider):
         ) = llm_provider
         self.ocr_provider: MistralOCRProvider = ocr_provider
 
+        self.client: UnstructuredClient | httpx.AsyncClient
         if config.provider == "unstructured_api":
             try:
                 self.unstructured_api_auth = os.environ["UNSTRUCTURED_API_KEY"]

--- a/py/sdk/asnyc_methods/conversations.py
+++ b/py/sdk/asnyc_methods/conversations.py
@@ -31,10 +31,11 @@ class ConversationsSDK:
         if name:
             data["name"] = name
 
+        # Send JSON so that FastAPI body validation succeeds.
         response_dict = await self.client._make_request(
             "POST",
             "conversations",
-            data=data,
+            json=data,
             version="v3",
         )
 

--- a/py/sdk/sync_methods/conversations.py
+++ b/py/sdk/sync_methods/conversations.py
@@ -32,7 +32,7 @@ class ConversationsSDK:
         response_dict = self.client._make_request(
             "POST",
             "conversations",
-            data=data,
+            json=data,
             version="v3",
         )
 


### PR DESCRIPTION
## Refactor ConversationsSDK to Use JSON Payloads

### Summary

This PR updates both the async and sync `ConversationsSDK` methods to send request payloads as JSON instead of form data. This change ensures compatibility with FastAPI's body validation.

### Changes

- **Async and Sync SDKs:**  
  - Updated `py/sdk/asnyc_methods/conversations.py` and `py/sdk/sync_methods/conversations.py` to use the `json` parameter instead of `data` when making POST requests and avoid the error where name args was not recognized.
- **Unstructured Ingestion Provider:**  
  - Minor type annotation addition for the `client` attribute in `py/core/providers/ingestion/unstructured/base.py` to fix mypy.

### Motivation

- Fixes issues with FastAPI expecting JSON bodies for POST requests.
- Improves consistency and reliability of API interactions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor ConversationsSDK to use JSON for request payloads in async and sync methods, ensuring FastAPI compatibility, and add type annotation in Unstructured Ingestion Provider.
> 
>   - **Behavior**:
>     - Refactor `ConversationsSDK` in `asnyc_methods/conversations.py` and `sync_methods/conversations.py` to use `json` parameter instead of `data` for POST requests.
>     - Ensures compatibility with FastAPI's body validation.
>   - **Unstructured Ingestion Provider**:
>     - Add type annotation for `client` attribute in `base.py` to fix mypy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 1b9fb1d503d03dc6112cce1178b2e118b126fb59. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->