### PR TITLE
Stop graph deduplication jobs for documents with zero entities

### DIFF
--- a/py/core/main/services/graph_service.py
+++ b/py/core/main/services/graph_service.py
@@ -1307,6 +1307,18 @@ class GraphService(Service):
         """
         Inlined from old code: merges duplicates by name, calls LLM for a new consolidated description, updates the record.
         """
+        entity_count = (
+            await self.providers.database.entities_handler.get_entity_count(
+                document_id=document_id,
+                entity_table_name="documents_entities",
+            )
+        )
+        if entity_count == 0:
+            logger.info(
+                f"No entities found for document {document_id}. Skipping deduplication."
+            )
+            return
+
         merged_results = await self.providers.database.entities_handler.merge_duplicate_name_blocks(
             parent_id=document_id,
             store_type=StoreType.DOCUMENTS,

--- a/py/scripts/backfill_document_summaries.py
+++ b/py/scripts/backfill_document_summaries.py
@@ -34,6 +34,20 @@ def _chunk_records_to_dicts(results: list[dict]) -> list[dict]:
 async def backfill_document_summaries() -> None:
     """Generate and store summaries for documents lacking one."""
     config = R2RConfig.load()
+    # `backfill_document_summaries` runs as a one-off maintenance script and
+    # does not require the distributed Hatchet orchestrator. Some config
+    # presets (e.g. "full") enable the Hatchet provider by default which in
+    # turn expects the `HATCHET_CLIENT_TOKEN` environment variable to be set.
+    # When the token is absent the script would previously crash during
+    # provider creation. Fallback to the lightweight "simple" orchestration
+    # provider unless the token is available so Hatchet can be used when
+    # desired.
+    if not os.getenv("HATCHET_CLIENT_TOKEN"):
+        logger.info(
+            "HATCHET_CLIENT_TOKEN not set; using simple orchestration provider"
+        )
+        config.orchestration.provider = "simple"
+
     builder = R2RBuilder(config)
     app = await builder.build()
 

--- a/py/scripts/backfill_document_summaries.py
+++ b/py/scripts/backfill_document_summaries.py
@@ -1,0 +1,73 @@
+import asyncio
+import os
+import sys
+from typing import List
+
+# Ensure the repository's Python package path is available when executing as a script.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.main.config import R2RConfig
+from core.main.assembly.builder import R2RBuilder
+from core.base import DocumentResponse
+
+
+def _chunk_records_to_dicts(results: List[dict]) -> List[dict]:
+    """Translate chunk records from the database into the format expected by
+    IngestionService.augment_document_info."""
+    chunk_dicts = []
+    for r in results:
+        chunk_dicts.append(
+            {
+                "id": r["id"],
+                "document_id": r["document_id"],
+                "owner_id": r["owner_id"],
+                "collection_ids": r["collection_ids"],
+                "data": r["text"],
+                "metadata": r["metadata"],
+            }
+        )
+    return chunk_dicts
+
+
+async def backfill_document_summaries() -> None:
+    """Generate and store summaries for documents lacking one."""
+    config = R2RConfig.from_toml(os.getenv("R2R_CONFIG"))
+    builder = R2RBuilder(config)
+    app = await builder.build()
+
+    ingestion_service = app.services.ingestion
+    providers = app.providers
+
+    # Fetch all documents missing a summary (NULL or empty string).
+    docs_resp = await providers.database.documents_handler.get_documents_overview(
+        offset=0,
+        limit=-1,
+        filters={
+            "$or": [
+                {"summary": {"$eq": None}},
+                {"summary": {"$eq": ""}},
+            ]
+        },
+    )
+    documents: List[DocumentResponse] = docs_resp["results"]
+
+    for doc in documents:
+        print(f"Processing document {doc.id}")
+        chunks_resp = await providers.database.chunks_handler.list_document_chunks(
+            document_id=doc.id,
+            offset=0,
+            limit=-1,
+        )
+        chunk_dicts = _chunk_records_to_dicts(chunks_resp["results"])
+        if not chunk_dicts:
+            print(f"Skipping {doc.id}; no chunks found")
+            continue
+
+        await ingestion_service.augment_document_info(doc, chunk_dicts)
+        await providers.database.documents_handler.upsert_documents_overview(doc)
+
+    await providers.database.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(backfill_document_summaries())

--- a/py/scripts/delete_files_and_vacuum.py
+++ b/py/scripts/delete_files_and_vacuum.py
@@ -14,7 +14,7 @@ from typing import Sequence
 # Ensure repository root is on the Python path when executed directly.
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from r2r import R2RClient
+from r2r import R2RClient, R2RException
 
 # Comprehensive list of supported file types.
 FILE_TYPES: list[str] = [
@@ -75,12 +75,26 @@ def delete_documents_by_type(client: R2RClient, file_types: Sequence[str]) -> No
                     client.documents.delete(doc_id)
                 except Exception as exc:  # pragma: no cover - best effort logging
                     logger.error("Failed to delete document %s: %s", doc_id, exc)
-        except Exception as exc:  # pragma: no cover - best effort logging
+
+        except R2RException as exc:  # pragma: no cover - best effort logging
+            if exc.status_code == 401:
+                logger.error(
+                    "No credentials provided. Set your API key with `r2r configure key` or set the R2R_API_KEY environment variable."
+                )
+                break
             logger.error("Failed to delete type %s: %s", file_type, exc)
+
 
 
 def main() -> None:
     base_url = os.getenv("R2R_BASE_URL", "http://localhost:7272")
+    api_key = os.getenv("R2R_API_KEY")
+    if not api_key:
+        logger.error(
+            "No API key provided. Set R2R_API_KEY or run `r2r configure key` before running this script."
+        )
+        return
+
     client = R2RClient(base_url=base_url)
     delete_documents_by_type(client, FILE_TYPES)
 

--- a/py/scripts/delete_files_and_vacuum.py
+++ b/py/scripts/delete_files_and_vacuum.py
@@ -1,17 +1,9 @@
-"""Utility script to purge documents by file type and vacuum the database.
+"""Utility script to purge documents by file type.
 
-The script iterates over a set of file extensions, deletes all documents of each
-extension using the REST API, and finally triggers a database vacuum. Example
-API call for deleting all `.xlsx` files:
-
-```
-curl -X DELETE 'http://localhost:7272/v3/documents/by-filter' \
-    -H 'Content-Type: application/json' \
-    -d '{"document_type": {"$eq": "xlsx"}}'
-```
-
-The vacuum endpoint assumes a maintenance route is exposed at
-`POST /v3/maintenance/vacuum`.
+The script iterates over a set of file extensions, lists all documents of each
+extension using the Python client, and deletes each document individually. This
+avoids the need for API-key based endpoints and removes the previous database
+vacuum step.
 """
 
 import logging
@@ -60,30 +52,37 @@ logger = logging.getLogger(__name__)
 
 def delete_documents_by_type(client: R2RClient, file_types: Sequence[str]) -> None:
     """Delete all documents matching the provided file extensions."""
+
     for file_type in file_types:
         try:
             logger.info("Deleting documents of type %s", file_type)
-            client.documents.delete_by_filter(
-                filters={"document_type": {"$eq": file_type}}
-            )
+            offset = 0
+            ids: list[str] = []
+            while True:
+                resp = client.documents.list(offset=offset, limit=1000)
+                documents = resp.results or []
+                if not documents:
+                    break
+                ids.extend(
+                    str(doc.id)
+                    for doc in documents
+                    if doc.document_type.value == file_type
+                )
+                offset += len(documents)
+
+            for doc_id in ids:
+                try:
+                    client.documents.delete(doc_id)
+                except Exception as exc:  # pragma: no cover - best effort logging
+                    logger.error("Failed to delete document %s: %s", doc_id, exc)
         except Exception as exc:  # pragma: no cover - best effort logging
             logger.error("Failed to delete type %s: %s", file_type, exc)
-
-
-def vacuum_database(client: R2RClient) -> None:
-    """Trigger a database vacuum via the maintenance API."""
-    try:
-        client._make_request("POST", "maintenance/vacuum", version="v3")
-        logger.info("Vacuum triggered successfully")
-    except Exception as exc:  # pragma: no cover - best effort logging
-        logger.error("Vacuum request failed: %s", exc)
 
 
 def main() -> None:
     base_url = os.getenv("R2R_BASE_URL", "http://localhost:7272")
     client = R2RClient(base_url=base_url)
     delete_documents_by_type(client, FILE_TYPES)
-    vacuum_database(client)
 
 
 if __name__ == "__main__":

--- a/py/scripts/delete_files_and_vacuum.py
+++ b/py/scripts/delete_files_and_vacuum.py
@@ -1,0 +1,90 @@
+"""Utility script to purge documents by file type and vacuum the database.
+
+The script iterates over a set of file extensions, deletes all documents of each
+extension using the REST API, and finally triggers a database vacuum. Example
+API call for deleting all `.xlsx` files:
+
+```
+curl -X DELETE 'http://localhost:7272/v3/documents/by-filter' \
+    -H 'Content-Type: application/json' \
+    -d '{"document_type": {"$eq": "xlsx"}}'
+```
+
+The vacuum endpoint assumes a maintenance route is exposed at
+`POST /v3/maintenance/vacuum`.
+"""
+
+import logging
+import os
+import sys
+from typing import Sequence
+
+# Ensure repository root is on the Python path when executed directly.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from r2r import R2RClient
+
+# Comprehensive list of supported file types.
+FILE_TYPES: list[str] = [
+    "doc",
+    "docx",
+    "odt",
+    "pdf",
+    "rtf",
+    "txt",
+    "ppt",
+    "pptx",
+    "csv",
+    "tsv",
+    "xls",
+    "xlsx",
+    "html",
+    "md",
+    "org",
+    "rst",
+    "bmp",
+    "heic",
+    "jpeg",
+    "jpg",
+    "png",
+    "tiff",
+    "eml",
+    "msg",
+    "p7s",
+    "epub",
+    "json",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def delete_documents_by_type(client: R2RClient, file_types: Sequence[str]) -> None:
+    """Delete all documents matching the provided file extensions."""
+    for file_type in file_types:
+        try:
+            logger.info("Deleting documents of type %s", file_type)
+            client.documents.delete_by_filter(
+                filters={"document_type": {"$eq": file_type}}
+            )
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logger.error("Failed to delete type %s: %s", file_type, exc)
+
+
+def vacuum_database(client: R2RClient) -> None:
+    """Trigger a database vacuum via the maintenance API."""
+    try:
+        client._make_request("POST", "maintenance/vacuum", version="v3")
+        logger.info("Vacuum triggered successfully")
+    except Exception as exc:  # pragma: no cover - best effort logging
+        logger.error("Vacuum request failed: %s", exc)
+
+
+def main() -> None:
+    base_url = os.getenv("R2R_BASE_URL", "http://localhost:7272")
+    client = R2RClient(base_url=base_url)
+    delete_documents_by_type(client, FILE_TYPES)
+    vacuum_database(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/scripts/remove_duplicate_documents.py
+++ b/py/scripts/remove_duplicate_documents.py
@@ -4,6 +4,7 @@ The script fetches all documents from the database, groups them by the
 `metadata['sha256']` field and deletes all but one document for each hash.
 """
 
+import argparse
 import asyncio
 import logging
 import os
@@ -19,8 +20,13 @@ from core.main.config import R2RConfig
 logger = logging.getLogger(__name__)
 
 
-async def remove_duplicate_documents() -> None:
-    """Delete duplicate documents sharing the same SHA-256 hash."""
+async def remove_duplicate_documents(commit: bool = False) -> None:
+    """Delete duplicate documents sharing the same SHA-256 hash.
+
+    When ``commit`` is ``False`` (the default), the function logs the
+    duplicates it would delete without removing them. Pass ``commit=True`` to
+    actually delete the duplicates.
+    """
     config = R2RConfig.load()
     if not os.getenv("HATCHET_CLIENT_TOKEN"):
         logger.info(
@@ -51,12 +57,31 @@ async def remove_duplicate_documents() -> None:
             seen[sha256] = doc
 
     for doc in duplicates:
-        logger.info("Deleting duplicate document %s", doc.id)
-        await providers.database.documents_handler.delete(doc.id, doc.version)
+        if commit:
+            logger.info("Deleting duplicate document %s", doc.id)
+            await providers.database.documents_handler.delete(doc.id, doc.version)
+        else:
+            logger.info("Would delete duplicate document %s", doc.id)
 
-    logger.info("Deleted %d duplicate documents", len(duplicates))
+    if commit:
+        logger.info("Deleted %d duplicate documents", len(duplicates))
+    else:
+        logger.info(
+            "Found %d duplicate documents; run with --commit to delete",
+            len(duplicates),
+        )
+
     await providers.database.close()
 
 
 if __name__ == "__main__":
-    asyncio.run(remove_duplicate_documents())
+    parser = argparse.ArgumentParser(
+        description="Remove duplicate documents based on metadata SHA-256 hash",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually delete duplicate documents instead of performing a dry run",
+    )
+    args = parser.parse_args()
+    asyncio.run(remove_duplicate_documents(commit=args.commit))

--- a/py/scripts/remove_duplicate_documents.py
+++ b/py/scripts/remove_duplicate_documents.py
@@ -1,0 +1,62 @@
+"""Remove duplicate documents based on metadata SHA-256 hash.
+
+The script fetches all documents from the database, groups them by the
+`metadata['sha256']` field and deletes all but one document for each hash.
+"""
+
+import asyncio
+import logging
+import os
+import sys
+
+# Ensure repository root is on the Python path when executed directly.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.base import DocumentResponse
+from core.main.assembly.builder import R2RBuilder
+from core.main.config import R2RConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def remove_duplicate_documents() -> None:
+    """Delete duplicate documents sharing the same SHA-256 hash."""
+    config = R2RConfig.load()
+    if not os.getenv("HATCHET_CLIENT_TOKEN"):
+        logger.info(
+            "HATCHET_CLIENT_TOKEN not set; using simple orchestration provider"
+        )
+        config.orchestration.provider = "simple"
+
+    builder = R2RBuilder(config)
+    app = await builder.build()
+    providers = app.providers
+
+    resp = await providers.database.documents_handler.get_documents_overview(
+        offset=0,
+        limit=-1,
+    )
+    documents: list[DocumentResponse] = resp["results"]
+
+    seen: dict[str, DocumentResponse] = {}
+    duplicates: list[DocumentResponse] = []
+
+    for doc in documents:
+        sha256 = doc.metadata.get("sha256")
+        if not sha256:
+            continue
+        if sha256 in seen:
+            duplicates.append(doc)
+        else:
+            seen[sha256] = doc
+
+    for doc in duplicates:
+        logger.info("Deleting duplicate document %s", doc.id)
+        await providers.database.documents_handler.delete(doc.id, doc.version)
+
+    logger.info("Deleted %d duplicate documents", len(duplicates))
+    await providers.database.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(remove_duplicate_documents())


### PR DESCRIPTION
Currently graph deduplication requests are triggered even for documents with zero entities.

This results in unnecessary LLM requests.

PR adds check and exits on zero entities.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a check in `deduplicate_document_entities()` to skip deduplication for documents with zero entities, logging the action.
> 
>   - **Behavior**:
>     - Adds a check in `deduplicate_document_entities()` in `graph_service.py` to exit early if a document has zero entities.
>     - Logs a message indicating the skip of deduplication for documents with zero entities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for a77f9c2b90942167af0da37f95f4d9ea3e22b979. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->