### PR TITLE
Add collection_ids to metadata

### DIFF
--- a/py/core/main/services/ingestion_service.py
+++ b/py/core/main/services/ingestion_service.py
@@ -863,6 +863,7 @@ class IngestionServiceAdapter:
 
     @staticmethod
     def parse_ingest_file_input(data: dict) -> dict:
+        data["metadata"]['collection_ids'] = data.get('collection_ids', [])
         return {
             "user": IngestionServiceAdapter._parse_user_data(data["user"]),
             "metadata": data["metadata"],


### PR DESCRIPTION
Add collection_ids to metadata, they are being used to create a record in `service.create_document_info_from_file``