### PR TITLE
Allow api_base/api_key in embedding config

### DIFF
--- a/py/core/base/providers/embedding.py
+++ b/py/core/base/providers/embedding.py
@@ -29,6 +29,8 @@ class EmbeddingConfig(ProviderConfig):
     max_retries: int = 3
     initial_backoff: float = 1
     max_backoff: float = 64.0
+    api_base: Optional[str] = None
+    api_key: Optional[str] = None
     quantization_settings: VectorQuantizationSettings = (
         VectorQuantizationSettings()
     )

--- a/py/core/providers/embeddings/litellm.py
+++ b/py/core/providers/embeddings/litellm.py
@@ -69,6 +69,10 @@ class LiteLLMEmbeddingProvider(EmbeddingProvider):
             "model": self.base_model,
             "dimensions": self.base_dimension,
         }
+        if self.config.api_base:
+            embedding_kwargs["api_base"] = self.config.api_base
+        if self.config.api_key:
+            embedding_kwargs["api_key"] = self.config.api_key
         embedding_kwargs.update(kwargs)
         return embedding_kwargs
 


### PR DESCRIPTION
Currently, to have embedding and completion hit two distinct API base URLs, you have to define the embedding base in the environment variable and set the completion base in the toml config. This patch obviates the need to use the environment at all and allows setting api_base and api_key in the config for embedding, as well.