### PR TITLE
# Document deletion bug

### DIFF
--- a/py/core/main/services/management_service.py
+++ b/py/core/main/services/management_service.py
@@ -193,7 +193,17 @@ class ManagementService(Service):
                     status_code=404,
                     message="Document not found or insufficient permissions",
                 )
-            docs_to_delete.append(doc_id)
+            
+            # BUGFIX: Only delete document if NO chunks remain
+            remaining_chunks = await self.providers.database.chunks_handler.list_chunks(
+                filters={"document_id": {"$eq": str(doc_id)}},
+                offset=0,
+                limit=1,
+                include_vectors=False
+            )
+            
+            if remaining_chunks["total_entries"] == 0:
+                docs_to_delete.append(doc_id)
 
         # Delete documents that no longer have associated chunks
         for doc_id in docs_to_delete:


### PR DESCRIPTION
Document is getting deleted when we delete one chunk multi chunked document
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix document deletion bug in `management_service.py` to only delete documents if no chunks remain.
> 
>   - **Bugfix**:
>     - In `management_service.py`, fix document deletion logic in `delete_documents_and_chunks_by_filter()`.
>     - Only delete document if no chunks remain, preventing accidental deletion when deleting a single chunk from a multi-chunk document.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SciPhi-AI%2FR2R&utm_source=github&utm_medium=referral)<sup> for 805a8e71c33b3308708c22025cf7ef439334920f. You can [customize](https://app.ellipsis.dev/SciPhi-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->