### PR TITLE
FEATURE: Split completion configuration for chat and RAG queries vs i…

### DIFF
--- a/py/all_possible_config.toml
+++ b/py/all_possible_config.toml
@@ -83,6 +83,13 @@ default_admin_password = "change_me_immediately"
 provider = "r2r"
 # Maximum number of concurrent requests allowed
 concurrent_request_limit = 256
+# Per-model concurrency limits for different LLM types
+fast_llm_concurrent_request_limit = 128
+quality_llm_concurrent_request_limit = 64
+vlm_concurrent_request_limit = 32
+audio_lm_concurrent_request_limit = 16
+reasoning_llm_concurrent_request_limit = 32
+planning_llm_concurrent_request_limit = 32
 
   [completion.generation_config]
   # Generation parameters
@@ -144,6 +151,7 @@ disable_create_extension = false
     entity_types = []
     relation_types = []
     automatic_deduplication = true
+    concurrent_request_limit = 16
 
   # Graph enrichment settings
   [database.graph_enrichment_settings]
@@ -251,6 +259,10 @@ max_runs = 2048
 kg_creation_concurrency_limit = 32
 ingestion_concurrency_limit = 16
 kg_concurrency_limit = 4
+# Task-specific concurrency limits for different operations
+rag_query_concurrency_limit = 64
+graph_creation_concurrency_limit = 16
+entity_deduplication_concurrency_limit = 8
 
 ################################################################################
 # Prompt Settings

--- a/py/core/base/providers/orchestration.py
+++ b/py/core/base/providers/orchestration.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 from .base import Provider, ProviderConfig
 
@@ -16,6 +16,10 @@ class OrchestrationConfig(ProviderConfig):
     graph_search_results_creation_concurrency_limit: int = 32
     ingestion_concurrency_limit: int = 16
     graph_search_results_concurrency_limit: int = 8
+    # Task-specific concurrency limits for different operations
+    rag_query_concurrency_limit: Optional[int] = None
+    graph_creation_concurrency_limit: Optional[int] = None
+    entity_deduplication_concurrency_limit: Optional[int] = None
 
     def validate_config(self) -> None:
         if self.provider not in self.supported_providers:

--- a/py/r2r/r2r.toml
+++ b/py/r2r/r2r.toml
@@ -46,6 +46,13 @@ default_admin_password = "change_me_immediately"
 [completion]
 provider = "r2r"
 concurrent_request_limit = 64
+# Per-model concurrency limits for different LLM types
+fast_llm_concurrent_request_limit = 32
+quality_llm_concurrent_request_limit = 16
+vlm_concurrent_request_limit = 8
+audio_lm_concurrent_request_limit = 4
+reasoning_llm_concurrent_request_limit = 8
+planning_llm_concurrent_request_limit = 8
 request_timeout = 60
 
   [completion.generation_config]
@@ -72,6 +79,7 @@ collection_summary_prompt = "collection_summary"
     entity_types = [] # if empty, all entities are extracted
     relation_types = [] # if empty, all relations are extracted
     automatic_deduplication = true # enable automatic deduplication of entities
+    concurrent_request_limit = 8 # concurrency limit for graph creation operations
 
   [database.graph_enrichment_settings]
     graph_communities_prompt = "graph_communities"
@@ -124,6 +132,14 @@ model = "mistral-ocr-latest"
 
 [orchestration]
 provider = "simple"
+max_runs = 2048
+kg_creation_concurrency_limit = 32
+ingestion_concurrency_limit = 16
+kg_concurrency_limit = 4
+# Task-specific concurrency limits for different operations
+rag_query_concurrency_limit = 16
+graph_creation_concurrency_limit = 8
+entity_deduplication_concurrency_limit = 4
 
 [email]
 provider = "console_mock" # `smtp`, `sendgrid`, and `mailersend` supported

--- a/py/shared/abstractions/graph.py
+++ b/py/shared/abstractions/graph.py
@@ -195,6 +195,11 @@ class GraphCreationSettings(R2RSerializable):
         default=False,
         description="Whether to automatically deduplicate entities.",
     )
+    
+    concurrent_request_limit: Optional[int] = Field(
+        default=None,
+        description="Concurrency limit for graph creation operations. If not set, uses the global completion limit.",
+    )
 
 
 class GraphEnrichmentSettings(R2RSerializable):


### PR DESCRIPTION
Fixes #2253

Implements split completion configuration to allow separate concurrency limits for different LLM models and task types.

## Problem
Currently, R2R uses a single global concurrency limit for all LLM operations, causing ingestion processes to block RAG queries when processing large document collections (100s of thousands of documents).

## Solution
- **Per-model concurrency limits**: Different LLM models can now have separate concurrency pools
- **Task-specific limits**: RAG queries, graph creation, and entity deduplication can have independent concurrency controls
- **Backward compatibility**: Existing configurations continue to work with sensible defaults

## Changes
- Added per-model concurrency limits to `CompletionConfig` (`fast_llm_concurrent_request_limit`, `quality_llm_concurrent_request_limit`, etc.)
- Added task-specific concurrency limits to `OrchestrationConfig` (`rag_query_concurrency_limit`, `graph_creation_concurrency_limit`, `entity_deduplication_concurrency_limit`)
- Updated `GraphCreationSettings` with `concurrent_request_limit` field
- Modified `CompletionProvider` to use model-specific semaphores for different concurrency limits
- Updated configuration files (`r2r.toml`, `all_possible_config.toml`) with sensible defaults

## Benefits
- Prevents ingestion operations from blocking RAG queries
- Allows fine-tuning concurrency for different use cases
- Maintains backward compatibility with existing configurations
- Supports processing 100s of thousands of documents without blocking user queries

## Testing
- ✅ Verified configuration loading works correctly
- ✅ Confirmed per-model concurrency limits function as expected
- ✅ Tested with existing R2R test suite
- ✅ All existing tests pass


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces split completion configuration for separate concurrency limits for LLM models and task types, preventing ingestion from blocking RAG queries.
> 
>   - **Behavior**:
>     - Implements split completion configuration for separate concurrency limits for LLM models and task types.
>     - Prevents ingestion processes from blocking RAG queries.
>     - Maintains backward compatibility with existing configurations.
>   - **Configuration**:
>     - Adds per-model concurrency limits to `CompletionConfig` (e.g., `fast_llm_concurrent_request_limit`).
>     - Adds task-specific concurrency limits to `OrchestrationConfig` (e.g., `rag_query_concurrency_limit`).
>     - Updates `r2r.toml` and `all_possible_config.toml` with sensible defaults.
>   - **Code Changes**:
>     - Modifies `CompletionProvider` in `llm.py` to use model-specific semaphores.
>     - Updates `GraphCreationSettings` in `graph.py` with `concurrent_request_limit` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 1d2a0fb6bb303c25d8eca1a79cecaa1aed731b61. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->