### PR TITLE
Fix https://github.com/SciPhi-AI/R2R/issues/2257

### DIFF
--- a/py/core/providers/database/collections.py
+++ b/py/core/providers/database/collections.py
@@ -310,6 +310,7 @@ class PostgresCollectionsHandler(Handler):
         query = f"""
             SELECT d.id, d.owner_id, d.type, d.metadata, d.title, d.version,
                 d.size_in_bytes, d.ingestion_status, d.extraction_status, d.created_at, d.updated_at, d.summary,
+                d.collection_ids,
                 COUNT(*) OVER() AS total_entries
             FROM {self._get_table_name("documents")} d
             WHERE $1 = ANY(d.collection_ids)

--- a/py/core/providers/database/collections.py
+++ b/py/core/providers/database/collections.py
@@ -326,7 +326,7 @@ class PostgresCollectionsHandler(Handler):
         documents = [
             DocumentResponse(
                 id=row["id"],
-                collection_ids=[collection_id],
+                collection_ids=row["collection_ids"],
                 owner_id=row["owner_id"],
                 document_type=DocumentType(row["type"]),
                 metadata=json.loads(row["metadata"]),


### PR DESCRIPTION
Closes https://github.com/SciPhi-AI/R2R/issues/2257

This pull request updates the document retrieval logic in the `documents_in_collection` method to more accurately reflect the collections a document belongs to. Instead of returning only the queried collection ID, it now returns all collection IDs associated with each document.

Improvements to document collection handling:

* Updated the SQL query in `collections.py` to select the `collection_ids` field directly from the `documents` table, ensuring all relevant collection IDs are retrieved for each document.
* Modified the construction of `DocumentResponse` objects to use the actual `collection_ids` from the database row, rather than just the queried collection ID.